### PR TITLE
Gateway connection status fix

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/GatewayRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/GatewayRegistrationEx.cs
@@ -71,13 +71,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
 
             var tags = twin.Tags ?? new Dictionary<string, VariantValue>();
-            var connected = twin.IsConnected();
 
             var registration = new GatewayRegistration {
                 // Device
 
                 DeviceId = twin.Id,
                 Etag = twin.Etag,
+
+                // Connected
+                Connected = twin.IsConnected() ?? false,
 
                 // Tags
 

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Pages/Gateways.razor
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Pages/Gateways.razor
@@ -46,7 +46,7 @@
                         @siteId
                     </div>
                 </td>
-                @{string connectStatus = gateway.Connected == null ? CommonHelper.None : gateway.Connected == true ? "Connected" : "Disconnected";}
+                @{string connectStatus = gateway.Connected == true ? "Connected" : "Disconnected";}
                 <td class="hover-text width-large">
                     <div>
                         @connectStatus

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Shared/MainLayout.razor
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Shared/MainLayout.razor
@@ -28,8 +28,7 @@
                 @Body
             </Authorized>
             <NotAuthorized>
-                <h1>Authentication Failure or expired</h1>
-                <p>Please sign in.</p>
+                <h1>Please sign in.</h1>
             </NotAuthorized>
         </AuthorizeView>
     </div>


### PR DESCRIPTION
- Gateway page didn't show the connection status, because the value has never been set.

- The error message from the home page is removed.