### PR TITLE
Bugfix: Reverting removal of PCS_STORAGE_KEY as it used later for TSI.

### DIFF
--- a/deploy/templates/azuredeploy.minimum.json
+++ b/deploy/templates/azuredeploy.minimum.json
@@ -654,6 +654,10 @@
                                 "value": "[concat('DefaultEndpointsProtocol=https', ';EndpointSuffix=', environment().suffixes.storage, ';AccountName=', parameters('storageName'), ';AccountKey=', listKeys(variables('storageResourceId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value)]"
                             },
                             {
+                                "key": "PCS_STORAGE_KEY",
+                                "value": "[listKeys(variables('storageResourceId'), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+                            },
+                            {
                                 "key": "PCS_COSMOSDB_CONNSTRING",
                                 "value": "[concat('AccountEndpoint=', reference(variables('cosmosDbResourceId')).documentEndpoint, ';AccountKey=', listkeys(variables('cosmosDbResourceId'), '2016-03-19').primaryMasterKey, ';')]"
                             },


### PR DESCRIPTION
`PCS_STORAGE_KEY ` was removed (#613) as it was seemingly not used in code or deployment scripts. What I previously missed was that while `PCS_STORAGE_KEY ` is not used, its representation in Azure Key Vault is, `pcs-storage-key` secret.
