### PR TITLE
IAI: Minor infrastructure changes.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -927,6 +927,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                 .CreateIotHubAsync(
                     _resourceGroup,
                     _iotHubName,
+                    IotHubMgmtClient.IOT_HUB_EVENT_HUB_RETENTION_TIME_IN_DAYS,
                     IotHubMgmtClient.IOT_HUB_EVENT_HUB_PARTITIONS_COUNT,
                     storageAccountGen2ConectionString,
                     iotHubBlobContainer.Name,
@@ -993,6 +994,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     _resourceGroup,
                     eventHubNamespace,
                     _eventHubName,
+                    EventHubMgmtClient.DEFAULT_MESSAGE_RETENTION_IN_DAYS,
+                    EventHubMgmtClient.DEFUALT_PARTITION_COUNT,
                     _defaultTagsDict,
                     cancellationToken
                 );

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION = "1.14.8";
+        public const string KUBERNETES_VERSION = "1.15.7";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/EventHubMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/EventHubMgmtClient.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
 
         public const string EVENT_HUB_CONSUMER_GROUP_TELEMETRY_CDM = "telemetry_cdm";
         public const string EVENT_HUB_CONSUMER_GROUP_TELEMETRY_UX = "telemetry_ux";
+        public const int DEFAULT_MESSAGE_RETENTION_IN_DAYS = 2;
+        public const int DEFUALT_PARTITION_COUNT = 4;
 
         private const string kEVENT_HUB_NAMESPACE_AUTHORIZATION_RULE = "RootManageSharedAccessKey";
 
@@ -260,6 +262,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         /// <param name="resourceGroup"></param>
         /// <param name="eventHubNamespace"></param>
         /// <param name="eventHubName"></param>
+        /// <param name="messageRetentionInDays"></param>
+        /// <param name="partitionCount"></param>
         /// <param name="tags"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
@@ -267,6 +271,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
             IResourceGroup resourceGroup,
             EHNamespaceInner eventHubNamespace,
             string eventHubName,
+            int messageRetentionInDays,
+            int partitionCount,
             IDictionary<string, string> tags = null,
             CancellationToken cancellationToken = default
         ) {
@@ -289,8 +295,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                     Location = resourceGroup.RegionName,
                     Tags = tags,
 
-                    MessageRetentionInDays = 1,
-                    PartitionCount = 2,
+                    MessageRetentionInDays = messageRetentionInDays,
+                    PartitionCount = partitionCount,
                     Status = EntityStatus.Active
                 };
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/IotHubMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/IotHubMgmtClient.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const int NUM_OF_MAX_NAME_AVAILABILITY_CHECKS = 5;
 
         public const int IOT_HUB_EVENT_HUB_PARTITIONS_COUNT = 4;
+        public const int IOT_HUB_EVENT_HUB_RETENTION_TIME_IN_DAYS = 2;
 
         public const string IOT_HUB_EVENT_HUB_EVENTS_ENDPOINT_NAME = "events";
         public const string IOT_HUB_EVENT_HUB_EVENTS_CONSUMER_GROUP_NAME = "events";
@@ -156,7 +157,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         /// </summary>
         /// <param name="resourceGroup"></param>
         /// <param name="iotHubName"></param>
-        /// <param name="iotHubEventHubEndpointsPartitionsCount"></param>
+        /// <param name="iotHubEventHubRetentionTimeInDays"></param>
+        /// <param name="iotHubEventHubPartitionsCount"></param>
         /// <param name="storageAccountConectionString"></param>
         /// <param name="storageAccountIotHubContainerName"></param>
         /// <param name="tags"></param>
@@ -165,7 +167,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public async Task<IotHubDescription> CreateIotHubAsync(
             IResourceGroup resourceGroup,
             string iotHubName,
-            int iotHubEventHubEndpointsPartitionsCount,
+            int iotHubEventHubRetentionTimeInDays,
+            int iotHubEventHubPartitionsCount,
             string storageAccountConectionString,
             string storageAccountIotHubContainerName,
             IDictionary<string, string> tags = null,
@@ -191,8 +194,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                     EventHubEndpoints = new Dictionary<string, EventHubProperties> {
                         // The only possible keys to this dictionary is 'events'.
                         { IOT_HUB_EVENT_HUB_EVENTS_ENDPOINT_NAME, new EventHubProperties {
-                                RetentionTimeInDays = 1,
-                                PartitionCount = iotHubEventHubEndpointsPartitionsCount
+                                RetentionTimeInDays = iotHubEventHubRetentionTimeInDays,
+                                PartitionCount = iotHubEventHubPartitionsCount
                             }
                         }
                     },

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/NetworkMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/NetworkMgmtClient.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                     SecurityRules = new List<SecurityRuleInner> {
                         new SecurityRuleInner {
                             Name = "UASC",
-
                             Protocol = SecurityRuleProtocol.Tcp,
                             SourcePortRange = "*",
                             DestinationPortRange = "4840",
@@ -88,7 +87,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                         },
                         new SecurityRuleInner {
                             Name = "HTTPS",
-
                             Protocol = SecurityRuleProtocol.Tcp,
                             SourcePortRange = "*",
                             DestinationPortRange = "443",
@@ -97,18 +95,27 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                             Access = SecurityRuleAccess.Allow,
                             Priority = 101,
                             Direction = SecurityRuleDirection.Inbound
-
+                        },
+                        new SecurityRuleInner {
+                            Name = "HTTP",
+                            Protocol = SecurityRuleProtocol.Tcp,
+                            SourcePortRange = "*",
+                            DestinationPortRange = "80",
+                            SourceAddressPrefix = "*",
+                            DestinationAddressPrefix = "*",
+                            Access = SecurityRuleAccess.Allow,
+                            Priority = 102,
+                            Direction = SecurityRuleDirection.Inbound
                         },
                         new SecurityRuleInner {
                             Name = "SSH",
-
                             Protocol = SecurityRuleProtocol.Tcp,
                             SourcePortRange = "*",
                             DestinationPortRange = "22",
                             SourceAddressPrefix = "*",
                             DestinationAddressPrefix = "*",
                             Access = SecurityRuleAccess.Deny,
-                            Priority = 102,
+                            Priority = 103,
                             Direction = SecurityRuleDirection.Inbound
                         }
                     }

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -40,7 +40,7 @@
 
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
 
-    <PackageReference Include="KubernetesClient" Version="1.6.20" />
+    <PackageReference Include="KubernetesClient" Version="1.6.33" />
 
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>


### PR DESCRIPTION
* Upgraded KubernetesClient NuGet package to 1.6.33.
* Upgraded AKS version to 1.15.7.
* Increased retention period (2 days) and number of partitions (4)  of both Event Hubs.
* Enabled incoming traffic on port 80 in NSG. This is required for next changes for `cert-manager`.