### PR TITLE
Fix onboarding id and hash calculation due to missing properties

### DIFF
--- a/common.props
+++ b/common.props
@@ -29,7 +29,7 @@
   </PropertyGroup>
   <ItemGroup Condition="$(NO_GIT) == ''">
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.28" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition="'$(FX_COP)' != ''">
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.3" />

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
@@ -5,6 +5,7 @@
     <Description>Azure Industrial IoT SignalR messaging</Description>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.2.3" />
   </ItemGroup>
   <ItemGroup>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/ApplicationRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/ApplicationRegistrationEx.cs
@@ -506,6 +506,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static ApplicationInfoModel ToServiceModel(this ApplicationRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new ApplicationInfoModel {
                 ApplicationId = registration.ApplicationId,
                 ApplicationName = registration.ApplicationName,
@@ -540,6 +543,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <returns></returns>
         public static bool Matches(this ApplicationRegistration registration,
             ApplicationInfoModel model) {
+            if (registration == null) {
+                return model == null;
+            }
             return model != null &&
                 registration.ApplicationId == model.ApplicationId &&
                 registration.ApplicationType == model.ApplicationType &&
@@ -569,6 +575,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// </summary>
         /// <param name="registration">The application record.</param>
         public static string GetApplicationName(this ApplicationRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             if (!string.IsNullOrEmpty(registration.ApplicationName)) {
                 return registration.ApplicationName;
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
@@ -337,6 +337,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static DiscovererModel ToServiceModel(this DiscovererRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new DiscovererModel {
                 Discovery = registration.Discovery != DiscoveryMode.Off ?
                     registration.Discovery : (DiscoveryMode?)null,
@@ -427,6 +430,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="other"></param>
         internal static bool IsInSyncWith(this DiscovererRegistration registration,
             DiscovererRegistration other) {
+            if (registration == null) {
+                return other == null;
+            }
             return
                 other != null &&
                 registration.SiteId == other.SiteId &&

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/EndpointRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/EndpointRegistrationEx.cs
@@ -301,6 +301,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static EndpointInfoModel ToServiceModel(this EndpointRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new EndpointInfoModel {
                 ApplicationId = registration.ApplicationId,
                 Registration = new EndpointRegistrationModel {
@@ -436,6 +439,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="other"></param>
         internal static bool IsInSyncWith(this EndpointRegistration registration,
             EndpointRegistration other) {
+            if (registration == null) {
+                return other == null;
+            }
             return
                 other != null &&
                 registration.EndpointUrl == other.EndpointUrl &&
@@ -454,11 +460,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
             /// <inheritdoc />
             public bool Equals(EndpointRegistration x, EndpointRegistration y) {
-                return
-                    x.EndpointUrlLC == y.EndpointUrlLC &&
-                    x.ApplicationId == y.ApplicationId &&
-                    x.SecurityPolicy == y.SecurityPolicy &&
-                    x.SecurityMode == y.SecurityMode;
+                if (x.EndpointUrlLC != y.EndpointUrlLC) {
+                    return false;
+                }
+                if (x.ApplicationId != y.ApplicationId) {
+                    return false;
+                }
+                if (x.SecurityPolicy != y.SecurityPolicy) {
+                    return false;
+                }
+                if (x.SecurityMode != y.SecurityMode) {
+                    return false;
+                }
+                return true;
             }
 
             /// <inheritdoc />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/GatewayRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/GatewayRegistrationEx.cs
@@ -128,18 +128,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
             var consolidated =
                 ToGatewayRegistration(twin, twin.GetConsolidatedProperties());
-            var desired = (twin.Properties?.Desired == null) ? null :
-                ToGatewayRegistration(twin, twin.Properties.Desired);
-
             connected = consolidated.Connected;
-            if (desired != null) {
-                desired.Connected = connected;
-                if (desired.SiteId == null && consolidated.SiteId != null) {
-                    // Not set by user, but by config, so fake user desiring it.
-                    desired.SiteId = consolidated.SiteId;
-                }
-            }
-            return desired;
+            return consolidated;
         }
 
         /// <summary>
@@ -167,6 +157,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static GatewayModel ToServiceModel(this GatewayRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new GatewayModel {
                 Id = registration.DeviceId,
                 SiteId = registration.SiteId,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/PublisherRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/PublisherRegistrationEx.cs
@@ -272,6 +272,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static PublisherModel ToServiceModel(this PublisherRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new PublisherModel {
                 Id = PublisherModelEx.CreatePublisherId(registration.DeviceId, registration.ModuleId),
                 SiteId = registration.SiteId,
@@ -328,6 +331,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="other"></param>
         internal static bool IsInSyncWith(this PublisherRegistration registration,
             PublisherRegistration other) {
+            if (registration == null) {
+                return other == null;
+            }
             return
                 other != null &&
                 registration.SiteId == other.SiteId &&

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/SupervisorRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/SupervisorRegistrationEx.cs
@@ -222,6 +222,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="registration"></param>
         /// <returns></returns>
         public static SupervisorModel ToServiceModel(this SupervisorRegistration registration) {
+            if (registration == null) {
+                return null;
+            }
             return new SupervisorModel {
                 Id = SupervisorModelEx.CreateSupervisorId(registration.DeviceId, registration.ModuleId),
                 SiteId = registration.SiteId,
@@ -239,6 +242,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         /// <param name="other"></param>
         internal static bool IsInSyncWith(this SupervisorRegistration registration,
             SupervisorRegistration other) {
+            if (registration == null) {
+                return other == null;
+            }
             return
                 other != null &&
                 registration.SiteId == other.SiteId &&

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -21,8 +21,8 @@
   * [User Interface](#user-interface)
 * [Resources](#resources)
 
-`Microsoft.Azure.IIoT.Deployment` is a command line application for deploying Industrial IoT platform.
-It takes care of deploying Azure infrastructure resources and microservices of Industrial IoT platform.
+`Microsoft.Azure.IIoT.Deployment` is a command line application for deploying Industrial IoT solution.
+It takes care of deploying Azure infrastructure resources and microservices of Industrial IoT solution.
 
 The main difference compared to the [script based deployment](howto-deploy-all-in-one.md) option is that
 from an infrastructure perspective `Microsoft.Azure.IIoT.Deployment` deploys microservices to an Azure
@@ -354,7 +354,7 @@ To grant admin consent you have to be **admin** in the Azure account. Here are t
 ### Resource Cleanup
 
 `Microsoft.Azure.IIoT.Deployment` will prompt for resource cleanup if it encounters an error during
-deployment of Industrial IoT platform. Cleanup works by deleting registered Applications and the
+deployment of Industrial IoT solution. Cleanup works by deleting registered Applications and the
 Resource Group that has been selected for deployment. This means, that one should be cautious with
 cleanup if an existing Resource Group has been selected for the deployment, since the cleanup will
 trigger deletion of **all** resources within the Resource Group, even the ones that have been present
@@ -467,7 +467,7 @@ Command line argument key-value pairs can be specified with:
   
     Properties correspond to that of application registration and Service Principal manifests. Definition
     of application properties can be found
-    [here](https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-app-manifest).
+    [here](https://docs.microsoft.com/azure/active-directory/develop/reference-app-manifest).
   
     Application objects should contain the following properties:
 
@@ -481,7 +481,7 @@ Command line argument key-value pairs can be specified with:
       "AppId": "<guid>"
     }
     ```
-  
+
     Service Principal objects should contain the following properties:
 
     ```json
@@ -490,7 +490,7 @@ Command line argument key-value pairs can be specified with:
       "DisplayName": "<service principal name string>",
     }
     ```
-  
+
     ApplicationRegistration object should have the keys as below. Note that:
     * Values of `ServiceApplication`, `ClientApplication` and `AksApplication` keys should be Application
       objects as described above.
@@ -514,34 +514,80 @@ Command line argument key-value pairs can be specified with:
 
 ### AKS
 
-All of microservices of Industrial IoT solution are deployed to an AKS Kubernetes cluster. The deployment
-creates `industrial-iot` namespace where all microservices are running. To provide connection details for
-all Azure resources created by `Microsoft.Azure.IIoT.Deployment`, we created `industrial-iot-env` secret,
-which is then consumed by deployments.
+All cloud microservices of Industrial IoT solution are deployed to an AKS Kubernetes cluster.
 
-To see YAML files of all Kubernetes resources that are created by the application check
-[deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/aks/](../deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/aks/)
+#### Resource Definitions
+
+The deployment creates `industrial-iot` namespace where all microservices are running. To provide connection
+details for all Azure resources created by `Microsoft.Azure.IIoT.Deployment`, we created
+`industrial-iot-env` secret, which is then consumed by deployments.
+
+To see YAML files of all Kubernetes resources that are created by the application, please check
+[deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/aks/](../../deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/aks/)
 directory.
 
-To see state of microservices you can check Kubernetes Dashboard. Follow this tutorial on how to access it:
+#### Kubernetes Dashboard
 
-* [Access the Kubernetes web dashboard in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/kubernetes-dashboard)
+To see state of microservices you can check Kubernetes dashboard.
+
+You can follow this tutorial to do that: [Access the Kubernetes web dashboard in Azure Kubernetes Service (AKS)](https://docs.microsoft.com/azure/aks/kubernetes-dashboard).
+
+Alternatively, you can run the following commands:
+
+1. Make sure you have `kubectl` installed. If it is not already installed, run the following command to
+    download and install `kubectl`:
+
+    ```bash
+    az aks install-cli
+    ```
+
+    More details about the command and its optional parameters can be found [here](https://docs.microsoft.com/cli/azure/aks?view=azure-cli-latest#az-aks-install-cli).
+
+2. Get access credentials for a managed Kubernetes cluster. You would need the name of the resource group
+    containing AKS resource and the name of the AKS resource:
+
+    ```bash
+    az aks get-credentials --resource-group myResourceGroup --name myAKSCluster
+    ```
+
+    More details about the command and its optional parameters can be found [here](https://docs.microsoft.com/cli/azure/aks?view=azure-cli-latest#az-aks-get-credentials).
+
+3. Create `ClusterRoleBinding` that will bind `ServiceAccount` of Kubernetes dashboard to `cluster-admin`
+    role. By default, the Kubernetes dashboard is deployed with minimal read access and displays RBAC access
+    errors.
+
+    ```bash
+    kubectl create clusterrolebinding kubernetes-dashboard --clusterrole=cluster-admin --serviceaccount=kube-system:kubernetes-dashboard
+    ```
+
+4. Open the dashboard for a Kubernetes cluster in a web browser. You would need the name of the resource
+    group containing AKS resource and the name of the AKS resource:
+
+    ```bash
+    az aks browse --resource-group myResourceGroup --name myAKSCluster
+    ```
+
+    More details about the command and its optional parameters can be found [here](https://docs.microsoft.com/cli/azure/aks?view=azure-cli-latest#az-aks-browse).
+
+    This will open a Kubernetes dashboard in a web browser.
+
+#### APIs of Microservices
 
 You should also be able to access APIs of microservices through URL of App Service. The URL is available
-in overview of App Service. For example, you can access OPC Registry Service by appending `/registry/` to the URL.
-It should look something like the link bellow, where `kktest00100` is the name of App Service.
+in overview of App Service. For example, you can access OPC Registry Service by appending `/registry/` to
+the URL. It should look something like the link bellow, where `kktest00100` is the name of App Service.
 
 * `https://kktest00100.azurewebsites.net/registry/`
 
 The following microservice endpoints are exposed:
 
-| URL Suffix  | Service Name                                |
-|-------------|---------------------------------------------|
-| `registry/` | [OPC Registry](services/registry.md)        |
-| `twin/`     | [OPC Twin](services/twin.md)                |
-| `history/`  | [OPC Historian Access](services/history.md) |
-| `ua/`       |                                             |
-| `vault/`    | [OPC Vault](services/vault.md)              |
+| URL Suffix  | Service Name                                   |
+|-------------|------------------------------------------------|
+| `registry/` | [OPC Registry](../services/registry.md)        |
+| `twin/`     | [OPC Twin](../services/twin.md)                |
+| `history/`  | [OPC Historian Access](../services/history.md) |
+| `ua/`       | [OPC Gateway](../services/gateway.md)          |
+| `vault/`    | [OPC Vault](../services/vault.md)              |
 
 ## Missing And Planned Features
 


### PR DESCRIPTION
When calling the onboarding API the provided events do not contain all needed information to create an id that matches existing device entries.   This means existing entries get removed first, before same ones are re-added interrupting operation with existing device entities and causing unnecessary twin updates.