### PR TITLE
IAI: Upgraded Microsoft.Graph.Beta. Added checks for ApplicationName.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/ApplicationsManager.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/ApplicationsManager.cs
@@ -454,8 +454,11 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     Oauth2PermissionScopes = oauth2Permissions
                 };
 
+                // ODataType = null is a workaround for a bug:
+                // https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/87
                 var serviceApplicationWebApplication = new WebApplication {
                     ImplicitGrantSettings = new ImplicitGrantSettings {
+                        ODataType = null,
                         EnableIdTokenIssuance = true
                     }
                 };
@@ -642,9 +645,12 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                 // Note: Oauth2AllowImplicitFlow will be enabled automatically since both
                 // EnableIdTokenIssuance and EnableAccessTokenIssuance are set to true.
 
+                // ODataType = null is a workaround for a bug:
+                // https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/87
                 var clientApplicationWebApplication = new WebApplication {
                     //Oauth2AllowImplicitFlow = true,
                     ImplicitGrantSettings = new ImplicitGrantSettings {
+                        ODataType = null,
                         EnableIdTokenIssuance = true,
                         EnableAccessTokenIssuance = true
                     }
@@ -732,8 +738,11 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     Oauth2PermissionScopes = aksOauth2Permissions
                 };
 
+                // ODataType = null is a workaround for a bug:
+                // https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/87
                 var aksApplicationWebApplication = new WebApplication {
                     ImplicitGrantSettings = new ImplicitGrantSettings {
+                        ODataType = null,
                         EnableIdTokenIssuance = true
                     }
                 };

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -25,8 +25,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.4.0" />
 
     <!--<PackageReference Include="Microsoft.Graph" Version="1.21.0" />-->
-    <!--<PackageReference Include="Microsoft.Graph.Beta" Version="0.12.0-preview" />-->
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.8.0-preview" />
+    <PackageReference Include="Microsoft.Graph.Beta" Version="0.12.0-preview" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.4" />
 
     <PackageReference Include="Microsoft.Identity.Client" Version="4.9.0" />


### PR DESCRIPTION
Implemented:

* Upgraded Microsoft.Graph.Beta NuGet to 0.12.0-preview.
* ApplicationName should include alphanumeric characters and '-'.

This fixes:
* [[IAI] Underscore not acceptable in Azure App Service](https://msazure.visualstudio.com/One/_workitems/edit/6089296)