### PR TITLE
opcpublisher: Added new command line parameters for specifying the maximum log file size and the number of log files to be retained.

### DIFF
--- a/docs/modules/publisher.md
+++ b/docs/modules/publisher.md
@@ -369,7 +369,14 @@ The complete usage of the application can be shown using the `--help` command li
               --ll, --loglevel=VALUE the loglevel to use (allowed: fatal, error, warn,
                                        info, debug, verbose).
                                        Default: info
-               --ih, --iothubprotocol=VALUE
+              --ls, --logfilesize=VALUE the max size of a log file [KB] before it will be 
+                                        rolled over.
+                                        0 no limit will be applied 
+                                        Default: 1024
+              --rl, --retainedlogs=VALUE the maximum number of log files to be retained
+                                         0 will enforce all files to be retained
+                                         Default: 2
+              --ih, --iothubprotocol=VALUE
                                       the protocol to use for communication with IoTHub (
                                         allowed values: Amqp, Http1, Amqp_WebSocket_Only,
                                          Amqp_Tcp_Only, Mqtt, Mqtt_WebSocket_Only, Mqtt_

--- a/modules/opc-publisher/opcpublisher/Program.cs
+++ b/modules/opc-publisher/opcpublisher/Program.cs
@@ -1015,7 +1015,8 @@ namespace OpcPublisher
                     break;
                 case "debug":
                     loggerConfiguration.MinimumLevel.Debug();
-                    OpcStackTraceMask = OpcTraceToLoggerDebug = Utils.TraceMasks.StackTrace | Utils.TraceMasks.Operation |
+                    OpcStackTraceMask = OpcTraceToLoggerDebug =
+                        Utils.TraceMasks.StackTrace | Utils.TraceMasks.Operation |
                         Utils.TraceMasks.StartStop | Utils.TraceMasks.ExternalSystem | Utils.TraceMasks.Security;
                     break;
                 case "verbose":
@@ -1042,7 +1043,9 @@ namespace OpcPublisher
             {
                 // configure rolling file sink
                 // configure rolling file sink
-                loggerConfiguration.WriteTo.File(LogFileName, fileSizeLimitBytes: LogFileSizeLimitKb*1024, flushToDiskInterval: _logFileFlushTimeSpanSec, rollOnFileSizeLimit: true, retainedFileCountLimit: RetainedLogFileCountLimit);
+                loggerConfiguration.WriteTo.File(LogFileName, fileSizeLimitBytes: LogFileSizeLimitKb * 1024,
+                    flushToDiskInterval: _logFileFlushTimeSpanSec, rollOnFileSizeLimit: true,
+                    retainedFileCountLimit: RetainedLogFileCountLimit);
             }
 
             // initialize publisher diagnostics
@@ -1052,7 +1055,9 @@ namespace OpcPublisher
             Logger.Information($"Current directory is: {System.IO.Directory.GetCurrentDirectory()}");
             Logger.Information($"Log file is: {LogFileName}");
             Logger.Information($"Log level is: {LogLevel}");
-            return;
+            Logger.Information($"File size limit for log files is {LogFileSizeLimitKb} [KB]");
+            Logger.Information(
+                $"{(RetainedLogFileCountLimit.HasValue ? RetainedLogFileCountLimit.Value.ToString() : "All")} log file(s) will be retained");
         }
 
         /// <summary>

--- a/modules/opc-publisher/opcpublisher/Program.cs
+++ b/modules/opc-publisher/opcpublisher/Program.cs
@@ -1055,7 +1055,7 @@ namespace OpcPublisher
             Logger.Information($"Current directory is: {System.IO.Directory.GetCurrentDirectory()}");
             Logger.Information($"Log file is: {LogFileName}");
             Logger.Information($"Log level is: {LogLevel}");
-            Logger.Information($"File size limit for log files is {(LogFileSizeLimit.HasValue ? LogFileSizeLimit.Value.ToString( ) : "infinite") } [KB]");
+            Logger.Information($"File size limit for log files is {(LogFileSizeLimit.HasValue ? (LogFileSizeLimit.Value/1024).ToString( ) : "infinite") } [KB]");
             Logger.Information(
                 $"{(RetainedLogFileCountLimit.HasValue ? RetainedLogFileCountLimit.Value.ToString() : "All")} log file(s) will be retained");
         }

--- a/modules/opc-publisher/opcpublisher/Program.cs
+++ b/modules/opc-publisher/opcpublisher/Program.cs
@@ -1042,7 +1042,7 @@ namespace OpcPublisher
             {
                 // configure rolling file sink
                 // configure rolling file sink
-                loggerConfiguration.WriteTo.File(LogFileName, fileSizeLimitBytes: LogFileSizeLimitKb, flushToDiskInterval: _logFileFlushTimeSpanSec, rollOnFileSizeLimit: true, retainedFileCountLimit: RetainedLogFileCountLimit);
+                loggerConfiguration.WriteTo.File(LogFileName, fileSizeLimitBytes: LogFileSizeLimitKb*1024, flushToDiskInterval: _logFileFlushTimeSpanSec, rollOnFileSizeLimit: true, retainedFileCountLimit: RetainedLogFileCountLimit);
             }
 
             // initialize publisher diagnostics


### PR DESCRIPTION
The default size for the log file is not suitable and also the number of files to be retained. This feature would make that configurable by new command line parameters.