### PR TITLE
Helm: Upgraded Azure Industrial IoT components to 2.7.105 version.

### DIFF
--- a/deploy/helm/azure-industrial-iot/Chart.yaml
+++ b/deploy/helm/azure-industrial-iot/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 - name: Karapet Kostandyan
   email: kakostan@microsoft.com
 icon: https://raw.githubusercontent.com/Azure/Industrial-IoT/master/docs/media/microsoft-symbol.png
-appVersion: 2.7.56
+appVersion: 2.7.105

--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -1,9 +1,9 @@
-# Azure Industrial IoT
+# Azure Industrial IoT <!-- omit in toc -->
 
 [Azure Industrial IoT](https://github.com/Azure/Industrial-IoT) allows users to discover OPC UA
 enabled servers in a factory network, register them in Azure IoT Hub and start collecting data from them.
 
-## Table Of Contents
+## Table Of Contents <!-- omit in toc -->
 
 * [Introduction](#introduction)
 * [Prerequisites](#prerequisites)
@@ -12,9 +12,13 @@ enabled servers in a factory network, register them in Azure IoT Hub and start c
     * [Azure IoT Hub](#azure-iot-hub)
     * [Azure Cosmos DB Account](#azure-cosmos-db-account)
     * [Azure Storage Account](#azure-storage-account)
+      * [Data Protection Container (Optional)](#data-protection-container-optional)
     * [Azure Event Hub Namespace](#azure-event-hub-namespace)
+      * [Azure Event Hub](#azure-event-hub)
+      * [Azure Event Hub Consumer Groups](#azure-event-hub-consumer-groups)
     * [Azure Service Bus Namespace](#azure-service-bus-namespace)
     * [Azure Key Vault](#azure-key-vault)
+      * [Data Protection Key (Optional)](#data-protection-key-optional)
     * [Azure SignalR](#azure-signalr)
   * [Recommended Azure Resources](#recommended-azure-resources)
     * [Azure AAD App Registration](#azure-aad-app-registration)
@@ -40,9 +44,13 @@ enabled servers in a factory network, register them in Azure IoT Hub and start c
 * [Special Notes](#special-notes)
   * [Resource Requests And Limits](#resource-requests-and-limits)
   * [Data Protection](#data-protection)
+    * [Azure Storage Account Container](#azure-storage-account-container)
+    * [Azure Key Vault Key](#azure-key-vault-key)
   * [Common Data Model](#common-data-model)
   * [Swagger](#swagger)
   * [NGINX Ingress Controller](#nginx-ingress-controller)
+    * [Controller configuration](#controller-configuration)
+    * [Ingress Annotations](#ingress-annotations)
 
 ## Introduction
 
@@ -499,7 +507,7 @@ The following details of the Azure Storage account would be required:
 
 ## Installing the Chart
 
-This chart installs `2.7.56` version of components by default.
+This chart installs `2.7.105` version of components by default.
 
 To install the chart first ensure that you have added `azure-iiot` repository:
 
@@ -565,7 +573,7 @@ values.
 | Parameter           | Description                              | Default             |
 |---------------------|------------------------------------------|---------------------|
 | `image.registry`    | URL of Docker Image Registry             | `mcr.microsoft.com` |
-| `image.tag`         | Image tag                                | `2.7.56`            |
+| `image.tag`         | Image tag                                | `2.7.105`           |
 | `image.pullPolicy`  | Image pull policy                        | `IfNotPresent`      |
 | `image.pullSecrets` | docker-registry secret names as an array | `[]`                |
 
@@ -1069,9 +1077,9 @@ Here is the full list of components with Swagger UIs:
 We tested Azure Industrial IoT solution with NGINX Ingress Controller. And it required a few configuration
 tweaks to make Ingress work smoothly.
 
-#### ConfigMap
+#### Controller configuration
 
-The following values need to be added to NGINX Ingress Controller
+The following values need to be added to NGINX Ingress Controller configuration
 [ConfigMap](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/).
 
 ```json

--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -321,7 +321,7 @@ we require two apps to be registered in your AAD:
 * One for web clients accessing web interfaces of Azure Industrial IoT components, we refer to this as
   **ClientsApp**.
 
-Here are the steps to [create AAD App Registrations](https://github.com/Azure/Industrial-IoT/blob/master/docs/deploy/howto-register-aad-applications.md).
+Here are the steps to [create AAD App Registrations](../../../docs/deploy/howto-register-aad-applications.md).
 
 > **NOTE:** For any production deployment of Azure Industrial IoT solution it is required that those AAD
 App Registrations are created and details are provided to the chart. And we strongly recommend having those
@@ -672,7 +672,7 @@ This parameter is required so that Publisher Edge Module can communicate with jo
 Edge Module will be presented with a Kubernetes internal URL, which will be accessible only from within
 Kubernetes cluster. Format of Kubernetes internal URL is `http://<service_name>.<namespace>:<service_port>`.
 
-**Documentation**: [Publisher Edge Module](https://github.com/Azure/Industrial-IoT/blob/master/docs/modules/publisher.md)
+**Documentation**: [Publisher Edge Module](../../../docs/modules/publisher.md)
 
 | Parameter            | Description                                                                | Default |
 |----------------------|----------------------------------------------------------------------------|---------|
@@ -732,7 +732,7 @@ following aspects of application runtime for microservices:
 
 ### Deployed Components
 
-**Documentation**: [Azure Industrial IoT Platform Components](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/readme.md)
+**Documentation**: [Azure Industrial IoT Platform Components](../../../docs/services/readme.md)
 
 Azure Industrial IoT comprises of fifteen micro-services that this chart will deploy as
 [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) resources. Eight of them
@@ -749,23 +749,23 @@ parameters.
 Here is the list of all Azure Industrial IoT components that are deployed by this chart. Currently only
 `engineeringTool` and `telemetryCdmProcessor` are disabled by default.
 
-| Name in `values.yaml`     | Description                                                                                                           | Enabled by Default |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------|
-| `registry`                | [Registry Microservice](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/registry.md)                | `true`             |
-| `sync`                    | [Registry Synchronization Agent](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/registry-sync.md)  | `true`             |
-| `twin`                    | [OPC Twin Microservice](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/twin.md)                    | `true`             |
-| `history`                 | [OPC Historian Access Microservice](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/twin-history.md)| `true`             |
-| `gateway`                 | [OPC Gateway Microservice](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/twin-gateway.md)         | `true`             |
-| `vault`                   | [OPC Vault Microservice](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/vault.md)                  | `true`             |
-| `publisher`               | [OPC Publisher Service](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/publisher.md)               | `true`             |
-| `events`                  | [Events Service](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/events.md)                         | `true`             |
-| `edgeJobs`                | [Publisher jobs orchestrator service](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/publisher.md) | `true`             |
-| `onboarding`              | [Onboarding Processor](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/processor-onboarding.md)     | `true`             |
-| `eventsProcessor`         | [Edge Event Processor](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/processor-events.md)         | `true`             |
-| `telemetryCdmProcessor`   | [Datalake export](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/processor-telemetry-cdm.md)       | `false`            |
-| `telemetryProcessor`      | [Edge Telemetry processor](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/processor-telemetry.md)  | `true`             |
-| `tunnelProcessor`         | [Http Tunnel processor](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/processor-tunnel.md)        | `true`             |
-| `engineeringTool`         | [Engineering Tool](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/engineeringtool.md)              | `false`            |
+| Name in `values.yaml`   | Description                                                                 | Enabled by Default |
+|-------------------------|-----------------------------------------------------------------------------|--------------------|
+| `registry`              | [Registry Microservice](../../../docs/services/registry.md)                 | `true`             |
+| `sync`                  | [Registry Synchronization Agent](../../../docs/services/registry-sync.md)   | `true`             |
+| `twin`                  | [OPC Twin Microservice](../../../docs/services/twin.md)                     | `true`             |
+| `history`               | [OPC Historian Access Microservice](../../../docs/services/twin-history.md) | `true`             |
+| `gateway`               | [OPC Gateway Microservice](../../../docs/services/twin-gateway.md)          | `true`             |
+| `vault`                 | [OPC Vault Microservice](../../../docs/services/vault.md)                   | `true`             |
+| `publisher`             | [OPC Publisher Service](../../../docs/services/publisher.md)                | `true`             |
+| `events`                | [Events Service](../../../docs/services/events.md)                          | `true`             |
+| `edgeJobs`              | [Publisher jobs orchestrator service](../../../docs/services/publisher.md)  | `true`             |
+| `onboarding`            | [Onboarding Processor](../../../docs/services/processor-onboarding.md)      | `true`             |
+| `eventsProcessor`       | [Edge Event Processor](../../../docs/services/processor-events.md)          | `true`             |
+| `telemetryCdmProcessor` | [Datalake export](../../../docs/services/processor-telemetry-cdm.md)        | `false`            |
+| `telemetryProcessor`    | [Edge Telemetry processor](../../../docs/services/processor-telemetry.md)   | `true`             |
+| `tunnelProcessor`       | [Http Tunnel processor](../../../docs/services/processor-tunnel.md)         | `true`             |
+| `engineeringTool`       | [Engineering Tool](../../../docs/services/engineeringtool.md)               | `false`            |
 
 #### Deployment Resource Configuration
 
@@ -1022,7 +1022,7 @@ permission on `Azure Storage`. Please follow these steps to
 [add API permissions](https://docs.microsoft.com/graph/notifications-integration-app-registration#api-permissions).
 
 Here is a tutorial on
-[how to connect Power BI with Azure Data Lake Storage Gen2 and visualize publisher telemetry](https://github.com/Azure/Industrial-IoT/blob/master/docs/tutorials/tut-power-bi-cdm.md).
+[how to connect Power BI with Azure Data Lake Storage Gen2 and visualize publisher telemetry](../../../docs/tutorials/tut-power-bi-cdm.md).
 
 ### Swagger
 

--- a/deploy/helm/azure-industrial-iot/values.yaml
+++ b/deploy/helm/azure-industrial-iot/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.registry is URL of Docker registry from where images will be pulled.
   registry: mcr.microsoft.com
   # image.tag defines which version of Docker images to pull.
-  tag: 2.7.56
+  tag: 2.7.105
   # image.pullPolicy defines value of imagePullPolicy of deployments.
   pullPolicy: IfNotPresent
   # image.pullSecrets defined docker-registry secrets that should be used for private container registries.


### PR DESCRIPTION
I have decided to change the way I reference other documents in Helm documentation, specifically documentation of our microservices.

Previously I was referencing them by the full URL to the `master` branch.This introduces several problems:
1. When viewing documentation of a specific version or branch/tag from GitHub repo, let's say `helm/0.2.0`, you are still redirected to docs in `master` branch. This is problematic as some of the microservices either do not exist any more or they may have been renamed. In both cases links are invalidated.
2. Similar problem exists when viewing published charts in Helm repositories. They also reference documents in `master` branch which do not exist any more.

Here is my plan going forward:
1. Use relative links in GitHub repo. This will make sure that when you view docs of a specific branch/tag you are still redirected to docs in the same branch/tag.
2. Create **tags** for Helm releases, thus having a stable versions for referencing from outside.
3. **Before** publishing the chart from a tag in our GitHub repo to Helm repositories, change relative links in `README.md` of the chart to full URLs of documents for that tag. **<- THIS IS VERY IMPORTANT**

With the proposed changes I will make sure that:
1. Helm documentation in GitHub repo will reference file in the same banch/tag thus making sure they are aligned.
2. Helm documentation in the Helm release tags references documents in the same commit.
3. Updates to the chart before publishing it will make sure that when the `README.md` is rendered in Helm repositories, it will still point to stable entries in GitHub repo and thus the documentation will be valid.