### PR TITLE
Adding site to the discoverer page

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/src/Registry/Extensions/ModelExtensions.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Registry/Extensions/ModelExtensions.cs
@@ -410,6 +410,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Registry.Models {
             return new DiscovererApiModel {
                 Id = model.Id,
                 SiteId = model.SiteId,
+                SiteOrGatewayId = model.SiteOrGatewayId,
                 LogLevel = (TraceLogLevel?)model.LogLevel,
                 RequestedMode = (DiscoveryMode?)model.RequestedMode,
                 RequestedConfig = model.RequestedConfig.ToApiModel(),

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Registry/src/Models/DiscovererApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Registry/src/Models/DiscovererApiModel.cs
@@ -83,5 +83,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Registry.Models {
         [DataMember(Name = "version", Order = 9,
             EmitDefaultValue = false)]
         public string Version { get; set; }
+
+        /// <summary>
+        /// Site/gateway of the discoverer
+        /// </summary>
+        [DataMember(Name = "siteOrGatewayId", Order = 10,
+            EmitDefaultValue = false)]
+        public string SiteOrGatewayId { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Extensions/DiscovererRegistrationEx.cs
@@ -347,6 +347,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
                     registration.Discovery : (DiscoveryMode?)null,
                 Id = DiscovererModelEx.CreateDiscovererId(registration.DeviceId, registration.ModuleId),
                 SiteId = registration.SiteId,
+                SiteOrGatewayId = registration.SiteOrGatewayId,
                 Version = registration.Version,
                 LogLevel = registration.LogLevel,
                 DiscoveryConfig = registration.ToConfigModel(),

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Models/DiscovererModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Models/DiscovererModel.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
         public string SiteId { get; set; }
 
         /// <summary>
+        /// Gateway of the discoverer
+        /// TODO: Stop using term Site for the gateway id
+        /// </summary>
+        public string SiteOrGatewayId { get; set; }
+
+        /// <summary>
         /// Whether discoverer is in discovery mode
         /// </summary>
         public DiscoveryMode? Discovery { get; set; }

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Pages/Discoverers.razor
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Pages/Discoverers.razor
@@ -51,6 +51,7 @@
     <thead>
         <tr>
             <th class="width-large">Discovery Module Id</th>
+            <th class="width-medium">Site</th>
             <th class="width-medium">Connection Status</th>
             <th class="width-medium">Scanning</th>
             <th class="width-large">Effective Configuration</th>
@@ -76,6 +77,9 @@
                 {
                     <td class="hover-text">@discoverer.DiscovererModel.Id</td>
                 }
+                <td class="hover-text width-medium">
+                    <div>@discoverer.DiscovererModel.SiteOrGatewayId</div>
+                </td>
                 @{connectStatus = discoverer.DiscovererModel.Connected == true ? "Connected" : "Disconnected";}
                 <td class="hover-text width-medium">
                     <div>@connectStatus</div>


### PR DESCRIPTION
Site is added to the discovery page for the consistency (Site is shown on the Asset page as well). In the future we should think about changing this term because it's being confused with SiteId which is set by users.