### PR TITLE
Fixing port exposed by twin container to 9041 instead of 9042.

### DIFF
--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/container.json
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/container.json
@@ -1,4 +1,4 @@
 {
     "name": "iot/opc-twin-service",
-    "exposes": [9042]
+    "exposes": [9041]
 }


### PR DESCRIPTION
Here is the code snippet from `Program.cs`:

```
        public static IHostBuilder CreateHostBuilder(string[] args) {
            return Host.CreateDefaultBuilder(args)
                .UseAutofac()
                .ConfigureWebHostDefaults(builder => builder
                    .UseUrls("http://*:9041")
                    .UseSerilog()
                    .UseStartup<Startup>()
                    .UseKestrel(o => o.AddServerHeader = false));
        }
```

Changed `container.json` to expose port `9041` instead of `9042`.