### PR TITLE
Errors after Twin module upgrade and Heartbeat

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Abstractions/src/Hub/Models/TwinProperty.cs
+++ b/common/src/Microsoft.Azure.IIoT.Abstractions/src/Hub/Models/TwinProperty.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Azure.IIoT.Hub {
     public static class TwinProperty {
 
         /// <summary>
-        /// Connected property name constant
-        /// </summary>
-        public const string Connected = "__connected__";
-
-        /// <summary>
         /// Type property name constant
         /// </summary>
         public const string Type = "__type__";

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Extensions/DeviceTwinModelEx.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Extensions/DeviceTwinModelEx.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.IIoT.Hub.Models {
         /// <param name="twin"></param>
         /// <returns></returns>
         public static bool? IsConnected(this DeviceTwinModel twin) {
-            return twin.ConnectionState?.EqualsIgnoreCase("connected");
+            return twin.ConnectionState?.EqualsIgnoreCase("Connected");
         }
 
         /// <summary>

--- a/common/src/Microsoft.Azure.IIoT.Hub.Mock/src/Services/IoTHubServices.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Mock/src/Services/IoTHubServices.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.IIoT.Hub.Mock {
                     };
                 }
                 if (Twin.ConnectionState == null) {
-                    Twin.ConnectionState = "disconnected";
+                    Twin.ConnectionState = "Disconnected";
                 }
                 if (Twin.Status == null) {
                     Twin.Status = "enabled";
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.IIoT.Hub.Mock {
             public void Connect(IIoTClientCallback client) {
                 lock (_lock) {
                     Connection = client;
-                    Twin.ConnectionState = client == null ? "disconnected" : "connected";
+                    Twin.ConnectionState = client == null ? "Disconnected" : "Connected";
                 }
             }
 

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Hosting/ModuleHost.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Hosting/ModuleHost.cs
@@ -68,19 +68,13 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
         }
 
         /// <inheritdoc/>
-        public async Task StopAsync(bool force) {
+        public async Task StopAsync() {
             if (Client != null) {
                 try {
                     await _lock.WaitAsync();
                     if (Client != null) {
                         _logger.Information("Stopping Module Host...");
                         try {
-                            if (!force) {
-                                var twinSettings = new TwinCollection {
-                                    [TwinProperty.Connected] = false
-                                };
-                                await Client.UpdateReportedPropertiesAsync(twinSettings);
-                            }
                             await Client.CloseAsync();
                         }
                         catch (OperationCanceledException) { }
@@ -98,7 +92,8 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                 }
                 finally {
                     kModuleStart.WithLabels(DeviceId ?? "", ModuleId ?? "",
-                        DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK", CultureInfo.InvariantCulture)).Set(0);
+                        DateTime.UtcNow.ToString("yyyy-MM-dd'T'HH:mm:ss.FFFFFFFK",
+                        CultureInfo.InvariantCulture)).Set(0);
                     Client?.Dispose();
                     Client = null;
                     _reported?.Clear();
@@ -136,8 +131,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
 
                         // Report type of service, chosen site, and connection state
                         var twinSettings = new TwinCollection {
-                            [TwinProperty.Type] = type,
-                            [TwinProperty.Connected] = true
+                            [TwinProperty.Type] = type
                         };
 
                         // Set site if provided
@@ -308,7 +302,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
         /// <inheritdoc/>
         public void Dispose() {
             if (Client != null) {
-                StopAsync(true).Wait();
+                StopAsync().Wait();
             }
             _lock.Dispose();
         }
@@ -521,7 +515,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
         private bool ProcessEdgeHostSettings(string key, VariantValue value,
             IDictionary<string, VariantValue> processed = null) {
             switch (key.ToLowerInvariant()) {
-                case TwinProperty.Connected:
                 case TwinProperty.Version:
                 case TwinProperty.Type:
                     break;

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Services/IModuleHost.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Services/IModuleHost.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Services {
         /// <summary>
         /// Stop module host
         /// </summary>
-        /// <param name="force"></param>
         /// <returns></returns>
-        Task StopAsync(bool force = false);
+        Task StopAsync();
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Common/ModuleHostHarness.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Common/ModuleHostHarness.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
 
                     // Assert
                     Assert.NotEqual(etag, twin.Etag);
-                    Assert.Equal("connected", twin.ConnectionState);
+                    Assert.Equal("Connected", twin.ConnectionState);
                     Assert.Equal("testType", twin.Properties.Reported[TwinProperty.Type]);
                     Assert.Equal("TestSite", twin.Properties.Reported[TwinProperty.SiteId]);
                     etag = twin.Etag;
@@ -70,15 +70,11 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     await edge.StopAsync();
                     twin = await services.GetAsync(deviceId, moduleId);
 
-                    // Assert
-                    Assert.False((bool)twin.Properties.Reported[TwinProperty.Connected]);
-
                     // TODO : Fix cleanup!!!
 
                     // TODO :Assert.True("testType" != twin.Properties.Reported[TwinProperty.kType]);
                     // TODO :Assert.True("TestSite" != twin.Properties.Reported[TwinProperty.kSiteId]);
-                    // TODO :Assert.Equal("disconnected", twin.ConnectionState);
-                    Assert.NotEqual(etag, twin.Etag);
+                    Assert.Equal("Disconnected", twin.ConnectionState);
                 }
             }
         }

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Hosting/SettingsRouterTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Hosting/SettingsRouterTests.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     Assert.True(controller._applyCalled);
                     Assert.Equal("test4", controller.TestSetting1);
                     Assert.Equal(test, twin.Properties.Reported[nameof(TestController1.TestSetting1)]);
-                    Assert.True((bool)twin.Properties.Reported[TwinProperty.Connected]);
                 });
         }
 
@@ -60,7 +59,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     Assert.Equal("test2", controller.TestSetting2);
                     Assert.Equal(test, twin.Properties.Reported[nameof(TestController1.TestSetting1)]);
                     Assert.Equal(test2, twin.Properties.Reported[nameof(TestController1.TestSetting2)]);
-                    Assert.True((bool)twin.Properties.Reported[TwinProperty.Connected]);
                 });
         }
 
@@ -93,7 +91,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     Assert.Equal(test, twin.Properties.Reported[nameof(TestController1.TestSetting1)]);
                     Assert.Equal(test2, twin.Properties.Reported[nameof(TestController1.TestSetting2)]);
                     Assert.Equal(test3, twin.Properties.Reported[nameof(TestController1.TestSetting3)]);
-                    Assert.True((bool)twin.Properties.Reported[TwinProperty.Connected]);
                 });
         }
 
@@ -122,7 +119,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     Assert.True(controller._applyCalled);
                     Assert.Equal(expected, controller.TestSetting);
                     Assert.Equal(test, twin.Properties.Reported[nameof(TestController2.TestSetting)]);
-                    Assert.True((bool)twin.Properties.Reported[TwinProperty.Connected]);
                 });
         }
 
@@ -168,7 +164,6 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
                     Assert.Null(controller.TestSetting3);
                     Assert.False(twin.Properties.Reported.TryGetValue(nameof(TestController1.TestSetting3), out var post));
                     Assert.Null(post);
-                    Assert.True((bool)twin.Properties.Reported[TwinProperty.Connected]);
                 });
         }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Cdm/src/Services/CdmMessageProcessor.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Cdm/src/Services/CdmMessageProcessor.cs
@@ -517,7 +517,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Cdm.Services {
                     manifest.Schema = "cdm:/schema.cdm.json";
                     manifest.JsonSchemaSemanticVersion = "1.0.0";
                     if (adlsRoot.Documents.Item(manifest.Name) == null) {
-                        adlsRoot.Documents.Add(manifest);
+                        Try.Op(() => adlsRoot.Documents.Add(manifest));
                     }
 
                     sw.Restart();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/src/Supervisor/Services/SupervisorServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/src/Supervisor/Services/SupervisorServices.cs
@@ -379,7 +379,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Supervisor.Services {
                     finally {
                         _logger.Debug("Stopping twin...");
                         Status = EndpointActivationState.Activated;
-                        await host.StopAsync(true);
+                        await host.StopAsync();
                         _logger.Information("Twin stopped.");
                         _started.TrySetResult(false); // Cancelled before started
                     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -199,6 +199,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                             NodeId = variable.PublishedVariableNodeId,
                             DisplayName = variable.PublishedVariableDisplayName,
                             SamplingInterval = variable.SamplingInterval,
+                            HeartbeatInterval = variable.HeartbeatInterval,
                             PublishingInterval = source.SubscriptionSettings.PublishingInterval
                         }))
                     .ToList();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
@@ -172,7 +172,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
 
             var tags = twin.Tags ?? new Dictionary<string, VariantValue>();
-            var connected = twin.IsConnected();
 
             var registration = new DiscovererRegistration {
                 // Device
@@ -180,6 +179,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
                 DeviceId = twin.Id,
                 ModuleId = twin.ModuleId,
                 Etag = twin.Etag,
+                Connected = twin.IsConnected() ?? false,
 
                 // Tags
 
@@ -223,8 +223,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
                 SiteId =
                     properties.GetValueOrDefault<string>(TwinProperty.SiteId, null),
-                Connected = connected ??
-                    properties.GetValueOrDefault(TwinProperty.Connected, false),
                 Version =
                     properties.GetValueOrDefault<string>(TwinProperty.Version, null),
                 Type =

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/EndpointRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/EndpointRegistrationEx.cs
@@ -190,13 +190,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
 
             var tags = twin.Tags ?? new Dictionary<string, VariantValue>();
-            var connected = twin.IsConnected();
 
             var registration = new EndpointRegistration {
                 // Device
 
                 DeviceId = twin.Id,
                 Etag = twin.Etag,
+                Connected = twin.IsConnected() ?? false,
 
                 // Tags
                 IsDisabled =
@@ -222,8 +222,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
                 // Properties
 
-                Connected = connected ??
-                    properties.GetValueOrDefault(TwinProperty.Connected, false),
                 Type =
                     properties.GetValueOrDefault<string>(TwinProperty.Type, null),
                 State =

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/PublisherRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/PublisherRegistrationEx.cs
@@ -121,7 +121,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
 
             var tags = twin.Tags ?? new Dictionary<string, VariantValue>();
-            var connected = twin.IsConnected();
 
             var registration = new PublisherRegistration {
                 // Device
@@ -129,6 +128,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
                 DeviceId = twin.Id,
                 ModuleId = twin.ModuleId,
                 Etag = twin.Etag,
+                Connected = twin.IsConnected() ?? false,
 
                 // Tags
 
@@ -154,8 +154,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
                 SiteId =
                     properties.GetValueOrDefault<string>(TwinProperty.SiteId, null),
-                Connected = connected ??
-                    properties.GetValueOrDefault(TwinProperty.Connected, false),
                 Version =
                     properties.GetValueOrDefault<string>(TwinProperty.Version, null),
                 Type =

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/SupervisorRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/SupervisorRegistrationEx.cs
@@ -88,7 +88,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
 
             var tags = twin.Tags ?? new Dictionary<string, VariantValue>();
-            var connected = twin.IsConnected();
 
             var registration = new SupervisorRegistration {
                 // Device
@@ -96,6 +95,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
                 DeviceId = twin.Id,
                 ModuleId = twin.ModuleId,
                 Etag = twin.Etag,
+                Connected = twin.IsConnected() ?? false,
 
                 // Tags
 
@@ -111,8 +111,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
 
                 SiteId =
                     properties.GetValueOrDefault<string>(TwinProperty.SiteId, null),
-                Connected = connected ??
-                    properties.GetValueOrDefault(TwinProperty.Connected, false),
                 Version =
                     properties.GetValueOrDefault<string>(TwinProperty.Version, null),
                 Type =

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/DiscovererRegistry.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/DiscovererRegistry.cs
@@ -215,11 +215,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                 // If flag provided, include it in search
                 if (model.Connected.Value) {
                     query += $"AND connectionState = 'Connected' ";
-                    // Do not use connected property as module might have exited before updating.
                 }
                 else {
-                    query += $"AND (connectionState = 'Disconnected' " +
-                        $"OR properties.reported.{TwinProperty.Connected} != true) ";
+                    query += $"AND connectionState != 'Connected' ";
                 }
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/EndpointRegistry.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/EndpointRegistry.cs
@@ -162,11 +162,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                 // If flag provided, include it in search
                 if (model.Connected.Value) {
                     query += $"AND connectionState = 'Connected' ";
-                    // Do not use connected property as module might have exited before updating.
                 }
                 else {
-                    query += $"AND (connectionState = 'Disconnected' " +
-                        $"OR properties.reported.{TwinProperty.Connected} != true) ";
+                    query += $"AND connectionState != 'Connected' ";
                 }
             }
             var result = await _iothub.QueryDeviceTwinsAsync(query, null, pageSize, ct);
@@ -544,7 +542,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
             var query = $"SELECT * FROM devices WHERE " +
                 $"tags.{nameof(EndpointRegistration.Activated)} = true AND " +
                 $"NOT IS_DEFINED(tags.{nameof(EndpointRegistration.IsDisabled)}) AND " +
-                $"connectionState = 'Disconnected' AND " +
+                $"connectionState != 'Connected' AND " +
                 $"tags.{nameof(EntityRegistration.DeviceType)} = '{IdentityType.Endpoint}' ";
 
             var result = new List<DeviceTwinModel>();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/GatewayRegistry.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/GatewayRegistry.cs
@@ -158,11 +158,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                 // If flag provided, include it in search
                 if (model.Connected.Value) {
                     query += $"AND connectionState = 'Connected' ";
-                    // Do not use connected property as module might have exited before updating.
                 }
                 else {
-                    query += $"AND (connectionState = 'Disconnected' " +
-                        $"OR properties.reported.{TwinProperty.Connected} != true) ";
+                    query += $"AND connectionState != 'Connected' ";
                 }
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/PublisherRegistry.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/PublisherRegistry.cs
@@ -210,11 +210,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                 // If flag provided, include it in search
                 if (model.Connected.Value) {
                     query += $"AND connectionState = 'Connected' ";
-                    // Do not use connected property as module might have exited before updating.
                 }
                 else {
-                    query += $"AND (connectionState = 'Disconnected' " +
-                        $"OR properties.reported.{TwinProperty.Connected} != true) ";
+                    query += $"AND connectionState != 'Connected' ";
                 }
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/SupervisorRegistry.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Services/SupervisorRegistry.cs
@@ -150,11 +150,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                 // If flag provided, include it in search
                 if (model.Connected.Value) {
                     query += $"AND connectionState = 'Connected' ";
-                    // Do not use connected property as module might have exited before updating.
                 }
                 else {
-                    query += $"AND (connectionState = 'Disconnected' " +
-                        $"OR properties.reported.{TwinProperty.Connected} != true) ";
+                    query += $"AND connectionState != 'Connected' ";
                 }
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Services/EndpointRegistryTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Services/EndpointRegistryTests.cs
@@ -329,10 +329,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Services {
                     if (a.Registration.SiteId != null) {
                         t.Properties.Reported.Add(TwinProperty.SiteId, a.Registration.SiteId);
                     }
-                    if (a.IsTwinConnected()) {
-                        t.ConnectionState = "Connected";
-                        t.Properties.Reported.Add(TwinProperty.Connected, true);
-                    }
+                    t.ConnectionState = a.IsTwinConnected() ? "Connected" : "Disconnected";
                     return t;
                 })
                 .Select(t => (t, new DeviceModel { Id = t.Id }))

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/src/Tests/TestData/ReadArrayValueTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/src/Tests/TestData/ReadArrayValueTests.cs
@@ -233,23 +233,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Testing.Tests {
 
             // Assert
             Assert.NotNull(result);
-            Assert.NotNull(result.Value);
             Assert.NotNull(result.SourceTimestamp);
             Assert.NotNull(result.ServerTimestamp);
             AssertEqualValue(expected, result.Value);
 
-            if (VariantValueEx.IsNull(result.Value)) {
-                return;
-            }
-
-            Assert.True(result.Value.IsString);
-            // TODO: Returns a bytestring, not byte array.  Investigate.
-            // Assert.Equal(VariantValueType.Bytes, result.Value.Type);
-            // Assert.True(result.Value.IsArray);
-            // if ((result.Value).Count == 0) return;
-            // Assert.Equal(VariantValueType.Integer, (result.Value)[0].Type);
             Assert.Equal("ByteString", result.DataType);
-            // TODO: Assert.Equal("Byte", result.DataType);
+            Assert.True(VariantValueEx.IsNull(result.Value) || result.Value.IsBytes);
         }
 
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/EndpointSettingsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/EndpointSettingsController.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Controllers {
 #pragma warning restore IDE0032 // Use auto property
         private readonly ITwinServices _twin;
         private static readonly string kTwinMetricsPrefix = "iiot_edge_twin_";
-        private static readonly Counter kApplyAsync = Metrics.CreateCounter(kTwinMetricsPrefix + "apply", "call to applyAsync");
+        private static readonly Counter kApplyAsync = Metrics
+            .CreateCounter(kTwinMetricsPrefix + "apply", "call to applyAsync");
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/SupervisorSettingsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/SupervisorSettingsController.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Controllers {
                     _endpoints.AddOrUpdate(endpointId, null);
                     return;
                 }
-                if (!value.IsString ||
-                    !value.ToString().IsBase64()) {
+                if (!value.IsString || !((string)value).IsBase64()) {
                     return;
                 }
                 _endpoints.AddOrUpdate(endpointId, value);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/ModuleProcess.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/ModuleProcess.cs
@@ -215,11 +215,9 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin {
                 // Register outer instances
                 builder.RegisterInstance(_logger)
                     .ExternallyOwned()
-                    .OnRelease(_ => { }) // Do not dispose
                     .AsImplementedInterfaces();
                 builder.RegisterInstance(_client)
                     .ExternallyOwned()
-                    .OnRelease(_ => { }) // Do not dispose
                     .AsImplementedInterfaces();
 
                 // Register other opc ua services

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Fixtures/TwinModuleFixture.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Fixtures/TwinModuleFixture.cs
@@ -195,12 +195,9 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests {
         private void AssertStopped() {
             Assert.False(_running);
             var twin = _hub.GetAsync(DeviceId, ModuleId).Result;
-            // Assert
-            Assert.False((bool)twin.Properties.Reported[TwinProperty.Connected]);
-
             // TODO : Fix cleanup!!!
             // TODO :Assert.NotEqual("testType", twin.Properties.Reported[TwinProperty.kType]);
-            // TODO :Assert.Equal("disconnected", twin.ConnectionState);
+            // TODO :Assert.Equal("Disconnected", twin.ConnectionState);
             Assert.NotEqual(_etag, twin.Etag);
         }
 
@@ -211,8 +208,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests {
             Assert.True(_running);
             var twin = _hub.GetAsync(DeviceId, ModuleId).Result;
             // Assert
-            Assert.Equal("connected", twin.ConnectionState);
-            Assert.Equal(true, twin.Properties.Reported[TwinProperty.Connected]);
+            Assert.Equal("Connected", twin.ConnectionState);
             Assert.Equal(IdentityType.Supervisor, twin.Properties.Reported[TwinProperty.Type]);
             Assert.False(twin.Properties.Reported.TryGetValue(TwinProperty.SiteId, out _));
         }

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Services/Registry.cs
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Services/Registry.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.IIoT.App.Services {
 
                 foreach (var ep in endpoints.Items) {
                     // Get non cached version of endpoint
-                    var endpoint = ep; // await _registryService.GetEndpointAsync(ep.Registration.Id);
+                    var endpoint = await _registryService.GetEndpointAsync(ep.Registration.Id);
                     pageResult.Results.Add(new EndpointInfo {
                         EndpointModel = endpoint
                     });
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.IIoT.App.Services {
 
                 if (discoverers != null && discoverers.Items.Any()) {
                     foreach (var disc in discoverers.Items) {
-                        var discoverer = disc; //  await _registryService.GetDiscovererAsync(disc.Id);
+                        var discoverer = await _registryService.GetDiscovererAsync(disc.Id);
                         var info = new DiscovererInfo {
                             DiscovererModel = discoverer,
                             HasApplication = false,
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.IIoT.App.Services {
 
                 if (applications != null) {
                     foreach (var app in applications.Items) {
-                        var application = app; // (await _registryService.GetApplicationAsync(app.ApplicationId)).Application;
+                        var application = (await _registryService.GetApplicationAsync(app.ApplicationId)).Application;
                         pageResult.Results.Add(application);
                     }
                 }
@@ -376,7 +376,7 @@ namespace Microsoft.Azure.IIoT.App.Services {
 
                 if (publishers != null) {
                     foreach (var pub in publishers.Items) {
-                        var publisher = pub; // await _registryService.GetPublisherAsync(pub.Id);
+                        var publisher = await _registryService.GetPublisherAsync(pub.Id);
                         pageResult.Results.Add(publisher);
                     }
                 }
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.IIoT.App.Services {
 
                 if (supervisors != null) {
                     foreach (var sup in supervisors.Items) {
-                        var supervisor = sup; // await _registryService.GetSupervisorAsync(sup.Id);
+                        var supervisor = await _registryService.GetSupervisorAsync(sup.Id);
                         pageResult.Results.Add(supervisor);
                     }
                 }


### PR DESCRIPTION
* Module upgrade does not update reported state correctly including connectivity status and twin activation status
* Heartbeat interval is not set in published nodes in list call.
* Temporarily eat ArgumentException in CDM processor during model.json creation to fix missing CSV persistency.
* Fix potential null byte array value returned by unit test server