### PR TITLE
Changed event processors to use .NET generic hosts.

### DIFF
--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/HostStarterService.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync {
+
+    using Microsoft.Azure.IIoT.Diagnostics;
+    using Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class HostStarterService : IHostedService {
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public IProcessIdentity ServiceInfo { get; }
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            IProcessIdentity serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync {
+namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/HostStarterService.cs
@@ -17,13 +17,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
     /// <summary>
     /// Generic host service which manages IHostProcess objects.
     /// </summary>
-    class StarterService : IHostedService {
-
-        /// <summary>
-        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
-        /// </summary>
-        private readonly List<IHostProcess> _hostProcesses;
-        private readonly ILogger _logger;
+    class HostStarterService : IHostedService {
 
         /// <summary>
         /// Details of application hosting environment.
@@ -45,7 +39,22 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
         /// </summary>
         public ServiceInfo ServiceInfo { get; }
 
-        public StarterService(
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
             IHostEnvironment hostEnvironment,
             IHostApplicationLifetime hostApplicationLifetime,
             Config config,
@@ -67,6 +76,10 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
                 _logger.Debug("Starting all hosts...");
                 await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
                 _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
             }
             catch (Exception ex) {
                 _logger.Error(ex, "Failed to start some hosts.");

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/HostStarterService.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Azure.IIoT.Services.Processor.Events {
 
+    using Microsoft.Azure.IIoT.Diagnostics;
     using Microsoft.Azure.IIoT.Services.Processor.Events.Runtime;
     using Microsoft.Extensions.Hosting;
     using System;
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
         /// <summary>
         /// Service information, will be provided by DI.
         /// </summary>
-        public ServiceInfo ServiceInfo { get; }
+        public IProcessIdentity ServiceInfo { get; }
 
         /// <summary>
         /// List of IHostProcess objects that will be managed by this instance, provided by DI.
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
             IHostEnvironment hostEnvironment,
             IHostApplicationLifetime hostApplicationLifetime,
             Config config,
-            ServiceInfo serviceInfo,
+            IProcessIdentity serviceInfo,
             IEnumerable<IHostProcess> hostProcesses,
             ILogger logger
         ) {

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
@@ -5,12 +5,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
@@ -1,11 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -59,14 +59,26 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
                     .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
                 })
                 .UseServiceProviderFactory(new AutofacServiceProviderFactory())
-                .ConfigureContainer<ContainerBuilder>((context, builder) => {
+                .ConfigureContainer<ContainerBuilder>((hostBuilderContext, builder) => {
                     // registering services in the Autofac ContainerBuilder
-                    ConfigureContainer(builder, context.Configuration);
+                    ConfigureContainer(builder, hostBuilderContext.Configuration);
                 })
-                .ConfigureServices((hostContext, services) => {
-                    services.AddHostedService<StarterService>();
+                .ConfigureServices((hostBuilderContext, services) => {
+                    ConfigureServices(services, hostBuilderContext.Configuration);
                 })
                 .UseSerilog();
+        }
+
+        /// <summary>
+        /// This is where you register dependencies, add services to the container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureServices(
+            IServiceCollection services,
+            IConfiguration configuration
+        ) {
+            services.AddHostedService<StarterService>();
         }
 
         /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -4,11 +4,11 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.Services.Processor.Events {
+
     using Microsoft.Azure.IIoT.Services.Processor.Events.Runtime;
     using Microsoft.Azure.IIoT.OpcUa.Registry;
     using Microsoft.Azure.IIoT.OpcUa.Registry.Handlers;
     using Microsoft.Azure.IIoT.OpcUa.Registry.Events.v2;
-    using Microsoft.Azure.IIoT.Exceptions;
     using Microsoft.Azure.IIoT.Messaging.Default;
     using Microsoft.Azure.IIoT.Messaging.ServiceBus.Clients;
     using Microsoft.Azure.IIoT.Messaging.ServiceBus.Services;
@@ -20,89 +20,76 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
     using Microsoft.Azure.IIoT.Http.Ssl;
     using Microsoft.Azure.IIoT.Auth.Clients;
     using Microsoft.Azure.IIoT.Serializers;
-    using Microsoft.Azure.IIoT.Utils;
+
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Autofac;
+    using Autofac.Extensions.DependencyInjection;
     using Serilog;
     using System;
-    using System.IO;
-    using System.Runtime.Loader;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// IoT Hub device events event processor host.  Processes all
     /// events from devices including onboarding and discovery events.
     /// </summary>
-    public class Program {
+    public static class Program {
 
-        /// <summary>
+        /// <summary>   
         /// Main entry point for iot hub device event processor host
         /// </summary>
         /// <param name="args"></param>
         public static void Main(string[] args) {
-
-            // Load hosting configuration
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
-                // Above configuration providers will provide connection
-                // details for KeyVault configuration provider.
-                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
-                .Build();
-
-            // Set up dependency injection for the event processor host
-            RunAsync(config).Wait();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Run
+        /// Create host builder
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="args"></param>
         /// <returns></returns>
-        public static async Task RunAsync(IConfiguration config) {
-            var exit = false;
-            while (!exit) {
-                // Wait until the event processor host unloads or is cancelled
-                var tcs = new TaskCompletionSource<bool>();
-                AssemblyLoadContext.Default.Unloading += _ => tcs.TrySetResult(true);
-                using (var container = ConfigureContainer(config).Build()) {
-                    var logger = container.Resolve<ILogger>();
-                    try {
-                        logger.Information("Events processor host started.");
-                        exit = await tcs.Task;
-                    }
-                    catch (InvalidConfigurationException e) {
-                        logger.Error(e,
-                            "Error starting events processor host - exit!");
-                        return;
-                    }
-                    catch (Exception ex) {
-                        logger.Error(ex,
-                            "Error running events processor host - restarting!");
-                    }
-                }
-            }
+        public static IHostBuilder CreateHostBuilder(string[] args) {
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureHostConfiguration(configHost => {
+                    configHost.AddFromDotEnvFile()
+                    .AddEnvironmentVariables()
+                    .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                    // Above configuration providers will provide connection
+                    // details for KeyVault configuration provider.
+                    .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
+                })
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                .ConfigureContainer<ContainerBuilder>((context, builder) => {
+                    // registering services in the Autofac ContainerBuilder
+                    ConfigureContainer(builder, context.Configuration);
+                })
+                .ConfigureServices((hostContext, services) => {
+                    services.AddHostedService<StarterService>();
+                })
+                .UseSerilog();
         }
 
         /// <summary>
         /// Autofac configuration.
         /// </summary>
-        public static ContainerBuilder ConfigureContainer(
-            IConfiguration configuration) {
-
+        /// <param name="builder"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureContainer(
+            ContainerBuilder builder,
+            IConfiguration configuration
+        ) {
             var serviceInfo = new ServiceInfo();
             var config = new Config(configuration);
-            var builder = new ContainerBuilder();
 
+            // Making sure that we reuse the same ServiceInfo instance.
             builder.RegisterInstance(serviceInfo)
-                .AsImplementedInterfaces();
+                .AsSelf()
+                .AsImplementedInterfaces()
+                .SingleInstance();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
+                .AsSelf()
                 .AsImplementedInterfaces();
             builder.RegisterInstance(config.Configuration)
                 .AsImplementedInterfaces();
@@ -154,12 +141,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
                 .AsImplementedInterfaces();
             builder.RegisterType<ServiceBusEventBus>()
                 .AsImplementedInterfaces().SingleInstance();
-
-            // ... and auto start
-            builder.RegisterType<HostAutoStart>()
-                .AutoActivate()
-                .AsImplementedInterfaces().SingleInstance();
-            return builder;
         }
     }
 }

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
             IServiceCollection services,
             IConfiguration configuration
         ) {
-            services.AddHostedService<StarterService>();
+            services.AddHostedService<HostStarterService>();
         }
 
         /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -95,9 +95,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
 
             // Making sure that we reuse the same ServiceInfo instance.
             builder.RegisterInstance(serviceInfo)
-                .AsSelf()
-                .AsImplementedInterfaces()
-                .SingleInstance();
+                .AsImplementedInterfaces();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Program.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="configuration"></param>
-        public static void ConfigureContainer(
+        public static ContainerBuilder ConfigureContainer(
             ContainerBuilder builder,
             IConfiguration configuration
         ) {
@@ -151,6 +151,8 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Events {
                 .AsImplementedInterfaces();
             builder.RegisterType<ServiceBusEventBus>()
                 .AsImplementedInterfaces().SingleInstance();
+
+            return builder;
         }
     }
 }

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.Processor.Events {
+namespace Microsoft.Azure.IIoT.Services.Processor.Events.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/StarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/StarterService.cs
@@ -1,0 +1,90 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.Processor.Events {
+
+    using Microsoft.Azure.IIoT.Services.Processor.Events.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class StarterService : IHostedService {
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public ServiceInfo ServiceInfo { get; }
+
+        public StarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            ServiceInfo serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/HostStarterService.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
 
+    using Microsoft.Azure.IIoT.Diagnostics;
     using Microsoft.Azure.IIoT.Services.Processor.Onboarding.Runtime;
     using Microsoft.Extensions.Hosting;
     using System;
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
         /// <summary>
         /// Service information, will be provided by DI.
         /// </summary>
-        public ServiceInfo ServiceInfo { get; }
+        public IProcessIdentity ServiceInfo { get; }
 
         /// <summary>
         /// List of IHostProcess objects that will be managed by this instance, provided by DI.
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
             IHostEnvironment hostEnvironment,
             IHostApplicationLifetime hostApplicationLifetime,
             Config config,
-            ServiceInfo serviceInfo,
+            IProcessIdentity serviceInfo,
             IEnumerable<IHostProcess> hostProcesses,
             ILogger logger
         ) {

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/HostStarterService.cs
@@ -1,0 +1,103 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
+
+    using Microsoft.Azure.IIoT.Services.Processor.Onboarding.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class HostStarterService : IHostedService {
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public ServiceInfo ServiceInfo { get; }
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            ServiceInfo serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Core\src\Microsoft.Azure.IIoT.Core.csproj" />
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Program.cs
@@ -4,33 +4,32 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
-    using Microsoft.Azure.IIoT.Services.Processor.Onboarding.Runtime;
-    using Microsoft.Azure.IIoT.OpcUa.Registry.Services;
-    using Microsoft.Azure.IIoT.OpcUa.Registry.Clients;
-    using Microsoft.Azure.IIoT.OpcUa.Registry.Handlers;
-    using Microsoft.Azure.IIoT.OpcUa.Registry;
-    using Microsoft.Azure.IIoT.OpcUa.Api.Twin.Clients;
+
+    using Autofac;
+    using Autofac.Extensions.DependencyInjection;
+    using Microsoft.Azure.IIoT.Http.Default;
+    using Microsoft.Azure.IIoT.Http.Ssl;
+    using Microsoft.Azure.IIoT.Hub.Client;
+    using Microsoft.Azure.IIoT.Hub.Processor.EventHub;
+    using Microsoft.Azure.IIoT.Hub.Processor.Services;
+    using Microsoft.Azure.IIoT.Hub.Services;
     using Microsoft.Azure.IIoT.Messaging.Default;
     using Microsoft.Azure.IIoT.Messaging.ServiceBus.Clients;
     using Microsoft.Azure.IIoT.Messaging.ServiceBus.Services;
     using Microsoft.Azure.IIoT.Module.Default;
-    using Microsoft.Azure.IIoT.Hub.Processor.EventHub;
-    using Microsoft.Azure.IIoT.Hub.Processor.Services;
-    using Microsoft.Azure.IIoT.Hub.Services;
-    using Microsoft.Azure.IIoT.Hub.Client;
-    using Microsoft.Azure.IIoT.Http.Default;
-    using Microsoft.Azure.IIoT.Http.Ssl;
+    using Microsoft.Azure.IIoT.OpcUa.Api.Twin.Clients;
+    using Microsoft.Azure.IIoT.OpcUa.Registry;
+    using Microsoft.Azure.IIoT.OpcUa.Registry.Clients;
+    using Microsoft.Azure.IIoT.OpcUa.Registry.Handlers;
+    using Microsoft.Azure.IIoT.OpcUa.Registry.Services;
     using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Services.Processor.Onboarding.Runtime;
     using Microsoft.Azure.IIoT.Tasks.Default;
-    using Microsoft.Azure.IIoT.Exceptions;
-    using Microsoft.Azure.IIoT.Utils;
     using Microsoft.Extensions.Configuration;
-    using Autofac;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Serilog;
     using System;
-    using System.IO;
-    using System.Runtime.Loader;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// IoT Hub device onboarding processor host.  Processes all
@@ -43,69 +42,66 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
         /// </summary>
         /// <param name="args"></param>
         public static void Main(string[] args) {
-
-            // Load hosting configuration
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true)
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
-                .AddCommandLine(args)
-                // Above configuration providers will provide connection
-                // details for KeyVault configuration provider.
-                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
-                .Build();
-
-            // Set up dependency injection for the event processor host
-            RunAsync(config).Wait();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Run
+        /// Create host builder
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="args"></param>
         /// <returns></returns>
-        public static async Task RunAsync(IConfiguration config) {
-            var exit = false;
-            while (!exit) {
-                // Wait until the event processor host unloads or is cancelled
-                var tcs = new TaskCompletionSource<bool>();
-                AssemblyLoadContext.Default.Unloading += _ => tcs.TrySetResult(true);
-                using (var container = ConfigureContainer(config).Build()) {
-                    var logger = container.Resolve<ILogger>();
-                    try {
-                        logger.Information("Events processor host started.");
-                        exit = await tcs.Task;
-                    }
-                    catch (InvalidConfigurationException e) {
-                        logger.Error(e,
-                            "Error starting events processor host - exit!");
-                        return;
-                    }
-                    catch (Exception ex) {
-                        logger.Error(ex,
-                            "Error running events processor host - restarting!");
-                    }
-                }
-            }
+        public static IHostBuilder CreateHostBuilder(string[] args) {
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureHostConfiguration(configHost => {
+                    configHost.AddFromDotEnvFile()
+                    .AddEnvironmentVariables()
+                    .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                    // Above configuration providers will provide connection
+                    // details for KeyVault configuration provider.
+                    .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
+                })
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                .ConfigureContainer<ContainerBuilder>((hostBuilderContext, builder) => {
+                    // registering services in the Autofac ContainerBuilder
+                    ConfigureContainer(builder, hostBuilderContext.Configuration);
+                })
+                .ConfigureServices((hostBuilderContext, services) => {
+                    ConfigureServices(services, hostBuilderContext.Configuration);
+                })
+                .UseSerilog();
+        }
+
+        /// <summary>
+        /// This is where you register dependencies, add services to the container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureServices(
+            IServiceCollection services,
+            IConfiguration configuration
+        ) {
+            services.AddHostedService<HostStarterService>();
         }
 
         /// <summary>
         /// Autofac configuration.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configuration"></param>
         public static ContainerBuilder ConfigureContainer(
-            IConfiguration configuration) {
-
+            ContainerBuilder builder,
+            IConfiguration configuration
+        ) {
             var serviceInfo = new ServiceInfo();
             var config = new Config(configuration);
-            var builder = new ContainerBuilder();
 
             builder.RegisterInstance(serviceInfo)
+                .AsSelf()
                 .AsImplementedInterfaces();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
+                .AsSelf()
                 .AsImplementedInterfaces();
             builder.RegisterInstance(config.Configuration)
                 .AsImplementedInterfaces();
@@ -184,10 +180,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
             builder.RegisterType<ServiceBusEventBus>()
                 .AsImplementedInterfaces().SingleInstance();
 
-            // ... and auto start
-            builder.RegisterType<HostAutoStart>()
-                .AutoActivate()
-                .AsImplementedInterfaces().SingleInstance();
             return builder;
         }
     }

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Program.cs
@@ -96,7 +96,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
             var config = new Config(configuration);
 
             builder.RegisterInstance(serviceInfo)
-                .AsSelf()
                 .AsImplementedInterfaces();
 
             // Register configuration interfaces

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding {
+namespace Microsoft.Azure.IIoT.Services.Processor.Onboarding.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/HostStarterService.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
+
+    using Microsoft.Azure.IIoT.Diagnostics;
+    using Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class HostStarterService : IHostedService {
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public IProcessIdentity ServiceInfo { get; }
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            IProcessIdentity serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -11,6 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Program.cs
@@ -18,15 +18,14 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
     using Microsoft.Azure.IIoT.Http.Ssl;
     using Microsoft.Azure.IIoT.Auth.Clients.Default;
     using Microsoft.Azure.IIoT.Auth.Clients;
-    using Microsoft.Azure.IIoT.Utils;
     using Microsoft.Azure.IIoT.Serializers;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Autofac;
+    using Autofac.Extensions.DependencyInjection;
     using Serilog;
     using System;
-    using System.IO;
-    using System.Runtime.Loader;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// IoT Hub device telemetry event processor host.  Processes all
@@ -40,69 +39,65 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
         /// </summary>
         /// <param name="args"></param>
         public static void Main(string[] args) {
-
-            // Load hosting configuration
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
-                // Above configuration providers will provide connection
-                // details for KeyVault configuration provider.
-                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
-                .Build();
-
-            // Set up dependency injection for the event processor host
-            RunAsync(config).Wait();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Run
+        /// Create host builder
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="args"></param>
         /// <returns></returns>
-        public static async Task RunAsync(IConfiguration config) {
-            var exit = false;
-            while (!exit) {
-                // Wait until the event processor host unloads or is cancelled
-                var tcs = new TaskCompletionSource<bool>();
-                AssemblyLoadContext.Default.Unloading += _ => tcs.TrySetResult(true);
-                using (var container = ConfigureContainer(config).Build()) {
-                    var logger = container.Resolve<ILogger>();
-                    try {
-                        logger.Information("Telemetry CDM event processor host started.");
-                        exit = await tcs.Task;
-                    }
-                    catch (InvalidConfigurationException e) {
-                        logger.Error(e,
-                            "Error starting telemetry CDM event processor host - exit!");
-                        return;
-                    }
-                    catch (Exception ex) {
-                        logger.Error(ex,
-                            "Error running telemetry CDM event processor host - restarting!");
-                    }
-                }
-            }
+        public static IHostBuilder CreateHostBuilder(string[] args) {
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureHostConfiguration(configHost => {
+                    configHost.AddFromDotEnvFile()
+                    .AddEnvironmentVariables()
+                    .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                    // Above configuration providers will provide connection
+                    // details for KeyVault configuration provider.
+                    .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
+                })
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                .ConfigureContainer<ContainerBuilder>((hostBuilderContext, builder) => {
+                    // registering services in the Autofac ContainerBuilder
+                    ConfigureContainer(builder, hostBuilderContext.Configuration);
+                })
+                .ConfigureServices((hostBuilderContext, services) => {
+                    ConfigureServices(services, hostBuilderContext.Configuration);
+                })
+                .UseSerilog();
+        }
+
+        /// <summary>
+        /// This is where you register dependencies, add services to the container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureServices(
+            IServiceCollection services,
+            IConfiguration configuration
+        ) {
+            services.AddHostedService<HostStarterService>();
         }
 
         /// <summary>
         /// Autofac configuration.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configuration"></param>
         public static ContainerBuilder ConfigureContainer(
-            IConfiguration configuration) {
-
+            ContainerBuilder builder,
+            IConfiguration configuration
+        ) {
             var serviceInfo = new ServiceInfo();
             var config = new Config(configuration);
-            var builder = new ContainerBuilder();
 
             builder.RegisterInstance(serviceInfo)
                 .AsImplementedInterfaces();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
+                .AsSelf()
                 .AsImplementedInterfaces();
             builder.RegisterInstance(config.Configuration)
                 .AsImplementedInterfaces();
@@ -151,11 +146,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
                 .AsImplementedInterfaces();
             builder.RegisterType<CdmMessageProcessor>()
                 .AsImplementedInterfaces();
-
-            // ... and auto start
-            builder.RegisterType<HostAutoStart>()
-                .AutoActivate()
-                .AsImplementedInterfaces().SingleInstance();
 
             return builder;
         }

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm {
+namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/HostStarterService.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
+
+    using Microsoft.Azure.IIoT.Diagnostics;
+    using Microsoft.Azure.IIoT.Services.Processor.Telemetry.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class HostStarterService : IHostedService {
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public IProcessIdentity ServiceInfo { get; }
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            IProcessIdentity serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Program.cs
@@ -11,20 +11,19 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Services;
     using Microsoft.Azure.IIoT.OpcUa.Subscriber.Handlers;
     using Microsoft.Azure.IIoT.OpcUa.Subscriber.Processors;
-    using Microsoft.Azure.IIoT.Exceptions;
     using Microsoft.Azure.IIoT.Serializers;
     using Microsoft.Azure.IIoT.Hub.Processor.EventHub;
     using Microsoft.Azure.IIoT.Hub.Processor.Services;
     using Microsoft.Azure.IIoT.Hub.Services;
-    using Microsoft.Azure.IIoT.Utils;
     using Microsoft.Extensions.Configuration;
     using Autofac;
     using Serilog;
     using System;
-    using System.IO;
-    using System.Runtime.Loader;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
+    using Autofac.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
 
     /// <summary>
     /// IoT Hub device telemetry event processor host.  Processes all
@@ -38,69 +37,65 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
         /// </summary>
         /// <param name="args"></param>
         public static void Main(string[] args) {
-
-            // Load hosting configuration
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true)
-                .AddFromDotEnvFile()
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddCommandLine(args)
-                // Above configuration providers will provide connection
-                // details for KeyVault configuration provider.
-                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
-                .Build();
-
-            // Set up dependency injection for the event processor host
-            RunAsync(config).Wait();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Run
+        /// Create host builder
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="args"></param>
         /// <returns></returns>
-        public static async Task RunAsync(IConfiguration config) {
-            var exit = false;
-            while (!exit) {
-                // Wait until the event processor host unloads or is cancelled
-                var tcs = new TaskCompletionSource<bool>();
-                AssemblyLoadContext.Default.Unloading += _ => tcs.TrySetResult(true);
-                using (var container = ConfigureContainer(config).Build()) {
-                    var logger = container.Resolve<ILogger>();
-                    try {
-                        logger.Information("Telemetry event processor host started.");
-                        exit = await tcs.Task;
-                    }
-                    catch (InvalidConfigurationException e) {
-                        logger.Error(e,
-                            "Error starting telemetry event processor host - exit!");
-                        return;
-                    }
-                    catch (Exception ex) {
-                        logger.Error(ex,
-                            "Error running telemetry event processor host - restarting!");
-                    }
-                }
-            }
+        public static IHostBuilder CreateHostBuilder(string[] args) {
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureHostConfiguration(configHost => {
+                    configHost.AddFromDotEnvFile()
+                    .AddEnvironmentVariables()
+                    .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                    // Above configuration providers will provide connection
+                    // details for KeyVault configuration provider.
+                    .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
+                })
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                .ConfigureContainer<ContainerBuilder>((hostBuilderContext, builder) => {
+                    // registering services in the Autofac ContainerBuilder
+                    ConfigureContainer(builder, hostBuilderContext.Configuration);
+                })
+                .ConfigureServices((hostBuilderContext, services) => {
+                    ConfigureServices(services, hostBuilderContext.Configuration);
+                })
+                .UseSerilog();
+        }
+
+        /// <summary>
+        /// This is where you register dependencies, add services to the container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureServices(
+            IServiceCollection services,
+            IConfiguration configuration
+        ) {
+            services.AddHostedService<HostStarterService>();
         }
 
         /// <summary>
         /// Autofac configuration.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configuration"></param>
         public static ContainerBuilder ConfigureContainer(
-            IConfiguration configuration) {
-
+            ContainerBuilder builder,
+            IConfiguration configuration
+        ) {
             var serviceInfo = new ServiceInfo();
             var config = new Config(configuration);
-            var builder = new ContainerBuilder();
 
             builder.RegisterInstance(serviceInfo)
                 .AsImplementedInterfaces();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
+                .AsSelf()
                 .AsImplementedInterfaces();
             builder.RegisterInstance(config.Configuration)
                 .AsImplementedInterfaces();
@@ -118,10 +113,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
                 .AsImplementedInterfaces().SingleInstance();
             builder.RegisterType<EventProcessorFactory>()
                 .AsImplementedInterfaces();
-            // ... and auto start
-            builder.RegisterType<HostAutoStart>()
-                .AutoActivate()
-                .AsImplementedInterfaces().SingleInstance();
 
             // Handle telemetry events
             builder.RegisterType<IoTHubDeviceEventHandler>()

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry {
+namespace Microsoft.Azure.IIoT.Services.Processor.Telemetry.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/HostStarterService.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/HostStarterService.cs
@@ -1,0 +1,104 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel {
+
+    using Microsoft.Azure.IIoT.Diagnostics;
+    using Microsoft.Azure.IIoT.Services.Processor.Tunnel.Runtime;
+    using Microsoft.Extensions.Hosting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Serilog;
+
+    /// <summary>
+    /// Generic host service which manages IHostProcess objects.
+    /// </summary>
+    class HostStarterService : IHostedService {
+
+        /// <summary>
+        /// Details of application hosting environment.
+        /// </summary>
+        public IHostEnvironment HostEnvironment { get; }
+
+        /// <summary>
+        /// Handler for subscribing to application lifetime events.
+        /// </summary>
+        public IHostApplicationLifetime HostApplicationLifetime { get; }
+
+        /// <summary>
+        /// Runtime configuration, will be provided by DI.
+        /// </summary>
+        public Config Config { get; }
+
+        /// <summary>
+        /// Service information, will be provided by DI.
+        /// </summary>
+        public IProcessIdentity ServiceInfo { get; }
+
+        /// <summary>
+        /// List of IHostProcess objects that will be managed by this instance, provided by DI.
+        /// </summary>
+        private readonly List<IHostProcess> _hostProcesses;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Constructor for generic host service which manages IHostProcess objects.
+        /// </summary>
+        /// <param name="hostEnvironment"></param>
+        /// <param name="hostApplicationLifetime"></param>
+        /// <param name="config"></param>
+        /// <param name="serviceInfo"></param>
+        /// <param name="hostProcesses"></param>
+        /// <param name="logger"></param>
+        public HostStarterService(
+            IHostEnvironment hostEnvironment,
+            IHostApplicationLifetime hostApplicationLifetime,
+            Config config,
+            IProcessIdentity serviceInfo,
+            IEnumerable<IHostProcess> hostProcesses,
+            ILogger logger
+        ) {
+            HostEnvironment = hostEnvironment ?? throw new ArgumentNullException(nameof(hostEnvironment));
+            HostApplicationLifetime = hostApplicationLifetime ?? throw new ArgumentNullException(nameof(hostApplicationLifetime));
+            Config = config ?? throw new ArgumentNullException(nameof(config));
+            ServiceInfo = serviceInfo ?? throw new ArgumentNullException(nameof(serviceInfo));
+            _hostProcesses = hostProcesses?.ToList() ?? throw new ArgumentNullException(nameof(hostProcesses));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <inheritdoc/>
+        public async Task StartAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Starting all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StartAsync()));
+                _logger.Information("All hosts started.");
+
+                // Print some useful information at bootstrap time
+                _logger.Information("{service} service started with id {id}",
+                    ServiceInfo.Name, ServiceInfo.Id);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to start some hosts.");
+                throw;
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task StopAsync(CancellationToken cancellationToken) {
+            try {
+                _logger.Debug("Stopping all hosts...");
+                await Task.WhenAll(_hostProcesses.Select(h => h.StopAsync()));
+                _logger.Information("All hosts stopped.");
+            }
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to stop all hosts.");
+                throw;
+            }
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -8,6 +8,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Program.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Program.cs
@@ -4,25 +4,24 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel {
-    using Microsoft.Azure.IIoT.Services.Processor.Tunnel.Runtime;
-    using Microsoft.Azure.IIoT.Exceptions;
-    using Microsoft.Azure.IIoT.Module.Default;
+
+    using Autofac;
+    using Autofac.Extensions.DependencyInjection;
+    using Microsoft.Azure.IIoT.Auth.Clients;
+    using Microsoft.Azure.IIoT.Http.Default;
+    using Microsoft.Azure.IIoT.Http.Ssl;
     using Microsoft.Azure.IIoT.Hub.Client;
     using Microsoft.Azure.IIoT.Hub.Processor.EventHub;
     using Microsoft.Azure.IIoT.Hub.Processor.Services;
     using Microsoft.Azure.IIoT.Hub.Services;
-    using Microsoft.Azure.IIoT.Http.Default;
-    using Microsoft.Azure.IIoT.Http.Ssl;
-    using Microsoft.Azure.IIoT.Auth.Clients;
-    using Microsoft.Azure.IIoT.Utils;
+    using Microsoft.Azure.IIoT.Module.Default;
     using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Services.Processor.Tunnel.Runtime;
     using Microsoft.Extensions.Configuration;
-    using Autofac;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
     using Serilog;
     using System;
-    using System.IO;
-    using System.Runtime.Loader;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// IoT Hub device telemetry event processor host.  Processes all
@@ -35,69 +34,65 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel {
         /// </summary>
         /// <param name="args"></param>
         public static void Main(string[] args) {
-
-            // Load hosting configuration
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json", true)
-                .AddEnvironmentVariables()
-                .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddFromDotEnvFile()
-                .AddCommandLine(args)
-                // Above configuration providers will provide connection
-                // details for KeyVault configuration provider.
-                .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest)
-                .Build();
-
-            // Set up dependency injection for the event processor host
-            RunAsync(config).Wait();
+            CreateHostBuilder(args).Build().Run();
         }
 
         /// <summary>
-        /// Run
+        /// Create host builder
         /// </summary>
-        /// <param name="config"></param>
+        /// <param name="args"></param>
         /// <returns></returns>
-        public static async Task RunAsync(IConfiguration config) {
-            var exit = false;
-            while (!exit) {
-                // Wait until the event processor host unloads or is cancelled
-                var tcs = new TaskCompletionSource<bool>();
-                AssemblyLoadContext.Default.Unloading += _ => tcs.TrySetResult(true);
-                using (var container = ConfigureContainer(config).Build()) {
-                    var logger = container.Resolve<ILogger>();
-                    try {
-                        logger.Information("Events processor host started.");
-                        exit = await tcs.Task;
-                    }
-                    catch (InvalidConfigurationException e) {
-                        logger.Error(e,
-                            "Error starting events processor host - exit!");
-                        return;
-                    }
-                    catch (Exception ex) {
-                        logger.Error(ex,
-                            "Error running events processor host - restarting!");
-                    }
-                }
-            }
+        public static IHostBuilder CreateHostBuilder(string[] args) {
+            return Host.CreateDefaultBuilder(args)
+                .ConfigureHostConfiguration(configHost => {
+                    configHost.AddFromDotEnvFile()
+                    .AddEnvironmentVariables()
+                    .AddEnvironmentVariables(EnvironmentVariableTarget.User)
+                    // Above configuration providers will provide connection
+                    // details for KeyVault configuration provider.
+                    .AddFromKeyVault(providerPriority: ConfigurationProviderPriority.Lowest);
+                })
+                .UseServiceProviderFactory(new AutofacServiceProviderFactory())
+                .ConfigureContainer<ContainerBuilder>((hostBuilderContext, builder) => {
+                    // registering services in the Autofac ContainerBuilder
+                    ConfigureContainer(builder, hostBuilderContext.Configuration);
+                })
+                .ConfigureServices((hostBuilderContext, services) => {
+                    ConfigureServices(services, hostBuilderContext.Configuration);
+                })
+                .UseSerilog();
+        }
+
+        /// <summary>
+        /// This is where you register dependencies, add services to the container.
+        /// </summary>
+        /// <param name="services"></param>
+        /// <param name="configuration"></param>
+        public static void ConfigureServices(
+            IServiceCollection services,
+            IConfiguration configuration
+        ) {
+            services.AddHostedService<HostStarterService>();
         }
 
         /// <summary>
         /// Autofac configuration.
         /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="configuration"></param>
         public static ContainerBuilder ConfigureContainer(
-            IConfiguration configuration) {
-
+            ContainerBuilder builder,
+            IConfiguration configuration
+        ) {
             var serviceInfo = new ServiceInfo();
             var config = new Config(configuration);
-            var builder = new ContainerBuilder();
 
             builder.RegisterInstance(serviceInfo)
                 .AsImplementedInterfaces();
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
+                .AsSelf()
                 .AsImplementedInterfaces();
             builder.RegisterInstance(config.Configuration)
                 .AsImplementedInterfaces();
@@ -125,10 +120,6 @@ namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel {
                 .AsImplementedInterfaces().SingleInstance();
             builder.RegisterType<EventProcessorFactory>()
                 .AsImplementedInterfaces();
-            // ... and auto start
-            builder.RegisterType<HostAutoStart>()
-                .AutoActivate()
-                .AsImplementedInterfaces().SingleInstance();
 
             // Handle tunnel server events
             builder.RegisterType<IoTHubDeviceEventHandler>()

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Runtime/ServiceInfo.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Runtime/ServiceInfo.cs
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel {
+namespace Microsoft.Azure.IIoT.Services.Processor.Tunnel.Runtime {
     using Microsoft.Azure.IIoT.Diagnostics;
 
     /// <summary>


### PR DESCRIPTION
Docs: [.NET Generic Host](https://docs.microsoft.com/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1)

* Using ASP.NET Core generic host for hosting event processor.
* Added Application Insights dependency tracking.
* Minor refactoring in Microsoft.Azure.IIoT.Services.Processor.Events.
* Generic host for Microsoft.Azure.IIoT.Services.Processor.Onboarding.
* Minor refactoring.
* Generic host for Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm..
* Generic host for Microsoft.Azure.IIoT.Services.Processor.Telemetry.
* Generic host for Microsoft.Azure.IIoT.Services.Processor.Tunnel.
* Generic host for Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.

One thing to note here is that I've removed `HostAutoStart` from container builder of event processors and I have delegated its responsibilities to `HostStarterService`. `HostStarterService` now received list of host processes (`IEnumerable<IHostProcess> hostProcesses`) that it should manage. It starts and stops them when start and stop are called on `HostStarterService` itself. This way lifetime of `IHostProcess` instances is tied to application lifetime events. 