### PR TITLE
IAI: Using latest 1.16.x patch version of Kubernetes in AKS.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -803,7 +803,24 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
             await setupKeyVaultTask;
             var operationalInsightsWorkspace = await operationalInsightsWorkspaceCreationTask;
 
+            var kubernetesVersions = await _azureResourceManager
+                .ListKubernetesVersionsAsync(_resourceGroup.Region, cancellationToken);
+            var kubernetesVersion = AksMgmtClient.SelectLatestPatchVersion(
+                AksMgmtClient.KUBERNETES_VERSION_MAJ_MIN, kubernetesVersions.ToList());
+            if (kubernetesVersion is null) {
+                // We will fall back to AksMgmtClient.KUBERNETES_VERSION_FALLBACK if it is available in the region.
+                if (kubernetesVersions.Contains(AksMgmtClient.KUBERNETES_VERSION_FALLBACK)) {
+                    kubernetesVersion = AksMgmtClient.KUBERNETES_VERSION_FALLBACK;
+                }
+                else {
+                    throw new Exception($"Fallback Kubernetes version is not suported in the region: {AksMgmtClient.KUBERNETES_VERSION_FALLBACK}");
+                }
+            }
+
+            Log.Information($"Kubernetest version {kubernetesVersion} will be used in AKS.");
+
             var clusterDefinition = _aksManagementClient.GetClusterDefinition(
+                kubernetesVersion,
                 _resourceGroup,
                 _applicationsManager.GetAKSApplication(),
                 _applicationsManager.GetAKSApplicationSecret(),

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION = "1.16.10";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.16.10";
+        public const string KUBERNETES_VERSION_MAJ_MIN = "1.16";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;
 
@@ -59,8 +60,38 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         //}
 
         /// <summary>
+        /// Select latest patch version of Kubernetes with major and minor defined by versionMajorMinor.
+        /// If function fails to parse provided versions then null will be returned.
+        /// </summary>
+        /// <param name="versionMajorMinor"> Minor and major versions in [major].[minor] format </param>
+        /// <param name="kubernetesVersions"> List of available versions in [major].[minor].[patch] format </param>
+        /// <returns></returns>
+        public static string SelectLatestPatchVersion(
+            string versionMajorMinor,
+            IList<string> kubernetesVersions
+        ) {
+            if (kubernetesVersions is null || kubernetesVersions.Count() == 0) {
+                throw new ArgumentNullException(nameof(kubernetesVersions));
+            }
+
+            try {
+                var latestVersion = kubernetesVersions
+                    .Where(version => version.StartsWith($"{versionMajorMinor}."))
+                    .OrderBy(version => Int32.Parse(version.Substring(versionMajorMinor.Length + 1)))
+                    .Last();
+
+                return latestVersion;
+            }
+            catch(FormatException) {
+                Log.Warning($"Failed to parse provided Kubernetes versions.");
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Get definition of default AKS cluster.
         /// </summary>
+        /// <param name="kubernetesVersion"></param>
         /// <param name="resourceGroup"></param>
         /// <param name="aksApplication"></param>
         /// <param name="aksApplicationSecret"></param>
@@ -71,6 +102,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         /// <param name="tags"></param>
         /// <returns></returns>
         public ManagedClusterInner GetClusterDefinition(
+            string kubernetesVersion,
             IResourceGroup resourceGroup,
             Application aksApplication,
             string aksApplicationSecret,
@@ -80,6 +112,9 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
             Workspace operationalInsightsWorkspace,
             IDictionary<string, string> tags = null
         ) {
+            if (string.IsNullOrWhiteSpace(kubernetesVersion)) {
+                throw new ArgumentNullException(nameof(kubernetesVersion));
+            }
             if (resourceGroup is null) {
                 throw new ArgumentNullException(nameof(resourceGroup));
             }
@@ -114,7 +149,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                 Tags = tags,
 
                 //ProvisioningState = null,
-                KubernetesVersion = KUBERNETES_VERSION,
+                KubernetesVersion = kubernetesVersion,
                 DnsPrefix = aksDnsPrefix,
                 //Fqdn = null,
                 AgentPoolProfiles = new List<ManagedClusterAgentPoolProfile> {

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AzureResourceManager.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AzureResourceManager.cs
@@ -209,5 +209,20 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
 
             return subscriptions;
         }
+
+        /// <summary>
+        /// Returns the list of available Kubernetes versions available for the given Azure region.
+        /// </summary>
+        /// <returns></returns>
+        public async Task<ISet<string>> ListKubernetesVersionsAsync(
+            Region region,
+            CancellationToken cancellationToken = default
+        ) {
+            var kubernetesVersions = await _azure
+                .KubernetesClusters
+                .ListKubernetesVersionsAsync(region, cancellationToken);
+
+            return kubernetesVersions;
+        }
     }
 }


### PR DESCRIPTION
I've introduced logic to select latest patch version of `1.16.x` Kubernetes for AKS.

This should solve issues that we were facing previously, when a specific version of Kubernetes has been deprecated from AKS, such as #593.