### PR TITLE
Helm: Exposing metrics ports for non-API services. 

### DIFF
--- a/deploy/helm/azure-industrial-iot/templates/26_onboarding_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/26_onboarding_deployment.yaml
@@ -71,6 +71,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.onboarding.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9501
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}

--- a/deploy/helm/azure-industrial-iot/templates/27_sync_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/27_sync_deployment.yaml
@@ -71,6 +71,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.sync.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9505
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}

--- a/deploy/helm/azure-industrial-iot/templates/33_events-processor_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/33_events-processor_deployment.yaml
@@ -71,6 +71,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.eventsProcessor.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9500
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}

--- a/deploy/helm/azure-industrial-iot/templates/38_telemetry_cdm_processor_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/38_telemetry_cdm_processor_deployment.yaml
@@ -76,6 +76,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.telemetryCdmProcessor.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9503
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}

--- a/deploy/helm/azure-industrial-iot/templates/39_telemetry_processor_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/39_telemetry_processor_deployment.yaml
@@ -71,6 +71,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.telemetryProcessor.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9502
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}

--- a/deploy/helm/azure-industrial-iot/templates/40_tunnel_processor_deployment.yaml
+++ b/deploy/helm/azure-industrial-iot/templates/40_tunnel_processor_deployment.yaml
@@ -71,6 +71,10 @@ spec:
         resources:
 {{ toYaml .Values.deployment.microServices.tunnelProcessor.resources | indent 10 }}
 {{- end }}
+        {{- if .Values.prometheus.scrape }}
+        ports:
+        - containerPort: 9504
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ include "azure-industrial-iot.env.fullname" . }}


### PR DESCRIPTION
I've changed deployment YAML files of non-API services to expose ports that should be used for Prometheus metrics scraping. The ports are exposed conditionally when scraping of metrics is enabled.

Modified services are the following:
- onboarding
- sync
- eventsProcessor
- telemetryProcessor
- telemetryCdmProcessor
- tunnelProcessor