### PR TITLE
IAI: Uploading IAI binaries to Azure Blob Container after build.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,8 +31,8 @@ stages:
   - template: tools/templates/iiot_deployment_win.yml
     parameters:
       sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
-  # - template: tools/templates/iiot_deployment_linux.yml
-  # - template: tools/templates/iiot_deployment_mac.yml
+  - template: tools/templates/iiot_deployment_linux.yml
+  - template: tools/templates/iiot_deployment_mac.yml
 # - stage: images
 #   displayName: 'Build Images'
 #   dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,39 +10,39 @@ trigger:
     - master
     - release/*
 stages:
-# - stage: build
-#   displayName: 'Build and Test Code'
-#   jobs:
-#   - template: tools/templates/ci.yml
-#   - template: tools/templates/sdl.yml
-# - stage: pack
-#   displayName: 'Package and Sign Nuget'
-#   dependsOn:
-#   - build
-#   jobs:
-#   - template: tools/templates/nuget.yml
-#     parameters:
-#       sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+- stage: build
+  displayName: 'Build and Test Code'
+  jobs:
+  - template: tools/templates/ci.yml
+  - template: tools/templates/sdl.yml
+- stage: pack
+  displayName: 'Package and Sign Nuget'
+  dependsOn:
+  - build
+  jobs:
+  - template: tools/templates/nuget.yml
+    parameters:
+      sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
 - stage: iiot_deployment
   displayName: 'Build Installer'
-  # dependsOn:
-  # - build
+  dependsOn:
+  - build
   jobs:
   - template: tools/templates/iiot_deployment_win.yml
     parameters:
       sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
   - template: tools/templates/iiot_deployment_linux.yml
   - template: tools/templates/iiot_deployment_mac.yml
-# - stage: images
-#   displayName: 'Build Images'
-#   dependsOn:
-#   - build
-#   jobs:
-#   - template: tools/templates/acrbuild.yml
-# - stage: coverage 
-#   displayName: 'Code Coverage'
-#   condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
-#   dependsOn:
-#   - build
-#   jobs:
-#   - template: tools/templates/cc.yml
+- stage: images
+  displayName: 'Build Images'
+  dependsOn:
+  - build
+  jobs:
+  - template: tools/templates/acrbuild.yml
+- stage: coverage 
+  displayName: 'Code Coverage'
+  condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+  dependsOn:
+  - build
+  jobs:
+  - template: tools/templates/cc.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,39 +10,39 @@ trigger:
     - master
     - release/*
 stages:
-- stage: build
-  displayName: 'Build and Test Code'
-  jobs:
-  - template: tools/templates/ci.yml
-  - template: tools/templates/sdl.yml
-- stage: pack
-  displayName: 'Package and Sign Nuget'
-  dependsOn:
-  - build
-  jobs:
-  - template: tools/templates/nuget.yml
-    parameters:
-      sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+# - stage: build
+#   displayName: 'Build and Test Code'
+#   jobs:
+#   - template: tools/templates/ci.yml
+#   - template: tools/templates/sdl.yml
+# - stage: pack
+#   displayName: 'Package and Sign Nuget'
+#   dependsOn:
+#   - build
+#   jobs:
+#   - template: tools/templates/nuget.yml
+#     parameters:
+#       sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
 - stage: iiot_deployment
   displayName: 'Build Installer'
-  dependsOn:
-  - build
+  # dependsOn:
+  # - build
   jobs:
   - template: tools/templates/iiot_deployment_win.yml
     parameters:
       sign: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
-  - template: tools/templates/iiot_deployment_linux.yml
-  - template: tools/templates/iiot_deployment_mac.yml
-- stage: images
-  displayName: 'Build Images'
-  dependsOn:
-  - build
-  jobs:
-  - template: tools/templates/acrbuild.yml
-- stage: coverage 
-  displayName: 'Code Coverage'
-  condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
-  dependsOn:
-  - build
-  jobs:
-  - template: tools/templates/cc.yml
+  # - template: tools/templates/iiot_deployment_linux.yml
+  # - template: tools/templates/iiot_deployment_mac.yml
+# - stage: images
+#   displayName: 'Build Images'
+#   dependsOn:
+#   - build
+#   jobs:
+#   - template: tools/templates/acrbuild.yml
+# - stage: coverage 
+#   displayName: 'Code Coverage'
+#   condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+#   dependsOn:
+#   - build
+#   jobs:
+#   - template: tools/templates/cc.yml

--- a/tools/templates/ci.yml
+++ b/tools/templates/ci.yml
@@ -30,7 +30,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: sdk
-      version: 3.1.101
+      version: 3.1.x
       includePreviewVersions: false
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: PowerShell@2
@@ -83,7 +83,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: sdk
-      version: 3.1.101
+      version: 3.1.x
       includePreviewVersions: false
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: PowerShell@2

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -44,3 +44,15 @@ jobs:
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
       artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+  - task: AzureCLI@2
+    displayName: 'Copy to Blob'
+    condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+    inputs:
+      azureSubscription: azureiiot-storage
+      scriptType: pscore
+      workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+      scriptLocation: inlineScript
+      inlineScript: |
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -53,6 +53,6 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -44,3 +44,15 @@ jobs:
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
       artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+  - task: AzureCLI@2
+    displayName: 'Copy to Blob'
+    condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+    inputs:
+      azureSubscription: azureiiot-storage
+      scriptType: pscore
+      workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+      scriptLocation: inlineScript
+      inlineScript: |
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -53,6 +53,6 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -15,7 +15,7 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: sdk
-      version: 3.1.101
+      version: 3.1.x
       includePreviewVersions: false
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: PowerShell@2

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -14,6 +14,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK for signing'
+    condition: ${{ eq(parameters.sign, 'True') }}
     inputs:
       packageType: sdk
       version: 2.0.x
@@ -51,54 +52,54 @@ jobs:
       TreatSignatureUpdateFailureAs: 'Warning'
       SignatureFreshness: 'UpToDate'
       TreatStaleSignatureAs: 'Error'
-  - ${{ if eq(parameters.sign, 'True') }}:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-      displayName: 'Executable Signing'
-      inputs:
-        ConnectedServiceName: 'Code Signing Certificate'
-        FolderPath: '$(Build.ArtifactStagingDirectory)'
-        Pattern: '**/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.exe'
-        UseMinimatch: true
-        signConfigType: inlineSignParams
-        inlineOperation: |
-          [{
-              "keyCode": "CP-230012",
-              "operationSetCode": "SigntoolSign",
-              "parameters": [
-              {
-                  "parameterName": "OpusName",
-                  "parameterValue": "Microsoft"
-              },
-              {
-                  "parameterName": "OpusInfo",
-                  "parameterValue": "http://www.microsoft.com"
-              },
-              {
-                  "parameterName": "FileDigest",
-                  "parameterValue": "/fd \"SHA256\""
-              },
-              {
-                  "parameterName": "PageHash",
-                  "parameterValue": "/NPH"
-              },
-              {
-                  "parameterName": "TimeStamp",
-                  "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-              }
-              ],
-              "toolName": "sign",
-              "toolVersion": "1.0"
-          },
-          {
-              "keyCode": "CP-230012",
-              "operationSetCode": "SigntoolVerify",
-              "parameters": [ ],
-              "toolName": "sign",
-              "toolVersion": "1.0"
-          }]
-        MaxConcurrency: 1
-        MaxRetryAttempts: 50
-        VerboseLogin: true
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    displayName: 'Executable Signing'
+    condition: ${{ eq(parameters.sign, 'True') }}
+    inputs:
+      ConnectedServiceName: 'Code Signing Certificate'
+      FolderPath: '$(Build.ArtifactStagingDirectory)'
+      Pattern: '**/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.exe'
+      UseMinimatch: true
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [{
+            "keyCode": "CP-230012",
+            "operationSetCode": "SigntoolSign",
+            "parameters": [
+            {
+                "parameterName": "OpusName",
+                "parameterValue": "Microsoft"
+            },
+            {
+                "parameterName": "OpusInfo",
+                "parameterValue": "http://www.microsoft.com"
+            },
+            {
+                "parameterName": "FileDigest",
+                "parameterValue": "/fd \"SHA256\""
+            },
+            {
+                "parameterName": "PageHash",
+                "parameterValue": "/NPH"
+            },
+            {
+                "parameterName": "TimeStamp",
+                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+            }
+            ],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+        },
+        {
+            "keyCode": "CP-230012",
+            "operationSetCode": "SigntoolVerify",
+            "parameters": [ ],
+            "toolName": "sign",
+            "toolVersion": "1.0"
+        }]
+      MaxConcurrency: 1
+      MaxRetryAttempts: 50
+      VerboseLogin: true
   - task: CmdLine@2
     displayName: 'Generate MD5 Checksum'
     inputs:

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -12,14 +12,20 @@ jobs:
   pool:
     name: ${{ parameters.poolName }}
   steps:
-  # .Net Core 3.0 installation causes problems for executable signing task.
-  # - task: UseDotNet@2
-  #   displayName: 'Install .NET Core SDK'
-  #   inputs:
-  #     packageType: sdk
-  #     version: 3.1.x
-  #     includePreviewVersions: false
-  #     installationPath: $(Agent.ToolsDirectory)/dotnet
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK for signing'
+    inputs:
+      packageType: sdk
+      version: 2.0.x
+      includePreviewVersions: false
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+  - task: UseDotNet@2
+    displayName: 'Install .NET Core SDK for building'
+    inputs:
+      packageType: sdk
+      version: 3.1.x
+      includePreviewVersions: false
+      installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: PowerShell@2
     displayName: Versioning
     name: setVersionInfo
@@ -105,3 +111,15 @@ jobs:
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
       artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+  - task: AzureCLI@2
+    displayName: 'Copy to Blob'
+    condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
+    inputs:
+      azureSubscription: azureiiot-storage
+      scriptType: pscore
+      workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+      scriptLocation: inlineScript
+      inlineScript: |
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -110,7 +110,7 @@ jobs:
     displayName: 'Publish Artifacts'
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
-      artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+      artifact: iiot_deployment_release_$(setVersionInfo.Version_Prefix)_${{ parameters.runtime }}
   - task: AzureCLI@2
     displayName: 'Copy to Blob'
     condition: ${{ startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}
@@ -120,6 +120,6 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.exe
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranchName'] }}/$(setVersionInfo.Version_Full)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -120,6 +120,6 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ variables['Build.SourceBranch'] }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5


### PR DESCRIPTION
Here I am uploading `Microsoft.Azure.IIoT.Deployment` (IAI) binaries to a public Blob Container after build.

The following files will be uploaded from each host OS:
* `Microsoft.Azure.IIoT.Deployment.exe` on Windows or `Microsoft.Azure.IIoT.Deployment` on Linux an macOS
* `Microsoft.Azure.IIoT.Deployment.pdb`
* `Microsoft.Azure.IIoT.Deployment.md5`

I will be using `binaries` Blob Container in `azureiiot` Storage Account for storing those files.

The Blobs will have the following general naming scheme: `<branch_name>/<version>/<os_version>/<filename>`

A sample of this will be `kakostan/bin_upload/2.7.125/win-x64/Microsoft.Azure.IIoT.Deployment.exe`, where `kakostan/bin_upload` is name of my branch, `2.7.125` is the version of binaries and `win-x64` specifies OS and its bitness.

The following values will be used as `os_version`: `linux-x64`, `osx-x64`, `win-x64`