### PR TITLE
Add codecov and codacy code coverage upload option

### DIFF
--- a/tools/templates/cc.yml
+++ b/tools/templates/cc.yml
@@ -33,6 +33,11 @@ jobs:
       projects: '**/tests/*.csproj'
       arguments: '--configuration Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura'
       publishTestResults: false
+  - script: |
+      bash <(curl -s https://codecov.io/bash)
+
+    continueOnError: true
+    displayName: 'Upload to codecov.io'
   - task: DotNetCoreCLI@2
     inputs:
       command: custom
@@ -51,3 +56,13 @@ jobs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
       reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
+  - script: |
+      bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r $REPORT_LOCATION --commit-uuid $COMMIT_UUID
+
+    condition: ne( variables['CODACY_PROJECT_TOKEN'], '')
+    env:
+      CODACY_PROJECT_TOKEN: $(CODACY_PROJECT_TOKEN)
+      REPORT_LOCATION: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
+      COMMIT_UUID: '$(Build.SourceVersion)'
+    continueOnError: true
+    displayName: 'Upload to Codacy'

--- a/tools/templates/cc.yml
+++ b/tools/templates/cc.yml
@@ -36,6 +36,8 @@ jobs:
   - script: |
       bash <(curl -s https://codecov.io/bash)
 
+    env:
+      CODECOV_TOKEN: $(CODECOV_TOKEN)
     continueOnError: true
     displayName: 'Upload to codecov.io'
   - task: DotNetCoreCLI@2


### PR DESCRIPTION
Codecov: https://codecov.io/gh/Azure/Industrial-IoT
Codacy requires an upload token, at this point the free plan works only on private forks.