### PR TITLE
Adding IoTSuiteType tag to PS1 deployment.

### DIFF
--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -828,6 +828,10 @@ Function New-Deployment() {
         $templateParameters.Add("keyVaultPrincipalId", $script:aadConfig.UserPrincipalId)
     }
 
+    # Add IoTSuiteType tag. This tag will be applied for all resources.
+    $tags = @{"IoTSuiteType" = "AzureIndustrialIoT-$($script:version)-PS1"}
+    $templateParameters.Add("tags", $tags)
+
     # register providers
     $script:requiredProviders | ForEach-Object {
         Register-AzResourceProvider -ProviderNamespace $_

--- a/deploy/templates/azuredeploy.configuration.json
+++ b/deploy/templates/azuredeploy.configuration.json
@@ -13,6 +13,13 @@
             "metadata": {
                 "description": "Configuration of key value pairs to store in keyvault."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "resources": [
@@ -27,6 +34,7 @@
             "name": "[concat(parameters('keyVaultName'), '/', toLower(replace(parameters('configuration')[copyIndex()].key, '_', '-')))]",
             "apiVersion": "2016-10-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "contentType": "application/json",
                 "value": "[string(parameters('configuration')[copyIndex()].value)]"

--- a/deploy/templates/azuredeploy.edge.json
+++ b/deploy/templates/azuredeploy.edge.json
@@ -226,6 +226,13 @@
             "metadata": {
                 "description": "A user created managed identity to use for keyvault access.  If not provided, above secret will be used to gain access to keyvault."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -312,6 +319,7 @@
             "type": "Microsoft.Network/virtualNetworks",
             "apiVersion": "2019-09-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [
@@ -336,6 +344,7 @@
             "type": "Microsoft.Network/networkInterfaces",
             "apiVersion": "2019-09-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "ipConfigurations": [
                     {
@@ -359,6 +368,7 @@
             "type": "Microsoft.Compute/virtualMachines",
             "apiVersion": "2019-03-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "identity": "[if(not(empty(parameters('managedIdentityResourceId'))), variables('identity'), '')]",
             "properties": {
                 "hardwareProfile": {
@@ -389,6 +399,7 @@
             "name": "[concat(variables('vmName'), '/', 'scriptextensions')]",
             "apiVersion": "2019-03-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": "[if (equals(parameters('edgeOs'), 'linux'), variables('linuxVmExtension'), variables('windowsVmExtension'))]",
             "dependsOn": [
                 "[variables('vmResourceId')]"
@@ -397,7 +408,7 @@
         {
             "comments": "Deploy factory network simulation.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[concat(variables('simulationName'), copyIndex())]",
             "condition": "[not(equals(parameters('numberOfSimulations'), 0))]",
             "copy": {
@@ -417,6 +428,7 @@
                             "type": "Microsoft.Network/networkInterfaces",
                             "apiVersion": "2019-09-01",
                             "location": "[resourceGroup().location]",
+                            "tags": "[parameters('tags')]",
                             "properties": {
                                 "ipConfigurations": [
                                     {
@@ -439,6 +451,7 @@
                             "name": "[concat(variables('simulationName'), copyIndex())]",
                             "apiVersion": "2019-03-01",
                             "location": "[resourceGroup().location]",
+                            "tags": "[parameters('tags')]",
                             "properties": {
                                 "hardwareProfile": {
                                     "vmSize": "[variables('simulationVmSku')]"
@@ -472,6 +485,7 @@
                             "name": "[concat(variables('simulationName'), copyIndex(), '/', 'scriptextensions')]",
                             "apiVersion": "2019-03-01",
                             "location": "[resourceGroup().location]",
+                            "tags": "[parameters('tags')]",
                             "properties": {
                                 "publisher": "Microsoft.Azure.Extensions",
                                 "type": "CustomScript",

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -253,7 +253,8 @@
                     "keyVaultPrincipalId": {
                         "value": "[parameters('keyVaultPrincipalId')]"
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -336,7 +337,8 @@
                             }
                         ]
                     },
-                    "tags" : "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -399,7 +401,8 @@
                             "secretName": "pcs-storage-key"
                         }
                     },
-                    "tags" : "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -464,7 +467,8 @@
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
                     },
-                    "tags" : "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -532,7 +536,8 @@
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
                     },
-                    "tags" : "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -254,7 +254,10 @@
                         "value": "[parameters('keyVaultPrincipalId')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -338,7 +341,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -402,7 +408,10 @@
                         }
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -468,7 +477,10 @@
                         "value": "[parameters('imagesTag')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -537,7 +549,10 @@
                         "value": "[parameters('imagesTag')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -211,6 +211,13 @@
             "metadata": {
                 "description": "Specifies the image version tag to use for all container images."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -232,7 +239,7 @@
         {
             "comments": "Deploy minimum required Azure Infrastructure for Industrial IoT.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('minimumInfrastructureResourceName')]",
             "properties": {
                 "mode": "Incremental",
@@ -245,7 +252,8 @@
                     },
                     "keyVaultPrincipalId": {
                         "value": "[parameters('keyVaultPrincipalId')]"
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -256,7 +264,7 @@
         {
             "comments": "Save auth configuration in keyVault.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('authConfigurationResourcName')]",
             "properties": {
                 "mode": "Incremental",
@@ -327,7 +335,8 @@
                                 "value": "[parameters('imagesNamespace')]"
                             }
                         ]
-                    }
+                    },
+                    "tags" : "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -341,7 +350,7 @@
         {
             "comments": "Deploy Azure Infrastructure required by the full Industrial IoT Platform.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('standardInfrastructureResourceName')]",
             "condition": "[variables('standardInfrastructureDeployment')]",
             "properties": {
@@ -389,7 +398,8 @@
                             },
                             "secretName": "pcs-storage-key"
                         }
-                    }
+                    },
+                    "tags" : "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -403,7 +413,7 @@
         {
             "comments": "Deploy Azure Industrial IoT platform.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('platformResourcName')]",
             "condition": "[variables('platformDeployment')]",
             "properties": {
@@ -453,7 +463,8 @@
                     },
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
-                    }
+                    },
+                    "tags" : "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -467,7 +478,7 @@
         {
             "comments": "Deploy Azure Industrial IoT Edge simulation.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('simulationResourcName')]",
             "condition": "[variables('simulationDeployment')]",
             "properties": {
@@ -520,7 +531,8 @@
                     },
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
-                    }
+                    },
+                    "tags" : "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -253,8 +253,6 @@
                     "keyVaultPrincipalId": {
                         "value": "[parameters('keyVaultPrincipalId')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -340,8 +338,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -407,8 +403,6 @@
                             "secretName": "pcs-storage-key"
                         }
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -476,8 +470,6 @@
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -548,8 +540,6 @@
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }

--- a/deploy/templates/azuredeploy.minimum.json
+++ b/deploy/templates/azuredeploy.minimum.json
@@ -688,7 +688,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.minimum.json
+++ b/deploy/templates/azuredeploy.minimum.json
@@ -244,6 +244,13 @@
             "metadata": {
                 "description": "The KeyVault SKU to use."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -275,7 +282,8 @@
             "name": "[parameters('managedIdentityName')]",
             "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
             "apiVersion": "2018-11-30",
-            "location": "[resourceGroup().location]"
+            "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]"
         },
         {
             "comments": "KeyVault for secrets and certificate store.",
@@ -283,6 +291,7 @@
             "name": "[parameters('keyVaultName')]",
             "apiVersion": "2016-10-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "enabledForDeployment": false,
                 "enabledForTemplateDeployment": true,
@@ -332,6 +341,7 @@
             "type": "Microsoft.KeyVault/vaults/accessPolicies",
             "name": "[concat(parameters('keyVaultName'), '/add')]",
             "apiVersion": "2016-10-01",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "accessPolicies": [
                     {
@@ -366,6 +376,7 @@
             "type": "Microsoft.Devices/Iothubs",
             "name": "[parameters('iotHubName')]",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('iotHubSku')]",
                 "tier": "[parameters('iotHubTier')]",
@@ -452,6 +463,7 @@
             "apiVersion": "2019-03-22",
             "name": "[concat(parameters('iotHubName'), '/events/', variables('iothubTelemetryConsumerGroup'))]",
             "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "tags": "[parameters('tags')]",
             "dependsOn": [
                 "[variables('iotHubResourceId')]"
             ]
@@ -461,6 +473,7 @@
             "apiVersion": "2019-03-22",
             "name": "[concat(parameters('iotHubName'), '/events/', variables('iothubEventsConsumerGroup'))]",
             "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "tags": "[parameters('tags')]",
             "dependsOn": [
                 "[variables('iotHubResourceId')]"
             ]
@@ -470,6 +483,7 @@
             "apiVersion": "2019-03-22",
             "name": "[concat(parameters('iotHubName'), '/events/', variables('iothubOnboardingConsumerGroup'))]",
             "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "tags": "[parameters('tags')]",
             "dependsOn": [
                 "[variables('iotHubResourceId')]"
             ]
@@ -479,6 +493,7 @@
             "apiVersion": "2019-03-22",
             "name": "[concat(parameters('iotHubName'), '/events/', variables('iothubTunnelConsumerGroup'))]",
             "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "tags": "[parameters('tags')]",
             "dependsOn": [
                 "[variables('iotHubResourceId')]"
             ]
@@ -489,6 +504,7 @@
             "apiVersion": "2017-04-01",
             "name": "[parameters('eventHubNamespaceName')]",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('eventHubSkuTier')]",
                 "tier": "[parameters('eventHubSkuTier')]",
@@ -507,6 +523,7 @@
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'))]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "messageRetentionInDays": "[parameters('eventHubRetentionInDays')]",
                 "partitionCount": "[parameters('eventHubPartitionCount')]",
@@ -522,6 +539,7 @@
             "name": "[parameters('storageName')]",
             "apiVersion": "2019-04-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "StorageV2",
             "sku": {
                 "name": "[parameters('storageSkuName')]"
@@ -555,6 +573,7 @@
             "type": "Microsoft.DocumentDb/databaseAccounts",
             "name": "[parameters('cosmosDbName')]",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "name": "[parameters('cosmosDbName')]",
                 "enableAutomaticFailover": false,
@@ -584,6 +603,7 @@
             "type": "Microsoft.ServiceBus/namespaces",
             "name": "[parameters('serviceBusNamespaceName')]",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('serviceBusSkuTier')]"
             },
@@ -595,7 +615,7 @@
         {
             "comments": "Save minimum infrastructure configuration in keyVault.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('configurationResourceName')]",
             "properties": {
                 "mode": "Incremental",
@@ -666,7 +686,8 @@
                                 "value": "[reference(variables('identityResourceId'), '2018-11-30').tenantId]"
                             }
                         ]
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.minimum.json
+++ b/deploy/templates/azuredeploy.minimum.json
@@ -687,7 +687,8 @@
                             }
                         ]
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.minimum.json
+++ b/deploy/templates/azuredeploy.minimum.json
@@ -687,8 +687,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -141,6 +141,13 @@
             "metadata": {
                 "description": "The pricing sku for the hosting plan."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -165,6 +172,7 @@
             "kind": "[if(parameters('deployFromSource'), 'app', 'linux')]",
             "name": "[parameters('hostingPlanName')]",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('hostingPlanSku')]",
                 "capacity": "[if(empty(parameters('siteName')), if(empty(parameters('serviceSiteName')), '0', '1'), '2')]"
@@ -183,6 +191,7 @@
             "name": "[variables('serviceSiteResourceName')]",
             "apiVersion": "2018-11-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
@@ -299,7 +308,7 @@
         {
             "comments": "Save service url as configuration.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('serviceConfigurationResourceName')]",
             "condition": "[and(not(empty(parameters('keyVaultName'))), not(empty(parameters('serviceSiteName'))))]",
             "properties": {
@@ -319,7 +328,8 @@
                                 "value": "[if(empty(parameters('serviceSiteName')), '', concat('https://$', list(variables('servicePublishingConfigResource'), '2016-08-01').properties.publishingUserName, ':', list(variables('servicePublishingConfigResource'), '2016-08-01').properties.publishingPassword, '@', replace(list(variables('servicePublishingConfigResource'), '2016-08-01').properties.scmUri, 'https://', ''), ''))]"
                             }
                         ]
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -338,6 +348,7 @@
             "name": "[variables('appSiteResourceName')]",
             "apiVersion": "2018-11-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "identity": {
                 "type": "UserAssigned",
                 "userAssignedIdentities": {
@@ -427,7 +438,7 @@
         {
             "comments": "Save app hook as configuration.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('appConfigurationResourceName')]",
             "condition": "[and(not(empty(parameters('keyVaultName'))), not(empty(parameters('siteName'))))]",
             "properties": {
@@ -443,7 +454,8 @@
                                 "value": "[if(empty(parameters('siteName')), '', concat('https://$', list(variables('appPublishingConfigResource'), '2016-08-01').properties.publishingUserName, ':', list(variables('appPublishingConfigResource'), '2016-08-01').properties.publishingPassword, '@', replace(list(variables('appPublishingConfigResource'), '2016-08-01').properties.scmUri, 'https://', ''), ''))]"
                             }
                         ]
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -330,7 +330,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -457,7 +460,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -329,7 +329,8 @@
                             }
                         ]
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -455,7 +456,8 @@
                             }
                         ]
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -329,8 +329,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -459,8 +457,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -121,6 +121,13 @@
             "metadata": {
                 "description": "Specifies the image version tag to use for all images."
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -131,7 +138,7 @@
         {
             "comments": "Deploy linux edge gateway and factory network simulation.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[concat('simulation.linux.', copyIndex())]",
             "condition": "[not(equals(0, parameters('numberOfLinuxGateways')))]",
             "copy": {
@@ -202,7 +209,8 @@
                     },
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -215,7 +223,7 @@
         {
             "comments": "Deploy windows edge gateway and factory network simulation.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[concat('simulation.windows.', copyIndex())]",
             "condition": "[not(equals(0, parameters('numberOfWindowsGateways')))]",
             "copy": {
@@ -286,7 +294,8 @@
                     },
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -299,7 +308,7 @@
         {
             "comments": "Save edge simulation user and password.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('simulationConfigurationResourceName')]",
             "condition": "[and(not(empty(parameters('keyVaultName'))), or(not(equals(0, parameters('numberOfLinuxGateways'))), not(equals(0, parameters('numberOfWindowsGateways')))))]",
             "properties": {
@@ -319,7 +328,8 @@
                                 "value": "[parameters('edgePassword')]"
                             }
                         ]
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -211,7 +211,10 @@
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -297,7 +300,10 @@
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -332,7 +338,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -210,7 +210,8 @@
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -295,7 +296,8 @@
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -329,7 +331,8 @@
                             }
                         ]
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -210,8 +210,6 @@
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -299,8 +297,6 @@
                     "managedIdentityResourceId": {
                         "value": "[parameters('managedIdentityResourceId')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -337,8 +333,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }

--- a/deploy/templates/azuredeploy.standard.json
+++ b/deploy/templates/azuredeploy.standard.json
@@ -762,7 +762,8 @@
                             }
                         ]
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -792,7 +793,8 @@
                     "workbookId": {
                         "value": "[parameters('workbookId')]"
                     },
-                    "tags": "[parameters('tags')]"
+                    // "tags": "[parameters('tags')]"//,
+                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.standard.json
+++ b/deploy/templates/azuredeploy.standard.json
@@ -329,6 +329,13 @@
             "metadata": {
                 "description": "The unique guid for this workbook instance"
             }
+        },
+        "tags": {
+            "type": "object",
+            "defaultValue": {},
+            "metadata": {
+                "description": "Tags for Azure resources."
+            }
         }
     },
     "variables": {
@@ -368,6 +375,7 @@
             "name": "[parameters('dpsName')]",
             "apiVersion": "2018-01-22",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('dpsSku')]",
                 "capacity": "[parameters('dpsCapacity')]"
@@ -388,6 +396,7 @@
             "name": "[parameters('datalakeName')]",
             "apiVersion": "2019-04-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "StorageV2",
             "sku": {
                 "name": "[parameters('datalakeSkuName')]"
@@ -423,6 +432,7 @@
             "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'), '/', variables('datalakeEventHubConsumerGroup'))]",
             "apiVersion": "2017-04-01",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "userMetadata": "CDM Telemetry Consumer Group"
             },
@@ -435,6 +445,7 @@
             "condition": "[not(empty(parameters('datalakeServicePrincipalId')))]",
             "apiVersion": "2018-09-01-preview",
             "name": "[concat(parameters('datalakeName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('datalakeName'))))]",
+            "tags" : "[parameters('tags')]",
             "properties": {
                 "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
                 "principalId": "[parameters('datalakeServicePrincipalId')]",
@@ -451,6 +462,7 @@
             "apiVersion": "2018-08-15-preview",
             "location": "[resourceGroup().location]",
             "kind": "[parameters('tsiEnvironmentKind')]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "storageConfiguration": {
                     "accountName": "[parameters('tsiStorageName')]",
@@ -484,6 +496,7 @@
             "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
             "apiVersion": "2017-04-01",
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'), '/', variables('tsiEventHubConsumerGroup'))]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "userMetadata": "Tsi Telemetry Consumer Group"
             },
@@ -496,6 +509,7 @@
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'), '/', parameters('tsiEventHubAuthorization'))]",
             "apiVersion": "2017-04-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "rights": [
                     "Listen"
@@ -510,6 +524,7 @@
             "name": "[concat(parameters('tsiEnvironmentName'), '/', variables('tsiEventSourceName'))]",
             "apiVersion": "2018-08-15-preview",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "Microsoft.EventHub",
             "properties": {
                 "eventSourceResourceId": "[variables('eventHubResourceId')]",
@@ -532,6 +547,7 @@
             "type": "Microsoft.Kusto/clusters",
             "apiVersion": "2020-02-15",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "sku": {
                 "name": "[parameters('kustoSkuName')]",
                 "tier": "[parameters('kustoSkuTier')]",
@@ -553,6 +569,7 @@
             "type": "Microsoft.Kusto/clusters/databases",
             "apiVersion": "2020-02-15",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "ReadWrite",
             "properties": {
                 "softDeletePeriod": "P365D",
@@ -567,6 +584,7 @@
             "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'), '/', variables('kustoEventHubConsumerGroup'))]",
             "apiVersion": "2017-04-01",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "userMetadata": "Kusto Telemetry Consumer Group"
             },
@@ -579,6 +597,7 @@
             "type": "Microsoft.Kusto/Clusters/Databases/DataConnections",
             "apiVersion": "2020-02-15",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "EventHub",
             "properties": {
                 "eventHubResourceId": "[variables('eventHubResourceId')]",
@@ -600,6 +619,7 @@
             "name": "[parameters('signalRName')]",
             "apiVersion": "2018-10-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "hostNamePrefix": "[parameters('signalRName')]",
                 "features": [
@@ -627,6 +647,7 @@
             "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
             "apiVersion": "2017-04-01",
             "name": "[concat(parameters('eventHubNamespaceName'), '/', parameters('eventHubName'), '/', variables('signalREventHubConsumerGroup'))]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "userMetadata": "UX Telemetry Consumer Group"
             },
@@ -639,6 +660,7 @@
             "name": "[parameters('workspaceName')]",
             "apiVersion": "2015-11-01-preview",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "properties": {
                 "sku": {
                     "Name": "[parameters('workspaceSku')]"
@@ -656,6 +678,7 @@
             "name": "[parameters('appInsightsName')]",
             "apiVersion": "2015-05-01",
             "location": "[resourceGroup().location]",
+            "tags": "[parameters('tags')]",
             "kind": "web",
             "properties": {
                 "Application_Type": "web",
@@ -667,7 +690,7 @@
         {
             "comments": "Save standard infrastructure configuration in keyVault.",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('standardConfigurationResourceName')]",
             "properties": {
                 "mode": "Incremental",
@@ -738,7 +761,8 @@
                                 "value": "[resourceGroup().name]"
                             }
                         ]
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -757,7 +781,7 @@
         {
             "comments": "Create azure workbook",
             "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2017-05-10",
+            "apiVersion": "2019-08-01",
             "name": "[variables('workbookConfigurationResourceName')]",
             "properties": {
                 "mode": "Incremental",
@@ -767,7 +791,8 @@
                     },
                     "workbookId": {
                         "value": "[parameters('workbookId')]"
-                    }
+                    },
+                    "tags": "[parameters('tags')]"
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.standard.json
+++ b/deploy/templates/azuredeploy.standard.json
@@ -763,7 +763,10 @@
                         ]
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",
@@ -794,7 +797,10 @@
                         "value": "[parameters('workbookId')]"
                     },
                     // "tags": "[parameters('tags')]"//,
-                    "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
+                    "tags": {
+                        "value": "[parameters('tags')]"
+                    }
                 },
                 "templateLink": {
                     "contentVersion": "1.0.0.0",

--- a/deploy/templates/azuredeploy.standard.json
+++ b/deploy/templates/azuredeploy.standard.json
@@ -762,8 +762,6 @@
                             }
                         ]
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }
@@ -796,8 +794,6 @@
                     "workbookId": {
                         "value": "[parameters('workbookId')]"
                     },
-                    // "tags": "[parameters('tags')]"//,
-                    // "tags": "[if(empty(parameters('tags')), json('{}'), parameters('tags'))]"
                     "tags": {
                         "value": "[parameters('tags')]"
                     }

--- a/deploy/templates/azuredeploy.workbook.json
+++ b/deploy/templates/azuredeploy.workbook.json
@@ -26,6 +26,13 @@
       "metadata": {
         "description": "The unique guid for this workbook instance"
       }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+          "description": "Tags for Azure resources."
+      }
     }
   },
   "resources": [
@@ -34,6 +41,7 @@
       "type": "microsoft.insights/workbooks",
       "location": "[resourceGroup().location]",
       "apiVersion": "2018-06-17-preview",
+      "tags": "[parameters('tags')]",
       "dependsOn": [],
       "kind": "shared",
       "properties": {


### PR DESCRIPTION
Work done:
* Adding tags to ARM templates.
* Generating value of `IoTSuiteType` tag in deploy.ps1.

`IoTSuiteType` tag will have the following value: `AzureIndustrialIoT-<docker_image_tag>-PS1`. This aligns with the value generated by IAI, which is `AzureIndustrialIoT-<docker_image_tag>-IAI`.