### PR TITLE
PS1: Added logic for simulation VM selection instead of Standard_B1ms.

### DIFF
--- a/deploy/templates/azuredeploy.edge.json
+++ b/deploy/templates/azuredeploy.edge.json
@@ -123,6 +123,7 @@
             "defaultValue": "",
             "allowedValues": [
                 "",
+                "Standard_B1ms",
                 "Standard_B2s",
                 "Standard_B2ms",
                 "Standard_A2",
@@ -310,7 +311,7 @@
             }
         },
         "edgeVmSku": "[if(not(empty(parameters('edgeVmSize'))), parameters('edgeVmSize'), 'Standard_B2s')]",
-        "simulationVmSku": "[if(not(empty(parameters('simulationVmSize'))), parameters('simulationVmSize'), 'Standard_B1ms')]"
+        "simulationVmSku": "[if(not(empty(parameters('simulationVmSize'))), parameters('simulationVmSize'), variables('edgeVmSku'))]"
     },
     "resources": [
         {

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -160,7 +160,14 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "The size of VMs to provision for simulation."
+                "description": "The size of the gateway VM to provision."
+            }
+        },
+        "simulationVmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The size of the simulation VM to provision."
             }
         },
         "edgeUserName": {
@@ -506,6 +513,9 @@
                     },
                     "edgeVmSize": {
                         "value": "[parameters('edgeVmSize')]"
+                    },
+                    "simulationVmSize": {
+                        "value": "[parameters('simulationVmSize')]"  
                     },
                     "edgeUserName": {
                         "value": "[parameters('edgeUserName')]"

--- a/deploy/templates/azuredeploy.simulation.json
+++ b/deploy/templates/azuredeploy.simulation.json
@@ -44,7 +44,14 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "The size of VMs to provision for simulation."
+                "description": "The size of the gateway VM to provision."
+            }
+        },
+        "simulationVmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "The size of the simulation VM to provision."
             }
         },
         "edgeUserName": {
@@ -191,6 +198,9 @@
                     "edgeVmSize": {
                         "value": "[parameters('edgeVmSize')]"  
                     },
+                    "simulationVmSize": {
+                        "value": "[parameters('simulationVmSize')]"  
+                    },
                     "dpsIdScope": {
                         "reference": {
                             "keyVault": {
@@ -277,6 +287,9 @@
                     },
                     "edgeVmSize": {
                         "value": "[parameters('edgeVmSize')]"  
+                    },
+                    "simulationVmSize": {
+                        "value": "[parameters('simulationVmSize')]"  
                     },
                     "dpsIdScope": {
                         "reference": {

--- a/readme.md
+++ b/readme.md
@@ -8,11 +8,11 @@ The Azure Industrial IoT Cloud Platform is a Microsoft product that has fully em
 
 ## Discover, register and manage your industrial assets with Azure
 
-The Azure Industrial IoT Cloud Platform allows you to discover industrial assets on-site and automatically registers them in the cloud for easy access there. It leverages managed Azure PaaS services. On top of the Azure PaaS services, we have built a number of edge and cloud micro-services that must be used together, leveraging OPC UA as the data model. This is also the first cloud platform to leverage the OPC UA PubSub telemetry format (both JSON and binary, on top of MQTT). If your assets don't support OPC UA as an interface, we have worked with our large partner network to support all types of industrial interfaces through the use of adapters, fully integrated with our platform. Please check out the [Azure IoT Edge Marketplace](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/internet-of-things?page=1&subcategories=iot-edge-modules). So far, we support modules from Softing and CopaData.
+The Azure Industrial IoT Cloud Platform allows you to discover industrial assets on-site and automatically registers them in the cloud for easy access there. It leverages managed Azure PaaS services. On top of the Azure PaaS services, we have built a number of edge and cloud micro-services that must be used together, leveraging OPC UA as the data model. This is also the first cloud platform to leverage the OPC UA PubSub telemetry format (both JSON and binary, on top of MQTT). If your assets don't support OPC UA as an interface, we have worked with our large partner network to support all types of industrial interfaces through the use of adapters, fully integrated with our platform. Please check out the [Azure IoT Edge Marketplace](https://azuremarketplace.microsoft.com/marketplace/apps/category/internet-of-things?page=1&subcategories=iot-edge-modules). So far, we support modules from Softing and CopaData.
 
 An overview architecture is depicted below:
 
-![diagram](/docs/media/IIoT-Diagram.png)
+![diagram](docs/media/IIoT-Diagram.png)
 
 The edge services are implemented as Azure IoT Edge modules and run on on-premises. The cloud services are implemented as ASP.NET micro-services with a REST interface and run on managed Azure Kubernetes Services (currently in preview) or stand-alone on Azure App Service. For both edge and cloud services, we have provided pre-built Docker containers in the Microsoft Container Registry (MCR), so you don't have to build them yourself. The edge and cloud services are leveraging each other and must be used together. We have also provided easy-to-use deployment scripts that allow you to deploy the entire platform in a step-by-step fashion.
 
@@ -31,25 +31,25 @@ We have also built an application running on Azure that lets you access the serv
 
 The minimal deployment script deploys the following managed Azure services into your Azure subscription:
 
-- 1 [IoT Hub](https://azure.microsoft.com/en-us/services/iot-hub/) with 4 partitions, S1 SKU (to communicate with the edge and ingress raw OPC UA telemetry data)
-- 1 [Key Vault](https://azure.microsoft.com/en-us/services/key-vault/), Premium SKU (to manage secrets and certificates)
-- 1 [Service Bus](https://azure.microsoft.com/en-us/services/service-bus/), Standard SKU (as integration event bus)
-- 1 [Event Hubs](https://azure.microsoft.com/en-us/services/event-hubs/) with 4 partitions and 2 day retention, Standard SKU (contains processed and contextualized OPC UA telemetry data)
-- 1 [Cosmos DB](https://azure.microsoft.com/en-us/services/cosmos-db/) with Session consistency level (to persist state that is not persisted in IoT Hub)
-- 1 [Blob Storage](https://azure.microsoft.com/en-us/services/storage/) V2, Standard LRS SKU (for event hub checkpointing)
+- 1 [IoT Hub](https://azure.microsoft.com/services/iot-hub/) with 4 partitions, S1 SKU (to communicate with the edge and ingress raw OPC UA telemetry data)
+- 1 [Key Vault](https://azure.microsoft.com/services/key-vault/), Premium SKU (to manage secrets and certificates)
+- 1 [Service Bus](https://azure.microsoft.com/services/service-bus/), Standard SKU (as integration event bus)
+- 1 [Event Hubs](https://azure.microsoft.com/services/event-hubs/) with 4 partitions and 2 day retention, Standard SKU (contains processed and contextualized OPC UA telemetry data)
+- 1 [Cosmos DB](https://azure.microsoft.com/services/cosmos-db/) with Session consistency level (to persist state that is not persisted in IoT Hub)
+- 1 [Blob Storage](https://azure.microsoft.com/services/storage/) V2, Standard LRS SKU (for event hub checkpointing)
 
-[Azure Kubernetes Services](https://azure.microsoft.com/en-us/services/kubernetes-service/) should be used to host the cloud micro-services (this is currently in preview, please see our documentation).
+[Azure Kubernetes Services](https://azure.microsoft.com/services/kubernetes-service/) should be used to host the cloud micro-services (this is currently in preview, please see our documentation).
 
 Alternatively, the full deployment script deploys the following additional managed Azure services into your Azure subscription and deploys the cloud micro-services into an App Service instance:
 
-- 1 [Data Lake Storage](https://azure.microsoft.com/en-us/services/storage/data-lake-storage/) V2, Standard LRS SKU (used to connect Power BI to the platform, see tutorial)
-- 1 [Time Series Insights](https://azure.microsoft.com/en-us/services/time-series-insights), Pay As You Go SKU, 1 Scale Unit
-- 1 [Blob Storage](https://azure.microsoft.com/en-us/services/storage/) V2, Standard LRS SKU (used for long-term storage for Time Series Insights)
-- 1 [App Service](https://azure.microsoft.com/en-us/services/app-service/), B1 SKU (for hosting the Industrial IoT Engineering Tool cloud application and for hosting the cloud micro-services [all-in-one](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/all-in-one.md))
-- 1 [SignalR](https://azure.microsoft.com/en-us/services/signalr-service/), Standard SKU (used to scale out asynchronous API notifications)
-- 3 [Virtual Machines](https://azure.microsoft.com/en-us/services/virtual-machines/), B2 SKU (1 Linux IoT Edge gateway, 1 Windows IoT Edge gateway, 1 OPC UA server. (used for a factory simulation to show the capabilities of the platform and to generate sample telemetry)
-- 1 [Device Provisioning Service](https://docs.microsoft.com/en-us/azure/iot-dps/), S1 SKU (used for deploying and provisioning the simulation gateways)
-- 1 [Application Insights](https://azure.microsoft.com/en-us/services/monitor/) and 1 Log Analytics Workspace for Operations Monitoring
+- 1 [Data Lake Storage](https://azure.microsoft.com/services/storage/data-lake-storage/) V2, Standard LRS SKU (used to connect Power BI to the platform, see tutorial)
+- 1 [Time Series Insights](https://azure.microsoft.com/services/time-series-insights), Pay As You Go SKU, 1 Scale Unit
+- 1 [Blob Storage](https://azure.microsoft.com/services/storage/) V2, Standard LRS SKU (used for long-term storage for Time Series Insights)
+- 2 [App Service](https://azure.microsoft.com/services/app-service/), B1 SKU (for hosting the Industrial IoT Engineering Tool cloud application and for hosting the cloud micro-services [all-in-one](https://github.com/Azure/Industrial-IoT/blob/master/docs/services/all-in-one.md))
+- 1 [SignalR](https://azure.microsoft.com/services/signalr-service/), Standard SKU (used to scale out asynchronous API notifications)
+- 4 [Virtual Machines](https://azure.microsoft.com/services/virtual-machines/), 2 B2 SKU (1 Linux IoT Edge gateway and 1 Windows IoT Edge gateway) and 2 B1 SKU (used for a factory simulation to show the capabilities of the platform and to generate sample telemetry)
+- 1 [Device Provisioning Service](https://docs.microsoft.com/azure/iot-dps/), S1 SKU (used for deploying and provisioning the simulation gateways)
+- 1 [Application Insights](https://azure.microsoft.com/services/monitor/) and 1 Log Analytics Workspace for Operations Monitoring
 
 ## Give feedback and report bugs
 


### PR DESCRIPTION
Now `deploy.ps1` script will select a VM SKU with at least 1 core and 2 GB memory instead of defaulting to `Standard_B1ms` for simulation VM. This is required because `Standard_B1ms` SKU is not available in all subscriptions.