### PR TITLE
Changing order of configuration providers.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/cli/Microsoft.Azure.IIoT.Cli.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/cli/Microsoft.Azure.IIoT.Cli.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.3" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/api/src/Microsoft.Azure.IIoT.Api/cli/Program.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/cli/Program.cs
@@ -106,7 +106,15 @@ namespace Microsoft.Azure.IIoT.Api.Cli {
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
                 .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build();
 
             using (var scope = new Program(config,

--- a/api/src/Microsoft.Azure.IIoT.Api/cli/Program.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/cli/Program.cs
@@ -110,11 +110,7 @@ namespace Microsoft.Azure.IIoT.Api.Cli {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
 
             using (var scope = new Program(config,

--- a/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
+++ b/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
@@ -31,9 +31,10 @@ namespace Microsoft.Extensions.Configuration {
         /// <param name="keyVaultUrlVarName"></param>
         /// <returns></returns>
         public static IConfigurationBuilder AddFromKeyVault(
-            this IConfigurationBuilder builder, bool singleton = true,
-            string keyVaultUrlVarName = null) {
-
+            this IConfigurationBuilder builder,
+            bool singleton = true,
+            string keyVaultUrlVarName = null
+        ) {
             var provider = KeyVaultConfigurationProvider.CreateInstanceAsync(
                 singleton, builder.Build(), keyVaultUrlVarName).Result;
             if (provider != null) {
@@ -121,7 +122,10 @@ namespace Microsoft.Extensions.Configuration {
             /// <param name="keyVaultUrlVarName"></param>
             /// <returns></returns>
             public static async Task<KeyVaultConfigurationProvider> CreateInstanceAsync(
-                bool singleton, IConfigurationRoot configuration, string keyVaultUrlVarName) {
+                bool singleton,
+                IConfigurationRoot configuration,
+                string keyVaultUrlVarName
+            ) {
                 if (string.IsNullOrEmpty(keyVaultUrlVarName)) {
                     keyVaultUrlVarName = PcsVariable.PCS_KEYVAULT_URL;
                 }
@@ -150,8 +154,10 @@ namespace Microsoft.Extensions.Configuration {
             /// <param name="lazyLoad"></param>
             /// <returns></returns>
             private static async Task<KeyVaultConfigurationProvider> CreateInstanceAsync(
-                IConfigurationRoot configuration, string keyVaultUrlVarName, bool lazyLoad) {
-
+                IConfigurationRoot configuration,
+                string keyVaultUrlVarName,
+                bool lazyLoad
+            ) {
                 var vaultUri = configuration.GetValue<string>(keyVaultUrlVarName, null);
                 if (string.IsNullOrEmpty(vaultUri)) {
                     Log.Logger.Debug("No keyvault uri found in configuration under {key}. ",

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -791,8 +791,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
 
             // Create AKS cluster
             // We have to wait for setupKeyVaultTask to finish before using _aksClusterX509Certificate.
-            setupKeyVaultTask.Wait();
-            var operationalInsightsWorkspace = operationalInsightsWorkspaceCreationTask.Result;
+            await setupKeyVaultTask;
+            var operationalInsightsWorkspace = await operationalInsightsWorkspaceCreationTask;
 
             var clusterDefinition = _aksManagementClient.GetClusterDefinition(
                 _resourceGroup,
@@ -1019,7 +1019,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            var cosmosDBAccount = cosmosDBAccountCreationTask.Result;
+            var cosmosDBAccount = await cosmosDBAccountCreationTask;
             var cosmosDBAccountConnectionString = await _cosmosDBManagementClient
                 .GetCosmosDBAccountConnectionStringAsync(
                     _resourceGroup,
@@ -1034,7 +1034,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            var serviceBusNamespace = serviceBusNamespaceCreationTask.Result;
+            var serviceBusNamespace = await serviceBusNamespaceCreationTask;
             var serviceBusNamespaceConnectionString = await _serviceBusManagementClient
                 .GetServiceBusNamespaceConnectionStringAsync(
                     _resourceGroup,
@@ -1042,7 +1042,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            var signalR = signalRCreationTask.Result;
+            var signalR = await signalRCreationTask;
             var signalRConnectionString = await _signalRManagementClient
                 .GetConnectionStringAsync(
                     _resourceGroup,
@@ -1050,10 +1050,10 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            var applicationInsightsComponent = applicationInsightsComponentCreationTask.Result;
+            var applicationInsightsComponent = await applicationInsightsComponentCreationTask;
 
             // Wat for Public IP of AKS before creating IIoTEnvironment
-            var aksCluster = aksClusterCreationTask.Result;
+            var aksCluster = await aksClusterCreationTask;
 
             // Create a PublicIP address in AKS node resource group
             var aksPublicIpName = "aks-public-ip";
@@ -1207,7 +1207,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
             _applicationURL = aksPublicIp.DnsSettings.Fqdn;
 
             // Waiting for unfinished tasks.
-            keyVaultConfCreationTask.Wait();
+            await keyVaultConfCreationTask;
 
             // Check if we want to save environment to .env file
             try {
@@ -1267,7 +1267,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-                _aksClusterX509Certificate = aksClusterX509CertificateGetTask.Result;
+                _aksClusterX509Certificate = await aksClusterX509CertificateGetTask;
             }
         }
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
     using System.Linq;
 
     using Microsoft.Azure.Management.ApplicationInsights.Management.Models;
-    using Microsoft.Azure.Management.AppService.Fluent.Models;
     using Microsoft.Azure.Management.EventHub.Fluent.Models;
     using Microsoft.Azure.Management.IotHub.Models;
     using Microsoft.Azure.Management.KeyVault.Fluent.Models;

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Diagnostic/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Diagnostic/cli/Program.cs
@@ -40,10 +40,15 @@ namespace Microsoft.Azure.IIoT.Modules.Diagnostic.Cli {
             var logger = ConsoleLogger.Create(LogEventLevel.Information);
             Console.WriteLine("Edge Diagnostics command line interface.");
             var configuration = new ConfigurationBuilder()
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Diagnostic/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Diagnostic/cli/Program.cs
@@ -45,10 +45,7 @@ namespace Microsoft.Azure.IIoT.Modules.Diagnostic.Cli {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Program.cs
@@ -41,10 +41,7 @@ namespace Microsoft.Azure.IIoT.Modules.Discovery.Cli {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Program.cs
@@ -36,10 +36,15 @@ namespace Microsoft.Azure.IIoT.Modules.Discovery.Cli {
             string deviceId = null, moduleId = null;
             Console.WriteLine("Discovery module command line interface.");
             var configuration = new ConfigurationBuilder()
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Program.cs
@@ -42,10 +42,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Cli {
             string deviceId = null, moduleId = null;
             Console.WriteLine("Publisher module command line interface.");
             var configuration = new ConfigurationBuilder()
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Program.cs
@@ -47,10 +47,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Cli {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Program.cs
@@ -52,10 +52,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Cli {
             string deviceId = null, moduleId = null;
             Console.WriteLine("Twin module command line interface.");
             var configuration = new ConfigurationBuilder()
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Program.cs
@@ -57,10 +57,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Cli {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
             var cs = configuration.GetValue<string>(PcsVariable.PCS_IOTHUB_CONNSTRING, null);
             if (string.IsNullOrEmpty(cs)) {

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Startup.cs
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Startup.cs
@@ -66,10 +66,7 @@ namespace Microsoft.Azure.IIoT.App {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Startup.cs
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Startup.cs
@@ -61,10 +61,15 @@ namespace Microsoft.Azure.IIoT.App {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.All/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.All/src/Startup.cs
@@ -49,10 +49,7 @@ namespace Microsoft.Azure.IIoT.Services.All {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.All/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.All/src/Startup.cs
@@ -44,10 +44,15 @@ namespace Microsoft.Azure.IIoT.Services.All {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Startup.cs
@@ -65,11 +65,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Events {
         /// <param name="configuration"></param>
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
-                .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Startup.cs
@@ -70,10 +70,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Events {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Startup.cs
@@ -65,10 +65,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Startup.cs
@@ -60,10 +60,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Startup.cs
@@ -67,10 +67,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Startup.cs
@@ -72,10 +72,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Program.cs
@@ -48,10 +48,17 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync {
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                .AddCommandLine(args)
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .AddCommandLine(args)
                 .Build();
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Program.cs
@@ -54,12 +54,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync {
                 .AddCommandLine(args)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
 
             // Set up dependency injection for the event processor host

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Startup.cs
@@ -71,10 +71,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this (env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Startup.cs
@@ -76,10 +76,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Startup.cs
@@ -60,10 +60,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Startup.cs
@@ -65,10 +65,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Startup.cs
@@ -60,10 +60,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin.History {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Startup.cs
@@ -65,10 +65,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin.History {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Startup.cs
@@ -65,10 +65,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Startup.cs
@@ -60,10 +60,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Twin {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/src/Startup.cs
@@ -76,10 +76,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Vault {
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/src/Startup.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/src/Startup.cs
@@ -71,10 +71,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Vault {
         public Startup(IWebHostEnvironment env, IConfiguration configuration) :
             this(env, new Config(new ConfigurationBuilder()
                 .AddConfiguration(configuration)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .Build())) {
         }
 

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -51,12 +51,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
                 .AddCommandLine(args)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
 
             // Set up dependency injection for the event processor host

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -45,10 +45,17 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                .AddCommandLine(args)
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .AddCommandLine(args)
                 .Build();
 

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
@@ -45,10 +45,17 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                .AddCommandLine(args)
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .AddCommandLine(args)
                 .Build();
 

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
@@ -51,12 +51,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
                 .AddCommandLine(args)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
 
             // Set up dependency injection for the event processor host

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
@@ -49,12 +49,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
                 .AddCommandLine(args)
                 // Above configuration providers will provide connection
                 // details for KeyVault configuration provider.
-                .AddFromKeyVault()
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
+                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
                 .Build();
 
             // Set up dependency injection for the event processor host

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
@@ -43,10 +43,17 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
             var config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
+                .AddCommandLine(args)
+                // Above configuration providers will provide connection
+                // details for KeyVault configuration provider.
                 .AddFromKeyVault()
+                .AddJsonFile("appsettings.json", true)
+                .AddFromDotEnvFile()
+                .AddEnvironmentVariables()
+                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .AddCommandLine(args)
                 .Build();
 


### PR DESCRIPTION
Purpose of this PR is to establish order of configuration providers so that any local configuration provider can override a value from KeyVault. This is required so that deployment through a Helm chart can use configuration deployed through `deploy.ps1` or IAI to KeyVault, but would still be able to override any value if needed. This will also help in local debugging when one wants to re-use most but not all values from KeyVault.

In general this is the order of increasing priority that I propose for configuration provider groups:
1. remote configuration provider (KeyVault)
2. local bulk configuration providers, `appsettings.json` and `.env`
3. local singular configuration providers, environment variables and command line arguments

More specifically, the order would look like this for configuration providers that we use:
1. KeyVault configuration provider
2. `appsettings.json` (if applicable)
3. `.env` file
4. Environment variables
5. User environment variables
6. Command line arguments (if applicable)

It should be noted that there is technical peculiarity with initialization of KeyVault configuration provider. As it itself uses the provided `IConfigurationBuilder` object to extract KeyVault connection details (including credentials). So to make things work I had to first determine the order of configuration providers for each service and then use all except KeyVault configuration provider twice. First  in the intended order before initialization of KeyVault configuration provider (to make sure that intended override order will be applied for configuration of for KeyVault connections details), and then again after initialization of KeyVault configuration provider so that values from local providers override values from KeyVault. The overhead of duplicating the providers would slow down loading of configuration, but that should happen only once when components starts.