### PR TITLE
Select VM Option and tagging resource group deployments

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -39,6 +39,56 @@
                 "description": "The name of the application to create. Leave empty for local or services only development."
             }
         },
+        "edgeVmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "allowedValues": [
+                "",
+                "Standard_B2s",
+                "Standard_B2ms",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_A4",
+                "Standard_A5",
+                "Standard_A6",
+                "Standard_A7",
+                "Standard_A8",
+                "Standard_A9",
+                "Standard_A10",
+                "Standard_A11",
+                "Standard_A2_v2",
+                "Standard_A4_v2",
+                "Standard_A8_v2",
+                "Standard_A2m_v2",
+                "Standard_A4m_v2",
+                "Standard_A8m_v2",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_D11",
+                "Standard_D12",
+                "Standard_D13",
+                "Standard_D14",
+                "Standard_D2_v2",
+                "Standard_D3_v2",
+                "Standard_D4_v2",
+                "Standard_D5_v2",
+                "Standard_D11_v2",
+                "Standard_D12_v2",
+                "Standard_D13_v2",
+                "Standard_D14_v2",
+                "Standard_D15_v2",
+                "Standard_G1",
+                "Standard_G2",
+                "Standard_G3",
+                "Standard_G4",
+                "Standard_G5",
+                "Standard_F2",
+                "Standard_F4",
+                "Standard_F8",
+                "Standard_F16"
+            ]
+        },
         "edgeUserName": {
             "type": "secureString",
             "defaultValue": "",
@@ -87,6 +137,9 @@
                     },
                     "imagesTag": {
                         "value": "preview"
+                    },
+                    "edgeVmSize": {
+                        "value": "[parameters('edgeVmSize')]"
                     },
                     "edgePassword": {
                         "value": "[parameters('edgePassword')]"

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -686,8 +686,8 @@ Function New-Deployment() {
             # Pick top
             if ($vmSizes.Count -ne 0) {
                 $vmSize = $vmSizes[0].Name
-                Write-Host "Using $($vmSize) as VM size for simulation hosts..."
-                $templateParameters.Add("vmSize", $vmSize)
+                Write-Host "Using $($vmSize) as VM size for all edge simulation hosts..."
+                $templateParameters.Add("edgeVmSize", $vmSize)
             }
 
             $adminUser = "sandboxuser"

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -297,6 +297,7 @@ Function Select-ResourceGroupLocation() {
         foreach ($location in $locations) {
             if ($location.Location -eq $script:resourceGroupLocation -or `
                     $location.DisplayName -eq $script:resourceGroupLocation) {
+                $script:resourceGroupLocation = $location.Location
                 return
             }
         }
@@ -325,6 +326,65 @@ Function Select-ResourceGroupLocation() {
     $script:resourceGroupLocation = $locations[$option - 1].Location
 }
 
+
+#*******************************************************************************************************
+# Update resource group tags
+#*******************************************************************************************************
+Function Set-ResourceGroupTags() {
+    Param(
+        [string] $state,
+        [string] $version
+    )
+    $resourceGroup = Get-AzResourceGroup -ResourceGroupName $script:resourceGroupName
+    if (!$resourceGroup) {
+        return
+    }
+    $tags = $resourceGroup.Tags
+    if (!$tags) {
+        $tags = @{}
+    }
+    $update = $false
+    if (![string]::IsNullOrEmpty($state)) {
+        if ($tags.ContainsKey("IoTSuiteState")) {
+            if ($tags.IoTSuiteState -ne $state) {
+                $tags.IoTSuiteState = $state
+                $update = $true
+            }
+        }
+        else {
+            $tags += @{ "IoTSuiteState" = $state }
+            $update = $true
+        }
+    }
+    if (![string]::IsNullOrEmpty($version)) {
+        if ($tags.ContainsKey("IoTSuiteVersion")) {
+            if ($tags.IoTSuiteVersion -ne $version) {
+                $tags.IoTSuiteVersion = $version
+                $update = $true
+            }
+        }
+        else {
+            $tags += @{ "IoTSuiteVersion" = $version }
+            $update = $true
+        }
+    }
+    $type = "AzureIndustrialIoT"
+    if ($tags.ContainsKey("IoTSuiteType")) {
+        if ($tags.IoTSuiteType -ne $type) {
+            $tags.IoTSuiteType = $type
+            $update = $true
+        }
+    }
+    else {
+        $tags += @{ "IoTSuiteType" = $type }
+        $update = $true
+    }
+    if (!$update) {
+        return
+    }
+    $resourceGroup = Set-AzResourceGroup -Name $script:resourceGroupName -Tag $tags
+}
+
 #*******************************************************************************************************
 # Get or create new resource group for deployment
 #*******************************************************************************************************
@@ -348,9 +408,12 @@ Function Select-ResourceGroup() {
         $resourceGroup = New-AzResourceGroup -Name $script:resourceGroupName `
             -Location $script:resourceGroupLocation
         Write-Host "Created new resource group  $($script:resourceGroupName) in $($resourceGroup.Location)."
+        Set-ResourceGroupTags -state "Created"
         return $True
     }
     else {
+        Set-ResourceGroupTags -state "Updating"
+        $script:resourceGroupLocation = $resourceGroup.Location
         Write-Host "Using existing resource group $($script:resourceGroupName)..."
         return $False
     }
@@ -541,6 +604,8 @@ Function New-Deployment() {
             }
         }
     }
+
+    Set-ResourceGroupTags -state "Deploying" -version $script:branchName
     Write-Host "Deployment will use '$($script:branchName)' branch in '$($script:repo)'."
     $templateParameters.Add("branchName", $script:branchName)
     $templateParameters.Add("repoUrl", $script:repo)
@@ -598,6 +663,32 @@ Function New-Deployment() {
             $templateParameters.Add("numberOfLinuxGateways", 1)
             $templateParameters.Add("numberOfWindowsGateways", 1)
             $templateParameters.Add("numberOfSimulations", 1)
+
+            # Get all vm skus available in the location and in the account
+            $availableVms = Get-AzComputeResourceSku | Where-Object {
+                ($_.ResourceType.Contains("virtualMachines")) -and `
+                ($_.Locations -icontains $script:resourceGroupLocation) -and `
+                ($_.Restrictions.Count -eq 0)
+            }
+            # Sort based on sizes and filter minimum requirements
+            $availableVmNames = $availableVms `
+                | Select-Object -ExpandProperty Name -Unique 
+            $vmSizes = Get-AzVMSize $script:resourceGroupLocation `
+                | Where-Object { $availableVmNames -icontains $_.Name } `
+                | Where-Object {
+                    ($_.NumberOfCores -ge 2) -and `
+                    ($_.MemoryInMB -ge 8192) -and `
+                    ($_.OSDiskSizeInMB -ge 1047552) -and `
+                    ($_.ResourceDiskSizeInMB -gt 8192) 
+                } `
+                | Sort-Object -Property `
+                    NumberOfCores,MemoryInMB,ResourceDiskSizeInMB,Name
+            # Pick top
+            if ($vmSizes.Count -ne 0) {
+                $vmSize = $vmSizes[0].Name
+                Write-Host "Using $($vmSize) as VM size for simulation hosts..."
+                $templateParameters.Add("vmSize", $vmSize)
+            }
 
             $adminUser = "sandboxuser"
             $adminPassword = New-Password
@@ -679,9 +770,11 @@ Function New-Deployment() {
                 -TemplateFile $templateFilePath -TemplateParameterObject $templateParameters
 
             if ($deployment.ProvisioningState -ne "Succeeded") {
+                Set-ResourceGroupTags -state "Failed"
                 throw "Deployment $($deployment.ProvisioningState)."
             }
 
+            Set-ResourceGroupTags -state "Complete"
             Write-Host "Deployment succeeded."
 
             #

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -122,6 +122,13 @@
                 "description": "Number of simulations to deploy into each gateway network."
             }
         },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_B2s",
+            "metadata": {
+                "description": "The size of VMs to provision for simulation."
+            }
+        },
         "edgeUserName": {
             "type": "secureString",
             "defaultValue": "",
@@ -312,6 +319,9 @@
                     },
                     "numberOfWindowsGateways": {
                         "value": "[parameters('numberOfWindowsGateways')]"
+                    },
+                    "vmSize": {
+                        "value": "[parameters('vmSize')]"
                     },
                     "edgeUserName": {
                         "value": "[parameters('edgeUserName')]"

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -122,9 +122,9 @@
                 "description": "Number of simulations to deploy into each gateway network."
             }
         },
-        "vmSize": {
+        "edgeVmSize": {
             "type": "string",
-            "defaultValue": "Standard_B2s",
+            "defaultValue": "",
             "metadata": {
                 "description": "The size of VMs to provision for simulation."
             }
@@ -320,8 +320,8 @@
                     "numberOfWindowsGateways": {
                         "value": "[parameters('numberOfWindowsGateways')]"
                     },
-                    "vmSize": {
-                        "value": "[parameters('vmSize')]"
+                    "edgeVmSize": {
+                        "value": "[parameters('edgeVmSize')]"
                     },
                     "edgeUserName": {
                         "value": "[parameters('edgeUserName')]"

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -43,9 +43,9 @@
                 "description": "Number of simulations to deploy into each gateway network."
             }
         },
-        "vmSize": {
+        "edgeVmSize": {
             "type": "string",
-            "defaultValue": "Standard_B2s",
+            "defaultValue": "",
             "metadata": {
                 "description": "The size of VMs to provision for simulation."
             }
@@ -550,8 +550,8 @@
                     "branchName": {
                         "value": "[parameters('branchName')]"
                     },
-                    "vmSize": {
-                        "value": "[parameters('vmSize')]"  
+                    "edgeVmSize": {
+                        "value": "[parameters('edgeVmSize')]"  
                     },
                     "dpsIdScope": {
                         "reference": {
@@ -631,8 +631,8 @@
                     "branchName": {
                         "value": "[parameters('branchName')]"
                     },
-                    "vmSize": {
-                        "value": "[parameters('vmSize')]"  
+                    "edgeVmSize": {
+                        "value": "[parameters('edgeVmSize')]"  
                     },
                     "dpsIdScope": {
                         "reference": {

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -43,6 +43,13 @@
                 "description": "Number of simulations to deploy into each gateway network."
             }
         },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_B2s",
+            "metadata": {
+                "description": "The size of VMs to provision for simulation."
+            }
+        },
         "edgeUserName": {
             "type": "string",
             "defaultValue": "sandboxuser",
@@ -543,6 +550,9 @@
                     "branchName": {
                         "value": "[parameters('branchName')]"
                     },
+                    "vmSize": {
+                        "value": "[parameters('vmSize')]"  
+                    },
                     "dpsIdScope": {
                         "reference": {
                             "keyVault": {
@@ -620,6 +630,9 @@
                     },
                     "branchName": {
                         "value": "[parameters('branchName')]"
+                    },
+                    "vmSize": {
+                        "value": "[parameters('vmSize')]"  
                     },
                     "dpsIdScope": {
                         "reference": {

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -45,6 +45,59 @@
                 "description": "Password for the IoT Edge virtual machine."
             }
         },
+        "edgeVmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "allowedValues": [
+                "",
+                "Standard_B2s",
+                "Standard_B2ms",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_A4",
+                "Standard_A5",
+                "Standard_A6",
+                "Standard_A7",
+                "Standard_A8",
+                "Standard_A9",
+                "Standard_A10",
+                "Standard_A11",
+                "Standard_A2_v2",
+                "Standard_A4_v2",
+                "Standard_A8_v2",
+                "Standard_A2m_v2",
+                "Standard_A4m_v2",
+                "Standard_A8m_v2",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_D11",
+                "Standard_D12",
+                "Standard_D13",
+                "Standard_D14",
+                "Standard_D2_v2",
+                "Standard_D3_v2",
+                "Standard_D4_v2",
+                "Standard_D5_v2",
+                "Standard_D11_v2",
+                "Standard_D12_v2",
+                "Standard_D13_v2",
+                "Standard_D14_v2",
+                "Standard_D15_v2",
+                "Standard_G1",
+                "Standard_G2",
+                "Standard_G3",
+                "Standard_G4",
+                "Standard_G5",
+                "Standard_F2",
+                "Standard_F4",
+                "Standard_F8",
+                "Standard_F16"
+            ],
+            "metadata": {
+                "description": "The size of the gateway VM to provision."
+            }
+        },
         "numberOfSimulations": {
             "type": "int",
             "defaultValue": 1,
@@ -52,6 +105,59 @@
             "minValue": 0,
             "metadata": {
                 "description": "Number of simulated factories to deploy."
+            }
+        },
+        "simulationVmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "allowedValues": [
+                "",
+                "Standard_B2s",
+                "Standard_B2ms",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_A4",
+                "Standard_A5",
+                "Standard_A6",
+                "Standard_A7",
+                "Standard_A8",
+                "Standard_A9",
+                "Standard_A10",
+                "Standard_A11",
+                "Standard_A2_v2",
+                "Standard_A4_v2",
+                "Standard_A8_v2",
+                "Standard_A2m_v2",
+                "Standard_A4m_v2",
+                "Standard_A8m_v2",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_D11",
+                "Standard_D12",
+                "Standard_D13",
+                "Standard_D14",
+                "Standard_D2_v2",
+                "Standard_D3_v2",
+                "Standard_D4_v2",
+                "Standard_D5_v2",
+                "Standard_D11_v2",
+                "Standard_D12_v2",
+                "Standard_D13_v2",
+                "Standard_D14_v2",
+                "Standard_D15_v2",
+                "Standard_G1",
+                "Standard_G2",
+                "Standard_G3",
+                "Standard_G4",
+                "Standard_G5",
+                "Standard_F2",
+                "Standard_F4",
+                "Standard_F8",
+                "Standard_F16"
+            ],
+            "metadata": {
+                "description": "The size of the simulation VM to provision."
             }
         },
         "dockerServer": {
@@ -108,13 +214,6 @@
             "defaultValue": "",
             "metadata": {
                 "description": "A user created managed identity to use for keyvault access.  If not provided, above secret will be used to gain access to keyvault."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_B2s",
-            "metadata": {
-                "description": "The size of the gateway VM to provision."
             }
         }
     },
@@ -191,7 +290,9 @@
             "protectedSettings": {
                 "commandToExecute": "[concat('sudo bash edge-setup.sh --idScope \"', parameters('dpsIdScope'), '\" --dpsConnString \"', parameters('dpsConnString'), '\"')]"
             }
-        }
+        },
+        "edgeVmSku": "[if(not(empty(parameters('edgeVmSize'))), parameters('edgeVmSize'), 'Standard_B2s')]",
+        "simulationVmSku": "[if(not(empty(parameters('simulationVmSize'))), parameters('simulationVmSize'), variables('edgeVmSku'))]"
     },
     "resources": [
         {
@@ -250,7 +351,7 @@
             "identity": "[if(not(empty(parameters('managedIdentityResourceId'))), variables('identity'), '')]",
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
+                    "vmSize": "[variables('edgeVmSku')]"
                 },
                 "osProfile": "[if(equals(parameters('edgeOs'), 'linux'), variables('linuxOsProfile'), variables('windowsOsProfile'))]",
                 "storageProfile": {
@@ -329,7 +430,7 @@
                             "location": "[resourceGroup().location]",
                             "properties": {
                                 "hardwareProfile": {
-                                    "vmSize": "[parameters('vmSize')]"
+                                    "vmSize": "[variables('simulationVmSku')]"
                                 },
                                 "osProfile": {
                                     "computerName": "[concat(variables('simulationName'), copyIndex())]",

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -109,6 +109,13 @@
             "metadata": {
                 "description": "A user created managed identity to use for keyvault access.  If not provided, above secret will be used to gain access to keyvault."
             }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_B2s",
+            "metadata": {
+                "description": "The size of the gateway VM to provision."
+            }
         }
     },
     "variables": {
@@ -243,7 +250,7 @@
             "identity": "[if(not(empty(parameters('managedIdentityResourceId'))), variables('identity'), '')]",
             "properties": {
                 "hardwareProfile": {
-                    "vmSize": "Standard_B2s"
+                    "vmSize": "[parameters('vmSize')]"
                 },
                 "osProfile": "[if(equals(parameters('edgeOs'), 'linux'), variables('linuxOsProfile'), variables('windowsOsProfile'))]",
                 "storageProfile": {
@@ -322,7 +329,7 @@
                             "location": "[resourceGroup().location]",
                             "properties": {
                                 "hardwareProfile": {
-                                    "vmSize": "Standard_A1"
+                                    "vmSize": "[parameters('vmSize')]"
                                 },
                                 "osProfile": {
                                     "computerName": "[concat(variables('simulationName'), copyIndex())]",

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -187,5 +187,5 @@ To support these scenarios, the `deploy.ps1` takes the following parameters:
 Now that you have successfully deployed the Azure Industrial IoT Platform and Simulation, here are the suggested next steps:
 
 - [Deploy Industrial IoT modules to IoT Edge](howto-install-iot-edge.md)
-- [Learn more about OPC Twin](services/readme.md)
-- [OPC Twin Dependencies](services/dependencies.md)
+- [Learn more about the Platform services](../services/readme.md)
+- [Learn more about the deployed Azure Service dependencies](../services/dependencies.md)

--- a/docs/deploy/howto-deploy-local.md
+++ b/docs/deploy/howto-deploy-local.md
@@ -37,5 +37,5 @@ This article explains how to deploy only the Azure services needed to do local d
 
 Now that you have successfully deployed Azure Industrial IoT Microservices to an existing project, here are the suggested next steps:
 
-* [Run the Industrial IoT modules locally](../howto-install-iot-edge.md)
-* [Learn about the OPC Twin dependencies](../services/dependencies.md)
+* [Run the Industrial IoT components locally](howto-run-microservices-locally.md)
+* [Learn more about the deployed Azure Service dependencies](../services/dependencies.md)

--- a/docs/deploy/howto-deploy-modules-portal.md
+++ b/docs/deploy/howto-deploy-modules-portal.md
@@ -23,13 +23,13 @@ To deploy all required modules to the Gateway using the Azure Portal...
 6. In the **IoT Edge Custom Module** dialog use `discovery` as name for the module, then specify the container *image URI* as
 
    ```bash
-mcr.microsoft.com/iotedge/discovery:latest
+   mcr.microsoft.com/iotedge/discovery:latest
    ```
 
    As *create options* use the following JSON:
 
    ```json
-{"NetworkingConfig":{"EndpointsConfig":{"host":{}}},"HostConfig":{"NetworkMode":"host","CapAdd":["NET_ADMIN"]}}
+   {"NetworkingConfig":{"EndpointsConfig":{"host":{}}},"HostConfig":{"NetworkMode":"host","CapAdd":["NET_ADMIN"]}}
    ```
 
    Fill out the optional fields if necessary. For more information about container create options, restart policy, and desired status see [EdgeAgent desired properties](https://docs.microsoft.com/azure/iot-edge/module-edgeagent-edgehub#edgeagent-desired-properties). For more information about the module twin see [Define or update desired properties](https://docs.microsoft.com/azure/iot-edge/module-composition#define-or-update-desired-properties).
@@ -39,7 +39,7 @@ mcr.microsoft.com/iotedge/discovery:latest
 8. In the **IoT Edge Custom Module** dialog use `opctwin` as name for the module, then specify the container *image URI* as
 
    ```bash
-mcr.microsoft.com/iotedge/opc-twin:latest
+   mcr.microsoft.com/iotedge/opc-twin:latest
    ```
 
    Leave the *create options* empty.
@@ -49,7 +49,7 @@ mcr.microsoft.com/iotedge/opc-twin:latest
 10. In the IoT Edge Custom Module dialog, use `opcpublisher` as name for the module and the container *image URI* as
 
     ```bash
-mcr.microsoft.com/iotedge/opc-publisher:latest
+    mcr.microsoft.com/iotedge/opc-publisher:latest
     ```
 
     Leave the *create options* empty.

--- a/docs/deploy/quickstart-gateway-installer.md
+++ b/docs/deploy/quickstart-gateway-installer.md
@@ -6,13 +6,16 @@ IoT Edge Runtime and the modules can also be deployed automatically using the Az
 To use the Azure Industrial IoT Gateway Installer to setup IoT Edge and the Industrial IoT Edge modules follow the following steps:
 
 ## Prerequisites
-- Download Azure CLI    
+
+- Download Azure CLI
 
     1. On the Azure CLI Wizard read and accept the terms in the License Agreement by checking “I accept the terms in the License Agreement.
     2. Select “Install” to install Azure CLI.
     3. Click “Next”.
     4. After Azure CLI is installed, click the Finish button to exit the Setup Wizard.
-- Activate Hyper-V 
+
+- Activate Hyper-V
+
     1. Right click on the Windows button and select ‘Apps and Features’.
     2. Select Programs and Features on the right under related settings.
     3. Select Turn Windows Features on or off.
@@ -21,25 +24,25 @@ To use the Azure Industrial IoT Gateway Installer to setup IoT Edge and the Indu
 
 ## Download the Gateway Installer
 
-1.	Download and run the Gateway Installer for Windows from [here](https://github.com/Azure/Industrial-IoT-Gateway-Installer/raw/master/Releases/Windows/setup.exe) and for Linux from [here](https://github.com/Azure/Industrial-IoT-Gateway-Installer/raw/master/Releases/Linux.zip).
+1. Download and run the Gateway Installer for Windows from [here](https://github.com/Azure/Industrial-IoT-Gateway-Installer/raw/master/Releases/Windows/setup.exe) and for Linux from [here](https://github.com/Azure/Industrial-IoT-Gateway-Installer/raw/master/Releases/Linux.zip).
 
-2.	Select “Install”.
+2. Select “Install”.
 
-3.	If Azure CLI hasn’t been downloaded yet, you will be asked to download it.
+3. If Azure CLI hasn’t been downloaded yet, you will be asked to download it.
 
-4.	The Industrial IoT Gateway Installer will check the requirements for the installation.
+4. The Industrial IoT Gateway Installer will check the requirements for the installation.
 
-5.	In the next step, you will be asked to install Azure IoT Edge on your computer. To do so
+5. In the next step, you will be asked to install Azure IoT Edge on your computer. To do so
 
     1. Select your IoT Hub.
     2. Name your IoT Edge device.
     3. Optionally, select a local network interface to host IoT Edge.
-    4. Check “install industrial modules (OPC Twin & OPC Publisher)” to install them. 
-    
-6.	To install them click “Install”.
+    4. Check “install industrial modules (OPC Twin & OPC Publisher)” to install them.
 
+6. To install them click “Install”.
 
 ## Next steps
+
 Get started with discovering your assets by deploying the 
 > [!div class="nextstepaction"]
 > [Azure Industrial IoT Platform using the deployment script](../deploy/howto-deploy-all-in-one.md)

--- a/docs/deploy/readme.md
+++ b/docs/deploy/readme.md
@@ -4,7 +4,7 @@
 
 ## Quickstart
 
-The simplest way to get started is to deploy the [Azure Industrial IoT Platform and Simulation demonstrator using the deployment script](howto-deploy-all-in-one.md).  Unless you decide otherwise, it also deploys 2 simulated Edge Gateways and assets.   
+The simplest way to get started is to deploy the [Azure Industrial IoT Platform and Simulation demonstrator using the deployment script](howto-deploy-all-in-one.md).  Unless you decide otherwise, it also deploys 2 simulated Edge Gateways and assets.
 
 > The all in one hosting option is intended as a quick start solution.   For production deployments that require staging, rollback, scaling and resilience you should deploy the platform into Kubernetes as explained [here](howto-deploy-aks.md).
 
@@ -17,5 +17,3 @@ Alternative options to deploy the platform services include:
 - Deploying the Industrial IoT platform to [Azure Kubernetes Service (AKS)](howto-deploy-aks.md) as production solution.
 - For development and testing purposes, you can also [deploy only the Microservices dependencies in Azure](howto-deploy-local.md) and [run Microservices locally](howto-run-microservices-locally.md)
 - [Enable ASC for IoT](howto-enable-asc-for-iot-and-sentinel-steps.md) if you want to monitor security of OPC UA endpoints
-
-


### PR DESCRIPTION
This fixes the issue that on some subscriptions certain vm sizes are disabled or not available.   The selection tries to find a comparable VM.   Also adds tagging of resource groups like connected factory.