### PR TITLE
Support deployment from Linux and fix Windows Gateway images not working

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+
+# Check powershell available and if not install
+if ! [ -x "$(command -v pwsh)" ]; then
+  if [ -x "$(command -v lsb_release)" ]; then
+    echo -e "\033[1;31mPwsh (Powershell) is not installed but required to deploy.\033[0m"
+    while true; do
+        read -p "Do you want to install Powershell (requires sudo privileges)? (y/n) " yn
+        case $yn in
+            [Yy]* ) break;;
+            * ) echo "You must install Powershell manually to continue..."; exit 1;;
+        esac
+    done
+    # install powershell
+    ubuntuversion="$(lsb_release -rs)"
+    curl -O https://packages.microsoft.com/config/ubuntu/$ubuntuversion/packages-microsoft-prod.deb
+    sudo dpkg -i packages-microsoft-prod.deb
+    rm -f packages-microsoft-prod.deb
+    sudo apt-get update
+    sudo apt-get install -y --no-install-recommends powershell
+    
+    sudo pwsh -Command "Set-psrepository -Name PSGallery -InstallationPolicy Trusted"
+    sudo pwsh -Command "Install-Module -Repository PSGallery -Name Az -AllowClobber"
+
+    # TODO Check update to released version when available
+    # sudo pwsh -Command "Install-Module -Repository PSGallery -Name AzureAD -AllowClobber"
+    sudo pwsh -Command "Register-PackageSource -ForceBootstrap -Force -Trusted -ProviderName 'PowerShellGet' -Name 'Posh Test Gallery' -Location https://www.poshtestgallery.com/api/v2/"
+    sudo pwsh -Command "Install-Module -Repository 'Posh Test Gallery' -Name AzureAD.Standard.Preview -RequiredVersion 0.0.0.10 -AllowClobber"
+  else
+    echo "Error: Pwsh (Powershell) is not installed but required to deploy - please install it." >&2
+    exit 1
+  fi
+fi
+
+# Call powershell script
+curdir="$( cd "$(dirname "$0")" ; pwd -P )"
+pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"
+

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -390,7 +390,14 @@ $ErrorActionPreference = "Stop"
 $script:ScriptDir = Split-Path $script:MyInvocation.MyCommand.Path
 
 Import-Module Az
-Import-Module AzureAD
+try {
+    # Try first release version
+    Import-Module AzureAD
+}
+catch {
+    # Fallback to preview
+    Import-Module AzureAD.Standard.Preview
+}
 
 $aadConfig = New-ADApplications  `
     -applicationName $script:Name  `

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -9,31 +9,44 @@ The ARM deployment templates included in the repository deploy the platform and 
 - A PLC server simulation
 - All required Azure infrastructure
 - The Industrial IoT Platform
-- The Industrial IoT Sample Engineering tool.
+- The Industrial IoT Engineering tool.
 
 ## Running the script
 
 The platform and simulation can also be deployed using the deploy script.
 
-1. Make sure you have PowerShell and [Az PowerShell](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps) extensions installed.  If not, first install PowerShell, then open PowerShell as Administrator and run
-
-   ```powershell
-   Install-Module -Name Az -AllowClobber
-   Install-Module -Name AzureAD -AllowClobber
-   ```
-
-2. If you have not done so yet, clone this GitHub repository.  Open a command prompt or terminal and run:
+1. If you have not done so yet, clone this GitHub repository.  Open a command prompt or terminal and run:
 
    ```bash
    git clone https://github.com/Azure/Industrial-IoT
    cd Industrial-IoT
    ```
 
-3. Open a command prompt or terminal in the repository root and run:
+2. Install all required dependencies:
 
-   ```bash
-   deploy
-   ```
+   - On **Windows** install [Az PowerShell](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps). Open Powershell as Administrator and run:
+
+     ```pwsh
+     Install-Module -Name Az -AllowClobber
+     Install-Module -Name AzureAD -AllowClobber
+     ```
+
+   - On **Ubuntu** Linux continue to step 3 and choose (y) to install required dependencies.  You must have Adminstrator rights.  
+     > For how to install required depdendencies on other Linux distributions see [here](#Deploy-from-Linux-other-than-Ubuntu).
+
+3. Open a command prompt or terminal in the repository root and depending on your operating system run:
+
+   - On Windows:
+
+     ```cmd
+     deploy
+     ```
+
+   - On Linux:
+
+     ```bash
+     ./deploy.sh
+     ```
 
    The supported parameters can be found [below](#deployment-script-options).
 
@@ -70,14 +83,14 @@ Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
 
 ### Security Warning
 
-1. If you see a message in PowerShell
+If you see a message in PowerShell
+
 `Security warning
-Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your
-computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning
-message. Do you want to run C:\MyConnectedFactoryClone\build.ps1?
+Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run <...> deploy.ps1?
 [D] Do not run  [R] Run once  [S] Suspend  [?] Help (default is "D"):
 Do you want to run this script?`
-2. Choose R
+
+Choose R to run once.
 
 ### Resource group name
 
@@ -99,6 +112,30 @@ cd deploy/scripts
 ./aad-register.ps1 -Name <application-name> -Output aad.json
 ./deploy.ps1 -aadConfig aad.json ...
 ```
+
+### Deploy from Linux other than Ubuntu
+
+To install all necessary requirements on other Linux distributions follow these steps:
+
+1. First [install PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7).  Follow the instructions for your Linux distribution.
+
+2. Open powershell using `sudo pwsh`.
+
+3. Install the required Azure Az Powershell module:
+
+   ```pwsh
+   Set-psrepository -Name PSGallery -InstallationPolicy Trusted
+   Install-Module -Repository PSGallery -Name Az -AllowClobber
+   ```
+
+4. To also have the installation script create AAD Application registrations (aad-register.ps1) install the preview Azure AD module:
+
+   ```pwsh
+   Register-PackageSource -ForceBootstrap -Force -Trusted -ProviderName 'PowerShellGet' -Name 'Posh Test Gallery' -Location https://www.poshtestgallery.com/api/v2/
+   Install-Module -Repository 'Posh Test Gallery' -Name AzureAD.Standard.Preview -RequiredVersion 0.0.0.10 -AllowClobber
+   ```
+
+5. `exit`
 
 ## Deployment script options
 

--- a/tools/scripts/acr-build.ps1
+++ b/tools/scripts/acr-build.ps1
@@ -239,19 +239,7 @@ $definitions | ForEach-Object {
         $architecture = ("architecture: {0}" -f $osArchArr[1])
         $variant = ""
         if ($osArchArr.Count -gt 2) {
-            # Backcompat for when release version was used as windows variant
-            $windowsVariantToOsVersionsTable = @{
-                "1803" = "10.0.17134.885"
-                "1809" = "10.0.17763.615"
-                "1903" = "10.0.18362.239"
-            }
-            if ($windowsVariantToOsVersionsTable.ContainsKey($osArchArr[2])) {
-                $osVersion = $windowsVariantToOsVersionsTable.Item($osArchArr[2])
-                $osVersion = ("osversion: {0}" -f $osVersion)
-            }
-            else {
-                $variant = ("variant: {0}" -f $osArchArr[2])
-            }
+            $variant = ("variant: {0}" -f $osArchArr[2])
         }
     }
 

--- a/tools/scripts/docker-source.ps1
+++ b/tools/scripts/docker-source.ps1
@@ -100,31 +100,38 @@ ENV PATH="${PATH}:/root/vsdbg/vsdbg"
             debugger = $installLinuxDebugger
             entryPoint = "[`"./$($assemblyName)`"]"
         }
-        "windows/amd64:10.0.17134.885" = @{
+        "windows/amd64:10.0.17134.1246" = @{
             runtimeId = "win-x64"
-            image = "mcr.microsoft.com/windows/nanoserver:1803"
+            image = "mcr.microsoft.com/windows/nanoserver:10.0.17134.1246-amd64"
             platformTag = "nanoserver-amd64-1803"
             debugger = $null
             entryPoint = "[`"$($assemblyName).exe`"]"
         }
-        "windows/amd64:10.0.17763.615" = @{
+        "windows/amd64:10.0.17763.973" = @{
             runtimeId = "win-x64"
-            image = "mcr.microsoft.com/windows/nanoserver:1809"
+            image = "mcr.microsoft.com/windows/nanoserver:10.0.17763.973-amd64"
             platformTag = "nanoserver-amd64-1809"
             debugger = $null
             entryPoint = "[`"$($assemblyName).exe`"]"
         }
-        "windows/arm" = @{
+        "windows/arm:10.0.17763.973" = @{
             runtimeId = "win-arm"
-            image = "mcr.microsoft.com/windows/nanoserver:1809-arm32v7"
+            image = "mcr.microsoft.com/windows/nanoserver:10.0.17763.973-arm32v7"
             platformTag = "nanoserver-arm32v7-1809"
             debugger = $null
             entryPoint = "[`"$($assemblyName).exe`"]"
         }
-        "windows/amd64:10.0.18362.239" = @{
+        "windows/amd64:10.0.18362.592" = @{
             runtimeId = "win-x64"
-            image = "mcr.microsoft.com/windows/nanoserver:1903"
+            image = "mcr.microsoft.com/windows/nanoserver:10.0.18362.592-amd64"
             platformTag = "nanoserver-amd64-1903"
+            debugger = $null
+            entryPoint = "[`"$($assemblyName).exe`"]"
+        }
+        "windows/amd64:10.0.18363.592" = @{
+            runtimeId = "win-x64"
+            image = "mcr.microsoft.com/windows/nanoserver:10.0.18363.592-amd64"
+            platformTag = "nanoserver-amd64-1909"
             debugger = $null
             entryPoint = "[`"$($assemblyName).exe`"]"
         }


### PR DESCRIPTION
* Use the correct base image version for Windows 1809 image - add 1909
* Update documentation regarding Linux deployment
* Add deployment shell script to root.