### PR TITLE
IAI: Fixing configuration for CDM processor.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -880,6 +880,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
 
             // Create Storage Account Gen2 with hierarchical namespace enabled.
             StorageAccountInner storageAccountGen2HNS;
+            StorageAccountKey storageAccountGen2HNSKey;
+            string storageAccountGen2HNSEndpointSuffix;
             string storageAccountGen2HNSConectionString;
             BlobContainerInner powerbiContainer;
 
@@ -892,6 +894,16 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
+            // NOTE: storageAccountGen2HNSKey and storageAccountGen2HNSEndpointSuffix are required for
+            // <2.8.5 version of components as processing of storageAccountGen2HNSConectionString is not
+            // present there.
+            storageAccountGen2HNSKey = await _storageManagementClient
+                .GetStorageAccountKeyAsync(
+                    _resourceGroup,
+                    storageAccountGen2HNS,
+                    cancellationToken
+                );
+            storageAccountGen2HNSEndpointSuffix = _storageManagementClient.GetDataLakeEndpointSuffix();
             storageAccountGen2HNSConectionString = await _storageManagementClient
                 .GetStorageAccountDataLakeConectionStringAsync(
                     _resourceGroup,
@@ -1119,6 +1131,9 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                 storageAccountGen2ConectionString,
                 dataprotectionBlobContainer.Name,
                 // ADLS Gen2 Storage Account with enabled HNS
+                storageAccountGen2HNS.Name,
+                storageAccountGen2HNSKey.Value,
+                storageAccountGen2HNSEndpointSuffix,
                 storageAccountGen2HNSConectionString,
                 powerbiContainer.Name,
                 StorageMgmtClient.POWERBI_ROOT_FOLDER,

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
@@ -36,6 +36,11 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public readonly string PCS_STORAGE_CONTAINER_DATAPROTECTION;
 
         // ADLS Gen2 Storage Account
+        // NOTE: PCS_ADLSG2_ACCOUNT, PCS_ADLSG2_ACCOUNT_KEY and PCS_ADLSG2_ENDPOINTSUFFIX are required
+        // for <2.8.5 version of components as processing of PCS_ADLSG2_CONNSTRING is not present there.
+        public readonly string PCS_ADLSG2_ACCOUNT;
+        public readonly string PCS_ADLSG2_ACCOUNT_KEY;
+        public readonly string PCS_ADLSG2_ENDPOINTSUFFIX;
         public readonly string PCS_ADLSG2_CONNSTRING;
         public readonly string PCS_ADLSG2_CONTAINER_CDM;
         public readonly string PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER;
@@ -130,6 +135,9 @@ namespace Microsoft.Azure.IIoT.Deployment {
             string storageAccountConectionString,
             string storageAccountContainerDataprotection,
             // ADLS Gen2 Storage Account
+            string adlsAccount,
+            string adlsAccountKey,
+            string adlsEndpointSuffix,
             string adlsConectionString,
             string adlsContainerCdm,
             string adlsContainerCdmRootFolder,
@@ -176,6 +184,11 @@ namespace Microsoft.Azure.IIoT.Deployment {
             PCS_STORAGE_CONTAINER_DATAPROTECTION = storageAccountContainerDataprotection;
 
             // ADLS Gen2 Storage Account
+            // NOTE: PCS_ADLSG2_ACCOUNT, PCS_ADLSG2_ACCOUNT_KEY and PCS_ADLSG2_ENDPOINTSUFFIX are required
+            // for <2.8.5 version of components as processing of PCS_ADLSG2_CONNSTRING is not present there.
+            PCS_ADLSG2_ACCOUNT = adlsAccount;
+            PCS_ADLSG2_ACCOUNT_KEY = adlsAccountKey;
+            PCS_ADLSG2_ENDPOINTSUFFIX = adlsEndpointSuffix;
             PCS_ADLSG2_CONNSTRING = adlsConectionString;
             PCS_ADLSG2_CONTAINER_CDM = adlsContainerCdm;
             PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER = adlsContainerCdmRootFolder;
@@ -270,6 +283,9 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 { $"{nameof(PCS_STORAGE_CONTAINER_DATAPROTECTION)}", PCS_STORAGE_CONTAINER_DATAPROTECTION },
 
                 // ADLS Gen2 Storage Account
+                { $"{nameof(PCS_ADLSG2_ACCOUNT)}", PCS_ADLSG2_ACCOUNT },
+                { $"{nameof(PCS_ADLSG2_ACCOUNT_KEY)}", PCS_ADLSG2_ACCOUNT_KEY },
+                { $"{nameof(PCS_ADLSG2_ENDPOINTSUFFIX)}", PCS_ADLSG2_ENDPOINTSUFFIX },
                 { $"{nameof(PCS_ADLSG2_CONNSTRING)}", PCS_ADLSG2_CONNSTRING },
                 { $"{nameof(PCS_ADLSG2_CONTAINER_CDM)}", PCS_ADLSG2_CONTAINER_CDM },
                 { $"{nameof(PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER)}", PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER },

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/StorageMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/StorageMgmtClient.cs
@@ -30,8 +30,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
 
         private const string kSTORAGE_ACCOUNT_CONECTION_STRING_FORMAT = 
             "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}";
-        private const string kSTORAGE_ACCOUNT_DATA_LAKE_CONECTION_STRING_FORMAT =
-            "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix=dfs.{2}";
+        private const string kDATA_LAKE_ENDPOINT_SUFFIX_FORMAT = "dfs.{0}";
 
         private readonly StorageManagementClient _storageManagementClient;
         private readonly AzureEnvironment _azureEnvironment;
@@ -397,6 +396,26 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         }
 
         /// <summary>
+        /// Get endpoint suffix.
+        /// </summary>
+        /// <returns></returns>
+        public string GetEndpointSuffix() {
+            return _azureEnvironment.StorageEndpointSuffix;
+        }
+
+        /// <summary>
+        /// Get data lake endpoint suffix.
+        /// </summary>
+        /// <returns></returns>
+        public string GetDataLakeEndpointSuffix() {
+            var dataLakeEndpointSuffix = string.Format(
+                kDATA_LAKE_ENDPOINT_SUFFIX_FORMAT,
+                _azureEnvironment.StorageEndpointSuffix
+            );
+            return dataLakeEndpointSuffix;
+        }
+
+        /// <summary>
         /// Get connection string for Storage Account with data lake specific endpoint suffix.
         /// </summary>
         /// <param name="resourceGroup"></param>
@@ -416,12 +435,13 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
             }
 
             var storageAccountKey = await GetStorageAccountKeyAsync(resourceGroup, storageAccount, cancellationToken);
+            var dataLakeEndpointSuffix = GetDataLakeEndpointSuffix();
 
             var storageAccountConectionString = string.Format(
-                kSTORAGE_ACCOUNT_DATA_LAKE_CONECTION_STRING_FORMAT,
+                kSTORAGE_ACCOUNT_CONECTION_STRING_FORMAT,
                 storageAccount.Name,
                 storageAccountKey.Value,
-                _azureEnvironment.StorageEndpointSuffix
+                dataLakeEndpointSuffix
             );
 
             return storageAccountConectionString;


### PR DESCRIPTION
Azure Industrial IoT components `<2.8.5` (#613) version lack processing of `PCS_ADLSG2_CONNSTRING` configuration parameters. Thus `telemetry-cdm-processor` deployed by current version of IAI does not receive enough parameters to connect to ADLS Gen2 storage account.

To provide connection details for ADLS Gen2 storage account I've added `PCS_ADLSG2_ACCOUNT`, `PCS_ADLSG2_ACCOUNT_KEY` and `PCS_ADLSG2_ENDPOINTSUFFIX` fallback parameters.