### PR TITLE
Added IWorkerDatabaseConfig interface to fix WorkerDatabase creation.

### DIFF
--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Runtime/Config.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Runtime/Config.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Runtime {
     public class Config : DiagnosticsConfig, IWebHostConfig, IIoTHubConfig,
         ICorsConfig, IOpenApiConfig, IRoleConfig,
         ICosmosDbConfig, IJobDatabaseConfig, IRegistryConfig, ITwinConfig,
-        IForwardedHeadersConfig, IContainerRegistryConfig {
+        IForwardedHeadersConfig, IContainerRegistryConfig, IWorkerDatabaseConfig {
 
         /// <inheritdoc/>
         public bool UseRoles => GetBoolOrDefault(PcsVariable.PCS_AUTH_ROLES);


### PR DESCRIPTION
`WorkerDatabase` requires a `IWorkerDatabaseConfig` config to be initialized. This change is making sure that `Config` of Opc-Publisher-Service implements this interface.

This was causing an error when  calling `/v2/workers` endpoint:

```
{
  "ClassName": "Autofac.Core.DependencyResolutionException",
  "Message": "An exception was thrown while activating Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.WorkerDatabase.",
  "Data": {
    "ActivatorChain": "Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.WorkerDatabase"
  },
  "InnerException": {
    "ClassName": "Autofac.Core.DependencyResolutionException",
    "Message": "None of the constructors found with 'Autofac.Core.Activators.Reflection.DefaultConstructorFinder' on type 'Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.WorkerDatabase' can be invoked with the available services and parameters:\nCannot resolve parameter 'Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.IWorkerDatabaseConfig databaseRegistryConfig' of constructor 'Void .ctor(Microsoft.Azure.IIoT.Storage.IDatabaseServer, Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.IWorkerDatabaseConfig)'.",
    "Data": {},
    "InnerException": null,
    "HelpURL": null,
    "StackTraceString": "   at Autofac.Core.Activators.Reflection.ReflectionActivator.GetValidConstructorBindings(ConstructorInfo[] availableConstructors, IComponentContext context, IEnumerable`1 parameters)\n   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)\n   at Autofac.Core.Resolving.InstanceLookup.CreateInstance(IEnumerable`1 parameters)",
    "RemoteStackTraceString": null,
    "RemoteStackIndex": 0,
    "ExceptionMethod": null,
    "HResult": -2146233088,
    "Source": "Autofac",
    "WatsonBuckets": null
  },
  "HelpURL": null,
  "StackTraceString": "   at Autofac.Core.Resolving.InstanceLookup.CreateInstance(IEnumerable`1 parameters)\n   at Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance(Guid id, Func`1 creator)\n   at Autofac.Core.Lifetime.LifetimeScope.CreateSharedInstance(Guid primaryId, Nullable`1 qualifyingId, Func`1 creator)\n   at Autofac.Core.Resolving.InstanceLookup.Execute()\n   at Autofac.Core.Resolving.ResolveOperation.GetOrCreateInstance(ISharingLifetimeScope currentOperationScope, ResolveRequest request)\n   at Autofac.Core.Resolving.ResolveOperation.Execute(ResolveRequest request)\n   at Autofac.ResolutionExtensions.TryResolveService(IComponentContext context, Service service, IEnumerable`1 parameters, Object& instance)\n   at Autofac.ResolutionExtensions.ResolveOptionalService(IComponentContext context, Service service, IEnumerable`1 parameters)\n   at Microsoft.Extensions.DependencyInjection.ActivatorUtilities.GetService(IServiceProvider sp, Type type, Type requiredBy, Boolean isDefaultParameterRequired)\n   at lambda_method(Closure , IServiceProvider , Object[] )\n   at Microsoft.AspNetCore.Mvc.Controllers.ControllerFactoryProvider.<>c__DisplayClass5_0.<CreateControllerFactory>g__CreateController|0(ControllerContext controllerContext)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next(State& next, Scope& scope, Object& state, Boolean& isCompleted)\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.InvokeInnerFilterAsync()\n--- End of stack trace from previous location where exception was thrown ---\n   at Microsoft.AspNetCore.Mvc.Infrastructure.ResourceInvoker.<InvokeNextExceptionFilterAsync>g__Awaited|25_0(ResourceInvoker invoker, Task lastTask, State next, Scope scope, Object state, Boolean isCompleted)",
  "RemoteStackTraceString": null,
  "RemoteStackIndex": 0,
  "ExceptionMethod": null,
  "HResult": -2146233088,
  "Source": "Autofac",
  "WatsonBuckets": null,
  "Exception": "DependencyResolutionException",
  "CausedBy": {
    "ClassName": "Autofac.Core.DependencyResolutionException",
    "Message": "None of the constructors found with 'Autofac.Core.Activators.Reflection.DefaultConstructorFinder' on type 'Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.WorkerDatabase' can be invoked with the available services and parameters:\nCannot resolve parameter 'Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.IWorkerDatabaseConfig databaseRegistryConfig' of constructor 'Void .ctor(Microsoft.Azure.IIoT.Storage.IDatabaseServer, Microsoft.Azure.IIoT.Agent.Framework.Storage.Database.IWorkerDatabaseConfig)'.",
    "Data": {},
    "InnerException": null,
    "HelpURL": null,
    "StackTraceString": "   at Autofac.Core.Activators.Reflection.ReflectionActivator.GetValidConstructorBindings(ConstructorInfo[] availableConstructors, IComponentContext context, IEnumerable`1 parameters)\n   at Autofac.Core.Activators.Reflection.ReflectionActivator.ActivateInstance(IComponentContext context, IEnumerable`1 parameters)\n   at Autofac.Core.Resolving.InstanceLookup.CreateInstance(IEnumerable`1 parameters)",
    "RemoteStackTraceString": null,
    "RemoteStackIndex": 0,
    "ExceptionMethod": null,
    "HResult": -2146233088,
    "Source": "Autofac",
    "WatsonBuckets": null,
    "Exception": "DependencyResolutionException"
  }
}
```