### PR TITLE
Remove all entries from jobs with the same node id and endpoint model…

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -369,8 +369,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
         /// <param name="connection"></param>
         private bool RemoveItemFromJob(WriterGroupJobModel publishJob,
             string nodeId, ConnectionModel connection) {
+            var found = false;
             foreach (var writer in publishJob.WriterGroup.DataSetWriters.ToList()) {
-                if (!writer.DataSet.DataSetSource.Connection.IsSameAs(connection)) {
+                if (!writer.DataSet.DataSetSource.Connection.Endpoint.IsSameAs(connection.Endpoint)) {
                     continue;
                 }
                 foreach (var item in writer.DataSet.DataSetSource.PublishedVariables.PublishedData.ToList()) {
@@ -380,11 +381,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                             // Trim writer also
                             publishJob.WriterGroup.DataSetWriters.Remove(writer);
                         }
-                        return true;
+                        found = true;
+                        break;
                     }
                 }
             }
-            return false;
+            return found;
         }
 
         /// <summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Clients/PublisherJobClientTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Clients/PublisherJobClientTests.cs
@@ -173,8 +173,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
         public async Task StartTwicePublishTest2Async() {
 
             using (var mock = Setup((v, q) => {
-                    throw new AssertActualExpectedException(null, q, "Query");
-                })) {
+                throw new AssertActualExpectedException(null, q, "Query");
+            })) {
 
                 IPublishServices<string> service = mock.Create<PublisherJobService>();
 
@@ -206,6 +206,108 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 Assert.Null(list.ContinuationToken);
                 Assert.Equal(TimeSpan.FromSeconds(2), list.Items.First().PublishingInterval);
                 Assert.Equal(TimeSpan.FromSeconds(1), list.Items.First().SamplingInterval);
+            }
+        }
+
+        [Fact]
+        public async Task StartPublishSameNodeWithDifferentCredentialsOnlyHasLastInListAsync() {
+
+            using (var mock = Setup((v, q) => {
+                throw new AssertActualExpectedException(null, q, "Query");
+            })) {
+
+                IPublishServices<string> service = mock.Create<PublisherJobService>();
+
+                // Run
+                var result = await service.NodePublishStartAsync("endpoint1", new PublishStartRequestModel {
+                    Item = new PublishedItemModel {
+                        NodeId = "i=2258"
+                    },
+                    Header = new RequestHeaderModel {
+                        Elevation = new CredentialModel {
+                            Type = CredentialType.UserName,
+                            Value = "abcdefg"
+                        }
+                    }
+                });
+                result = await service.NodePublishStartAsync("endpoint1", new PublishStartRequestModel {
+                    Item = new PublishedItemModel {
+                        NodeId = "i=2258"
+                    },
+                    Header = new RequestHeaderModel {
+                        Elevation = new CredentialModel {
+                            Type = CredentialType.UserName,
+                            Value = "123456"
+                        }
+                    }
+                });
+                result = await service.NodePublishStartAsync("endpoint1", new PublishStartRequestModel {
+                    Item = new PublishedItemModel {
+                        NodeId = "i=2258"
+                    },
+                    Header = new RequestHeaderModel {
+                        Elevation = new CredentialModel {
+                            Type = CredentialType.UserName,
+                            Value = "asdfasdf"
+                        }
+                    }
+                });
+
+
+                var list = await service.NodePublishListAsync("endpoint1", new PublishedItemListRequestModel {
+                    ContinuationToken = null
+                });
+
+                // Assert
+                Assert.NotNull(list);
+                Assert.NotNull(result);
+                Assert.Single(list.Items);
+                Assert.Null(list.ContinuationToken);
+                Assert.Equal("i=2258", list.Items.Single().NodeId);
+            }
+        }
+
+        [Fact]
+        public async Task StartandStopPublishNodeWithDifferentCredentialsHasNoItemsInListAsync() {
+
+            using (var mock = Setup((v, q) => {
+                throw new AssertActualExpectedException(null, q, "Query");
+            })) {
+
+                IPublishServices<string> service = mock.Create<PublisherJobService>();
+
+                // Run
+                var result1 = await service.NodePublishStartAsync("endpoint1", new PublishStartRequestModel {
+                    Item = new PublishedItemModel {
+                        NodeId = "i=2258"
+                    },
+                    Header = new RequestHeaderModel {
+                        Elevation = new CredentialModel {
+                            Type = CredentialType.UserName,
+                            Value = "abcdefg"
+                        }
+                    }
+                });
+                var result2 = await service.NodePublishStopAsync("endpoint1", new PublishStopRequestModel {
+                    NodeId = "i=2258",
+                    Header = new RequestHeaderModel {
+                        Elevation = new CredentialModel {
+                            Type = CredentialType.UserName,
+                            Value = "123456"
+                        }
+                    }
+                });
+
+                var list = await service.NodePublishListAsync("endpoint1", new PublishedItemListRequestModel {
+                    ContinuationToken = null
+                });
+
+                // Assert
+                Assert.NotNull(list);
+                Assert.NotNull(result1);
+                Assert.NotNull(result2);
+                Assert.Empty(list.Items);
+                Assert.Null(list.ContinuationToken);
             }
         }
 


### PR DESCRIPTION
….  Do not use credentials comparison.  Add unit tests to test the issue.