### PR TITLE
Add support to deploy with specific auth tenant

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
+++ b/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
@@ -198,10 +198,10 @@ namespace Microsoft.Extensions.Configuration {
                 }
                 catch (Exception ex) {
                     throw new InvalidConfigurationException(
-                        "A keyvault uri was provided could not access keyvault at the address. " +
-                        "If you want to read configuration from keyvault, make sure " +
-                        "the keyvault is reachable, the required permissions are configured " +
-                        "on keyvault and authentication provider information is available. " +
+                        "Could not access the provided keyvault URI. " +
+                        "If you want to read configuration from the keyvault, make sure " +
+                        "it is reachable, the required permissions are configured " +
+                        "and authentication provider information is available. " +
                         "Sign into Visual Studio or Azure CLI on this machine and try again.", ex);
                 }
                 if (!lazyLoad) {

--- a/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
+++ b/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Extensions/ConfigurationEx.cs
@@ -197,6 +197,7 @@ namespace Microsoft.Extensions.Configuration {
                     await provider.ValidateReadSecretAsync(keyVaultUrlVarName);
                 }
                 catch (Exception ex) {
+                    // https://github.com/Azure/Industrial-IoT/tree/master/deploy/helm/azure-industrial-iot#load-configuration-from-azure-key-vault
                     throw new InvalidConfigurationException(
                         "Could not access the provided keyvault URI. " +
                         "If you want to read configuration from the keyvault, make sure " +

--- a/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Runtime/AadUserKeyVaultConfig.cs
+++ b/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Runtime/AadUserKeyVaultConfig.cs
@@ -35,8 +35,9 @@ namespace Microsoft.Azure.IIoT.Auth.Runtime {
         public string ClientSecret => null;
         /// <summary>Optional tenant</summary>
         public string TenantId => GetStringOrDefault(kAuth_TenantIdKey,
+            () => GetStringOrDefault(PcsVariable.PCS_MSI_TENANT,
             () => GetStringOrDefault(PcsVariable.PCS_AUTH_TENANT,
-                () => null))?.Trim();
+                () => null)))?.Trim();
         /// <summary>Authority url</summary>
         public string InstanceUrl => GetStringOrDefault(kAuth_AuthorityUrlKey,
             () => GetStringOrDefault(PcsVariable.PCS_AAD_INSTANCE,

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -56,7 +56,7 @@ Function Select-Context() {
             -Environment $environmentName `
             -ErrorAction Stop
 
-        $reply = Read-Host -Prompt "Save credention in .user file [y/n]"
+        $reply = Read-Host -Prompt "Save credentials in .user file [y/n]"
         if ($reply -match "[yY]") {
             Save-AzContext -Path $contextFile -Profile $connection
         }

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -219,6 +219,17 @@ Function New-ADApplications() {
             Write-Verbose "Getting user principal for $($creds.Account.Id) failed."
         }
 
+        if(!$user) {
+            $accountId = (Get-AzContext).Account.Id.Replace("@", "_")
+            $userObjectId = (Get-AzureADUser -Filter "startswith(userPrincipalName, '$($accountId)')").ObjectId
+
+            $properties = @{
+                UserPrincipalName = $accountId
+                ObjectId = $userObjectId
+            }
+            $user = New-Object psobject -Property $properties
+        }
+
         # Get or create native client application
         $clientDisplayName = $applicationName + "-client"
         $clientAadApplication = Get-AzureADApplication -Filter "DisplayName eq '$clientDisplayName'"

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -8,9 +8,6 @@
  .PARAMETER Name
     The Name prefix under which to register the applications
 
- .PARAMETER Webapp
-    The Webapp URI to register as reply url, e.g. https://<NAME>.azurewebsites.net/
-
  .PARAMETER Context
     A previously created az context (optional)
 #>
@@ -18,7 +15,6 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Name,
     $Context,
-    [string] $Webapp = $null,
     [string] $Output = $null,
     [string] $EnvironmentName = "AzureCloud"
 )
@@ -56,7 +52,7 @@ Function Select-Context() {
             -Environment $environmentName `
             -ErrorAction Stop
 
-        $reply = Read-Host -Prompt "Save credentials in .user file [y/n]"
+        $reply = Read-Host -Prompt "Save credention in .user file [y/n]"
         if ($reply -match "[yY]") {
             Save-AzContext -Path $contextFile -Profile $connection
         }
@@ -394,13 +390,8 @@ Function New-ADApplications() {
         }
         Write-Host "'$($clientDisplayName)' updated with required resource access."
 
-        $replyUrls = New-Object System.Collections.Generic.List[System.String]
-        if (![string]::IsNullOrEmpty($script:Webapp)) {
-            $replyUrls.Add("$($script:Webapp)signin-oidc")
-        }
-
         Set-AzureADApplication -ObjectId $webAadApplication.ObjectId `
-            -RequiredResourceAccess $requiredResourcesAccess -ReplyUrls $replyUrls `
+            -RequiredResourceAccess $requiredResourcesAccess `
             -Oauth2AllowImplicitFlow $True -Oauth2AllowUrlPathMatching $True | Out-Null
         # Grant permissions to web app
         try {

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -8,6 +8,9 @@
  .PARAMETER Name
     The Name prefix under which to register the applications
 
+ .PARAMETER ReplyUrl
+    A reply_url to register, e.g. https://<NAME>.azurewebsites.net/
+
  .PARAMETER Context
     A previously created az context (optional)
 #>
@@ -15,6 +18,7 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Name,
     $Context,
+    [string] $ReplyUrl = $null,
     [string] $Output = $null,
     [string] $EnvironmentName = "AzureCloud"
 )
@@ -390,8 +394,13 @@ Function New-ADApplications() {
         }
         Write-Host "'$($clientDisplayName)' updated with required resource access."
 
+        $replyUrls = New-Object System.Collections.Generic.List[System.String]
+        if (![string]::IsNullOrEmpty($script:ReplyUrl)) {
+            $replyUrls.Add("$($script:ReplyUrl)signin-oidc")
+        }
+
         Set-AzureADApplication -ObjectId $webAadApplication.ObjectId `
-            -RequiredResourceAccess $requiredResourcesAccess `
+            -RequiredResourceAccess $requiredResourcesAccess -ReplyUrls $replyUrls `
             -Oauth2AllowImplicitFlow $True -Oauth2AllowUrlPathMatching $True | Out-Null
         # Grant permissions to web app
         try {

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -395,7 +395,9 @@ Function New-ADApplications() {
         Write-Host "'$($clientDisplayName)' updated with required resource access."
 
         $replyUrls = New-Object System.Collections.Generic.List[System.String]
-        $replyUrls.Add("$($script:Webapp)signin-oidc")
+        if (![string]::IsNullOrEmpty($script:Webapp)) {
+            $replyUrls.Add("$($script:Webapp)signin-oidc")
+        }
 
         Set-AzureADApplication -ObjectId $webAadApplication.ObjectId `
             -RequiredResourceAccess $requiredResourcesAccess -ReplyUrls $replyUrls `

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -219,6 +219,7 @@ Function New-ADApplications() {
             Write-Verbose "Getting user principal for $($creds.Account.Id) failed."
         }
 
+        # May be using authTenantId, get ObjectId from external account.  
         if(!$user) {
             $accountId = (Get-AzContext).Account.Id.Replace("@", "_")
             $userObjectId = (Get-AzureADUser -Filter "startswith(userPrincipalName, '$($accountId)')").ObjectId
@@ -228,6 +229,7 @@ Function New-ADApplications() {
                 ObjectId = $userObjectId
             }
             $user = New-Object psobject -Property $properties
+            $useFallBackUser = true
         }
 
         # Get or create native client application
@@ -422,6 +424,11 @@ Function New-ADApplications() {
             Write-Host "$($_.Exception) - this must be done manually with appropriate permissions."
         }
         Write-Host "'$($webDisplayName)' updated with required resource access."
+
+        # Reset ObjectId to use the one from the default tenant.
+        if($useFallBackUser) {
+            $user.ObjectId = null
+        }
 
         return [pscustomobject] @{
             TenantId           = $creds.Tenant.Id

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -229,7 +229,7 @@ Function New-ADApplications() {
                 ObjectId = $userObjectId
             }
             $user = New-Object psobject -Property $properties
-            $useFallBackUser = true
+            $useFallBackUser = $true
         }
 
         # Get or create native client application
@@ -427,7 +427,7 @@ Function New-ADApplications() {
 
         # Reset ObjectId to use the one from the default tenant.
         if($useFallBackUser) {
-            $user.ObjectId = null
+            $user.ObjectId = $null
         }
 
         return [pscustomobject] @{

--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -8,6 +8,9 @@
  .PARAMETER Name
     The Name prefix under which to register the applications
 
+ .PARAMETER Webapp
+    The Webapp URI to register as reply url, e.g. https://<NAME>.azurewebsites.net/
+
  .PARAMETER Context
     A previously created az context (optional)
 #>
@@ -15,6 +18,7 @@
 param(
     [Parameter(Mandatory = $true)] [string] $Name,
     $Context,
+    [string] $Webapp = $null,
     [string] $Output = $null,
     [string] $EnvironmentName = "AzureCloud"
 )
@@ -390,8 +394,11 @@ Function New-ADApplications() {
         }
         Write-Host "'$($clientDisplayName)' updated with required resource access."
 
+        $replyUrls = New-Object System.Collections.Generic.List[System.String]
+        $replyUrls.Add("$($script:Webapp)signin-oidc")
+
         Set-AzureADApplication -ObjectId $webAadApplication.ObjectId `
-            -RequiredResourceAccess $requiredResourcesAccess `
+            -RequiredResourceAccess $requiredResourcesAccess -ReplyUrls $replyUrls `
             -Oauth2AllowImplicitFlow $True -Oauth2AllowUrlPathMatching $True | Out-Null
         # Grant permissions to web app
         try {

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -816,6 +816,8 @@ Function New-Deployment() {
         Write-Host
         Write-Host "Registering client and services AAD applications in your tenant..."
         $aadRegisterContext = $context
+
+        # Use context of auth tenant
         if (![string]::IsNullOrEmpty($authTenantId)) {
             Connect-AzAccount -Tenant $authTenantId -ContextName AuthTenantId -Force
             $aadRegisterContext = Select-AzContext AuthTenantId
@@ -827,6 +829,9 @@ Function New-Deployment() {
         Write-Host "Client and services AAD applications registered..."
         Write-Host
         $aadAddReplyUrls = $true
+
+        # Restore AD context
+        Set-AzContext -Context $context
     }
     elseif (($script:aadConfig -is [string]) -and (Test-Path $script:aadConfig)) {
         # read configuration from file
@@ -897,6 +902,11 @@ Function New-Deployment() {
 
             Set-ResourceGroupTags -state "Complete"
             Write-Host "Deployment succeeded."
+
+            # Use context of auth tenant
+            if (![string]::IsNullOrEmpty($authTenantId)) {
+                Set-AzContext -Tenant $authTenantId
+            }
 
             #
             # Add reply urls

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -816,7 +816,7 @@ Function New-Deployment() {
         Write-Host
         Write-Host "Registering client and services AAD applications in your tenant..."
         $aadRegisterContext = $context
-        if ([string]::IsNullOrEmpty($authTenantId)) {
+        if (![string]::IsNullOrEmpty($authTenantId)) {
             Connect-AzAccount -Tenant $authTenantId -ContextName AuthTenantId -Force
             $aadRegisterContext = Select-AzContext AuthTenantId
         }

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -782,7 +782,7 @@ Function New-Deployment() {
             $templateParameters.Add("edgeVmSize", $edgeVmSize)
         }
 
-        # We will use VM with at least 1 core and 2 GB of memory for hosting OPC PLC simulatoin containers.
+        # We will use VM with at least 1 core and 2 GB of memory for hosting OPC PLC simulation containers.
         $simulationVmSizes = Get-AzVMSize $script:resourceGroupLocation `
             | Where-Object { $availableVmNames -icontains $_.Name } `
             | Where-Object {

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -536,7 +536,8 @@ Function New-Password() {
 #******************************************************************************
 Function Get-EnvironmentVariables() {
     Param(
-        $deployment
+        $deployment,
+        $authTenantId
     )
     if (![string]::IsNullOrEmpty($script:resourceGroupName)) {
         Write-Output "PCS_RESOURCE_GROUP=$($script:resourceGroupName)"
@@ -549,10 +550,18 @@ Function Get-EnvironmentVariables() {
     if (![string]::IsNullOrEmpty($var)) {
         Write-Output "PCS_AUTH_PUBLIC_CLIENT_APPID=$($var)"
     }
+
     $var = $deployment.Outputs["tenantId"].Value
+    if (![string]::IsNullOrEmpty($authTenantId)) {
+        if (![string]::IsNullOrEmpty($var)) {
+            Write-Output "PCS_MSI_TENANT=$($var)"
+        }
+        $var = $authTenantId
+    }
     if (![string]::IsNullOrEmpty($var)) {
         Write-Output "PCS_AUTH_TENANT=$($var)"
     }
+
     $var = $deployment.Outputs["tsiUrl"].Value
     if (![string]::IsNullOrEmpty($var)) {
         Write-Output "PCS_TSI_URL=$($var)"
@@ -606,7 +615,7 @@ Function Write-EnvironmentVariables() {
         if ($writeFile) {
             if (Test-Path $ENVVARS) {
                 $prompt = "Overwrite existing .env file in $rootDir? [y/n]"
-                if ( $reply -match "[yY]" ) {
+                if ($reply -match "[yY]") {
                     Remove-Item $ENVVARS -Force
                 }
                 else {
@@ -629,7 +638,7 @@ Function Write-EnvironmentVariables() {
         Write-Host
     }
     else {
-        Get-EnvironmentVariables $deployment | Out-Default
+        Get-EnvironmentVariables $deployment $authTenantId | Out-Default
     }
 }
 

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -38,6 +38,9 @@
  .PARAMETER aadApplicationName
     The application name to use when registering aad application.  If not set, uses applicationName
 
+ .PARAMETER authTenantId
+    Specifies an Azure Active Directory tenant for authentication that is different from the one tied to the subscription.
+
  .PARAMETER acrRegistryName
     An optional name of a Azure container registry to deploy containers from.
 
@@ -70,6 +73,7 @@ param(
     [string] $subscriptionId,
     [string] $accountName,
     [string] $aadApplicationName,
+    [string] $authTenantId,
     [string] $acrRegistryName,
     [string] $acrSubscriptionName,
     [string] $simulationProfile,
@@ -811,8 +815,14 @@ Function New-Deployment() {
         # register aad application
         Write-Host
         Write-Host "Registering client and services AAD applications in your tenant..."
+        $aadRegisterContext = $context
+        if ([string]::IsNullOrEmpty($authTenantId)) {
+            Connect-AzAccount -Tenant $authTenantId -ContextName AuthTenantId -Force
+            $aadRegisterContext = Select-AzContext AuthTenantId
+        }
+
         $script:aadConfig = & (Join-Path $script:ScriptDir "aad-register.ps1") `
-            -Context $context -Name $script:aadApplicationName
+            -Context $aadRegisterContext -Name $script:aadApplicationName
 
         Write-Host "Client and services AAD applications registered..."
         Write-Host

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -930,7 +930,7 @@ Function New-Deployment() {
             $replyUrls = New-Object System.Collections.Generic.List[System.String]
             if ($aadAddReplyUrls) {
                 # retrieve existing urls
-                $app = Get-AzADApplication -ObjectId $aadConfig.WebAppPrincipalId
+                $app = Get-AzADApplication -ApplicationId $aadConfig.WebAppId
                 if ($app.ReplyUrls -and ($app.ReplyUrls.Count -ne 0)) {
                     $replyUrls = $app.ReplyUrls;
                 }
@@ -941,10 +941,10 @@ Function New-Deployment() {
                 Write-Host "The deployed application can be found at:"
                 Write-Host $website
                 Write-Host
-                if (![string]::IsNullOrEmpty($script:aadConfig.WebAppPrincipalId)) {
+                if (![string]::IsNullOrEmpty($script:aadConfig.WebAppId)) {
                     if (!$aadAddReplyUrls) {
                         Write-Host "To be able to use the application you need to register the following"
-                        Write-Host "reply url for AAD application $($script:aadConfig.WebAppPrincipalId):"
+                        Write-Host "reply url for AAD application $($script:aadConfig.WebAppId):"
                         Write-Host "$($website)/signin-oidc"
                     }
                     else {
@@ -953,7 +953,7 @@ Function New-Deployment() {
                 }
             }
 
-            if ($aadAddReplyUrls -and ![string]::IsNullOrEmpty($script:aadConfig.WebAppPrincipalId)) {
+            if ($aadAddReplyUrls -and ![string]::IsNullOrEmpty($script:aadConfig.WebAppId)) {
                 $serviceUri = $deployment.Outputs["serviceUrl"].Value
 
                 if (![string]::IsNullOrEmpty($serviceUri)) {
@@ -981,7 +981,7 @@ Function New-Deployment() {
             if ($aadAddReplyUrls) {
                 # register reply urls in web application registration
                 Write-Host
-                Write-Host "Registering reply urls for $($aadConfig.WebAppPrincipalId)..."
+                Write-Host "Registering reply urls for $($aadConfig.WebAppId)..."
 
                 try {
                     # assumes we are still connected
@@ -992,17 +992,17 @@ Function New-Deployment() {
                     #    & (Join-Path $script:ScriptDir "aad-update.ps1") `
                     #        $context `
                     #        -ObjectId $aadConfig.WebAppPrincipalId -ReplyUrls $replyUrls
-                    Update-AzADApplication -ObjectId $aadConfig.WebAppPrincipalId -ReplyUrl $replyUrls `
+                    Update-AzADApplication -ApplicationId $aadConfig.WebAppId -ReplyUrl $replyUrls `
                         | Out-Null
 
-                    Write-Host "Reply urls registered in web app $($aadConfig.WebAppPrincipalId)..."
+                    Write-Host "Reply urls registered in web app $($aadConfig.WebAppId)..."
                     Write-Host
                 }
                 catch {
                     Write-Host $_.Exception.Message
                     Write-Host
                     Write-Host "Registering reply urls failed. Please add the following urls to"
-                    Write-Host "the web app '$($aadConfig.WebAppPrincipalId)' manually:"
+                    Write-Host "the web app '$($aadConfig.WebAppId)' manually:"
                     $replyUrls | ForEach-Object { Write-Host $_ }
                 }
             }

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -879,6 +879,10 @@ Function New-Deployment() {
     if (![string]::IsNullOrEmpty($script:aadConfig.UserPrincipalId)) {
         $templateParameters.Add("keyVaultPrincipalId", $script:aadConfig.UserPrincipalId)
     }
+    else {
+        $userPrincipalId = (Get-AzADUser -UserPrincipalName (Get-AzContext).Account.Id).Id
+        $templateParameters.Add("keyVaultPrincipalId", $userPrincipalId)
+    }
 
     # Add IoTSuiteType tag. This tag will be applied for all resources.
     $tags = @{"IoTSuiteType" = "AzureIndustrialIoT-$($script:version)-PS1"}

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -684,6 +684,9 @@ Function New-Deployment() {
             $templateParameters.Add("serviceSiteName", $script:applicationName)
         }
     }
+
+    $StartTime = $(get-date)
+    write-host "Start time: $($StartTime.ToShortTimeString())"
     
     # Select docker images to use
     if (-not (($script:type -eq "local") -or ($script:type -eq "minimum"))) {
@@ -842,6 +845,9 @@ Function New-Deployment() {
     if (![string]::IsNullOrEmpty($script:aadConfig.Authority)) {
         $templateParameters.Add("authorityUri", $script:aadConfig.Authority)
     }
+    if (![string]::IsNullOrEmpty($script:aadConfig.tenantId)) {
+        $templateParameters.Add("authTenantId", $script:aadConfig.tenantId)
+    }
 
     # Register current aad user to access keyvault
     if (![string]::IsNullOrEmpty($script:aadConfig.UserPrincipalId)) {
@@ -964,6 +970,9 @@ Function New-Deployment() {
                     $replyUrls | ForEach-Object { Write-Host $_ }
                 }
             }
+
+            $elapsedTime = $(get-date) - $StartTime
+            write-host "Elapsed time (hh:mm:ss): $($elapsedTime.ToString("hh\:mm\:ss"))" 
 
             #
             # Create environment file

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -819,6 +819,7 @@ Function New-Deployment() {
 
         # Use context of auth tenant
         if (![string]::IsNullOrEmpty($authTenantId)) {
+            Write-Host "Connecting to AAD tenant $($authTenantId)..."
             Connect-AzAccount -Tenant $authTenantId -ContextName AuthTenantId -Force
             $aadRegisterContext = Select-AzContext AuthTenantId
         }
@@ -831,6 +832,7 @@ Function New-Deployment() {
         $aadAddReplyUrls = $true
 
         # Restore AD context
+        Write-Host "Switching to AAD tenant $($context.Tenant)..."
         Set-AzContext -Context $context
     }
     elseif (($script:aadConfig -is [string]) -and (Test-Path $script:aadConfig)) {
@@ -905,7 +907,8 @@ Function New-Deployment() {
 
             # Use context of auth tenant
             if (![string]::IsNullOrEmpty($authTenantId)) {
-                Set-AzContext -Tenant $authTenantId
+                Write-Host "Switching to AAD tenant $($authTenantId)..."
+                Select-AzContext AuthTenantId
             }
 
             #

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -536,8 +536,7 @@ Function New-Password() {
 #******************************************************************************
 Function Get-EnvironmentVariables() {
     Param(
-        $deployment,
-        $authTenantId
+        $deployment
     )
     if (![string]::IsNullOrEmpty($script:resourceGroupName)) {
         Write-Output "PCS_RESOURCE_GROUP=$($script:resourceGroupName)"
@@ -552,7 +551,8 @@ Function Get-EnvironmentVariables() {
     }
 
     $var = $deployment.Outputs["tenantId"].Value
-    if (![string]::IsNullOrEmpty($authTenantId)) {
+    $authTenantId = $script:aadConfig.TenantId
+    if($var -ne $authTenantId) {
         if (![string]::IsNullOrEmpty($var)) {
             Write-Output "PCS_MSI_TENANT=$($var)"
         }
@@ -638,7 +638,7 @@ Function Write-EnvironmentVariables() {
         Write-Host
     }
     else {
-        Get-EnvironmentVariables $deployment $authTenantId | Out-Default
+        Get-EnvironmentVariables $deployment | Out-Default
     }
 }
 

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -909,7 +909,7 @@ Function New-Deployment() {
         try {
             if (![string]::IsNullOrEmpty($adminUser) -and ![string]::IsNullOrEmpty($adminPassword)) {
                 Write-Host
-                Write-Host "The following User and Password can be used to log into deployed VM's:"
+                Write-Host "The following username and password can be used to log into the deployed VMs:"
                 Write-Host
                 Write-Host $adminUser
                 Write-Host $adminPassword

--- a/deploy/templates/azuredeploy.json
+++ b/deploy/templates/azuredeploy.json
@@ -164,14 +164,14 @@
             }
         },
         "edgeUserName": {
-            "type": "secureString",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "A name for the simulation vm administrator user."
             }
         },
         "edgePassword": {
-            "type": "secureString",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "The supplied password must be between 8-75 characters long and must satisfy at least 3 of password complexity requirements: 1) Contains an uppercase character 2) Contains a lowercase character 3) Contains a numeric digit 4) Contains a special character. Control characters are not allowed"
@@ -192,7 +192,7 @@
             }
         },
         "dockerPassword": {
-            "type": "secureString",
+            "type": "securestring",
             "defaultValue": "",
             "metadata": {
                 "description": "Specifies the password to use for a private Container Registry."
@@ -210,6 +210,13 @@
             "defaultValue": "latest",
             "metadata": {
                 "description": "Specifies the image version tag to use for all container images."
+            }
+        },
+        "authTenantId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies an Azure Active Directory tenant for authentication that is different from the one tied to the subscription."
             }
         },
         "tags": {
@@ -466,6 +473,9 @@
                     },
                     "imagesTag": {
                         "value": "[parameters('imagesTag')]"
+                    },
+                    "authTenantId": {
+                        "value": "[parameters('authTenantId')]"
                     },
                     "tags": {
                         "value": "[parameters('tags')]"

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -262,7 +262,7 @@
                         },
                         {
                             "name": "PCS_AUTH_TENANT",
-                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]"
+                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId'))]"
                         },
                         {
                             "name": "PCS_SERVICE_URL",
@@ -284,7 +284,7 @@
                         "PCS_KEYVAULT_URL": "[parameters('keyVaultUri')]",
                         "PCS_MSI_APPID": "[parameters('managedIdentityClientId')]",
                         "PCS_MSI_TENANT": "[parameters('managedIdentityTenantId')]",
-                        "PCS_AUTH_TENANT": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]",
+                        "PCS_AUTH_TENANT": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId'))]",
                         "DOCKER_ENABLE_CI": "[if(parameters('deployFromSource'), '', 'false')]",
                         "DOCKER_REGISTRY_SERVER_URL": "[if(parameters('deployFromSource'), '', concat('https://', parameters('dockerServer')))]",
                         "DOCKER_REGISTRY_SERVER_USERNAME": "[if(parameters('deployFromSource'), '', parameters('dockerUser'))]",
@@ -421,7 +421,7 @@
                         },
                         {
                             "name": "PCS_AUTH_TENANT",
-                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]"
+                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId'))]"
                         },
                         {
                             "name": "PCS_SERVICE_URL",

--- a/deploy/templates/azuredeploy.platform.json
+++ b/deploy/templates/azuredeploy.platform.json
@@ -82,6 +82,13 @@
                 "description": "The tenant the managed identity was registered in."
             }
         },
+        "authTenantId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Specifies an Azure Active Directory tenant for authentication that is different from the one tied to the subscription."
+            }
+        },
         "dockerServer": {
             "type": "string",
             "defaultValue": "mcr.microsoft.com",
@@ -254,6 +261,10 @@
                             "value": "[parameters('managedIdentityTenantId')]"
                         },
                         {
+                            "name": "PCS_AUTH_TENANT",
+                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]"
+                        },
+                        {
                             "name": "PCS_SERVICE_URL",
                             "value": "[if(empty(parameters('serviceSiteName')), '', concat('https://', variables('serviceSiteResourceName'), '.azurewebsites.net'))]"
                         }
@@ -273,6 +284,7 @@
                         "PCS_KEYVAULT_URL": "[parameters('keyVaultUri')]",
                         "PCS_MSI_APPID": "[parameters('managedIdentityClientId')]",
                         "PCS_MSI_TENANT": "[parameters('managedIdentityTenantId')]",
+                        "PCS_AUTH_TENANT": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]",
                         "DOCKER_ENABLE_CI": "[if(parameters('deployFromSource'), '', 'false')]",
                         "DOCKER_REGISTRY_SERVER_URL": "[if(parameters('deployFromSource'), '', concat('https://', parameters('dockerServer')))]",
                         "DOCKER_REGISTRY_SERVER_USERNAME": "[if(parameters('deployFromSource'), '', parameters('dockerUser'))]",
@@ -406,6 +418,10 @@
                         {
                             "name": "PCS_MSI_TENANT",
                             "value": "[parameters('managedIdentityTenantId')]"
+                        },
+                        {
+                            "name": "PCS_AUTH_TENANT",
+                            "value": "[if(not(empty(parameters('authTenantId'))), parameters('authTenantId'), parameters('managedIdentityTenantId')]"
                         },
                         {
                             "name": "PCS_SERVICE_URL",

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -89,15 +89,34 @@ It is possible that the name of the website is already in use. If you run into t
 
 ### Azure Active Directory Registration
 
-The deployment script tries to register 2 Azure Active Directory (AAD) applications representing the client and the platform (service). Depending on your rights to the selected AAD tenant, this might fail.
+The deployment script tries to register two Azure Active Directory (AAD) applications representing the client and the platform (service). This requires [Global Administrator, Application Administrator or Cloud Application Administrator](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent) rights.
 
-An administrator with the relevant rights to the tenant can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying. The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
-
-```pwsh
-cd deploy/scripts
-./aad-register.ps1 -Name <application-name> -Output aad.json
-./deploy.ps1 -aadConfig aad.json ...
+If the deployment fails or if you see the following error when trying to sign-in, see further below for more options:
 ```
+Need admin approval
+<APPLICATION> needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
+```
+
+Option 1: Create your own AAD tenant, in which you are the admin
+  - Azure Portal: Create a resource -> Azure Active Directory  
+  - After about 1 min, click the link to manage the directory, or click on your account profile at the top right of the Azure Portal -> Switch directory, then select it from *All Directories*
+  - Copy the Tenant ID
+
+Start the deployment
+
+   ```pwsh
+   ./deploy -authTenantId <NEW_AAD_TENANT_ID>`
+   ```
+
+Option 2: Ask your AAD admin to grant tenant-wide admin consent for your application, there might be a process or tool for this in your enterprise environment
+
+Option 3: An AAD admin can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from the deployment. The output of the script is a file containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
+
+   ```pwsh
+   cd deploy/scripts
+   ./aad-register.ps1 -Name <application-name> -Output aad.json
+   ./deploy.ps1 -aadConfig aad.json
+   ```
 
 ### Missing Script dependencies
 
@@ -142,13 +161,12 @@ Using the `deploy/scripts/deploy.ps1` script you can deploy several configuratio
 
 To support these scenarios, the `deploy.ps1` takes the following parameters:
 
-```bash
-
+```
  .PARAMETER type
-    The type of deployment (local, services, app, all)
+    The type of deployment (local, services, app, all).
 
  .PARAMETER resourceGroupName
-    Can be the name of an existing or a new resource group
+    Can be the name of an existing or a new resource group.
 
  .PARAMETER resourceGroupLocation
     Optional, a resource group location. If specified, will try to create a new resource group in this location.
@@ -172,13 +190,16 @@ To support these scenarios, the `deploy.ps1` takes the following parameters:
     A previously created az context to be used as authentication.
 
  .PARAMETER aadApplicationName
-    The application name to use when registering aad application. If not set, uses applicationName
+    The application name to use when registering aad application. If not set, uses applicationName.
+
+ .PARAMETER authTenantId
+    Specifies an Azure Active Directory tenant for authentication that is different from the one tied to the subscription.
 
  .PARAMETER acrRegistryName
     An optional name of a Azure container registry to deploy containers from.
 
  .PARAMETER acrSubscriptionName
-    The subscription of the container registry if differemt from the specified subscription.
+    The subscription of the container registry if different from the specified subscription.
 ```
 
 ## Next steps

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -87,16 +87,16 @@ Ensure you use a short and simple resource group name. The name is used also to 
 
 It is possible that the name of the website is already in use. If you run into this error, you need to use a different application name.
 
-### Azure Active Directory Registration
+### Azure Active Directory registration
 
-The deployment script tries to register two Azure Active Directory (AAD) applications representing the client and the platform (service). This requires [Global Administrator, Application Administrator or Cloud Application Administrator](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent) rights.
+The deployment script tries to register three AAD applications representing the web app, the client and the platform (service). This requires [Global Administrator, Application Administrator or Cloud Application Administrator](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent) rights.
 
-If the deployment fails or if you see the following error when trying to sign-in, see further below for more options:
+If the deployment fails or if you see the following error when trying to sign-in, see further below for options:
 
-> Need admin approval  
+> **Need admin approval**  
 > \<APPLICATION\> needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
 
-Option 1: Create your own AAD tenant, in which you are the admin
+**Option 1**: Create your own AAD tenant, in which you are the admin
   - Azure Portal: Create a resource -> Azure Active Directory  
   - After about 1 min, click the link to manage the directory, or click on your account profile at the top right of the Azure Portal -> Switch directory, then select it from *All Directories*
   - Copy the Tenant ID
@@ -107,9 +107,9 @@ Start the deployment
    ./deploy -authTenantId <NEW_AAD_TENANT_ID>`
    ```
 
-Option 2: Ask your AAD admin to grant tenant-wide admin consent for your application, there might be a process or tool for this in your enterprise environment
+**Option 2**: Ask your AAD admin to grant tenant-wide admin consent for your application, there might be a process or tool for this in your enterprise environment
 
-Option 3: An AAD admin can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from the deployment. The output of the script is a file containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
+**Option 3**: An AAD admin can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from the deployment. The output of the script is a file containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
 
    ```pwsh
    cd deploy/scripts
@@ -121,7 +121,7 @@ Option 3: An AAD admin can create the AAD applications for you. The `deploy/scri
 
 On **Windows**, the script uses Powershell, which comes with Windows. The deploy batch file uses it to install all required modules.
 
-In case you run into issues, e.g. because you want to use pscore, run following two commands in PowerShell as Administrator. For more info on AzureAD and Az modules, refer [here](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
+In case you run into issues, e.g. because you want to use pscore, run following two commands in PowerShell as Administrator. See more information about [AzureAD and Az modules](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
    ```pwsh
    Install-Module -Name Az -AllowClobber

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -92,10 +92,9 @@ It is possible that the name of the website is already in use. If you run into t
 The deployment script tries to register two Azure Active Directory (AAD) applications representing the client and the platform (service). This requires [Global Administrator, Application Administrator or Cloud Application Administrator](https://docs.microsoft.com/en-us/azure/active-directory/manage-apps/grant-admin-consent) rights.
 
 If the deployment fails or if you see the following error when trying to sign-in, see further below for more options:
-```
-Need admin approval
-<APPLICATION> needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
-```
+
+> Need admin approval  
+> \<APPLICATION\> needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
 
 Option 1: Create your own AAD tenant, in which you are the admin
   - Azure Portal: Create a resource -> Azure Active Directory  

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -113,7 +113,7 @@ Start the deployment
 
    ```pwsh
    cd deploy/scripts
-   ./aad-register.ps1 -Name <application-name> -Output aad.json
+   ./aad-register.ps1 -Name <application-name> -ReplyUrl https://<name>.azurewebsites.net/ -Output aad.json
    ./deploy.ps1 -aadConfig aad.json
    ```
 

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -94,7 +94,6 @@ The deployment script tries to register 2 Azure Active Directory (AAD) applicati
 An administrator with the relevant rights to the tenant can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying. The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
 
 ```pwsh
-pwsh
 cd deploy/scripts
 ./aad-register.ps1 -Name <application-name> -Output aad.json
 ./deploy.ps1 -aadConfig aad.json ...

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -14,7 +14,7 @@ This article explains how to deploy the Azure Industrial IoT Platform and Simula
 
 The platform and simulation can also be deployed using the deploy script.
 
-1. If you have not done so yet, clone the GitHub repository. To clone the repository you need git. If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it. Open a new command prompt or terminal and run:
+1. If you have not done so yet, clone the GitHub repository. To clone the repository, you need git. If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it. Open a new command prompt or terminal and run:
 
    ```bash
    git clone https://github.com/Azure/Industrial-IoT
@@ -35,7 +35,7 @@ The platform and simulation can also be deployed using the deploy script.
      ./deploy.sh
      ```
 
-   > Additional supported parameters can be found [here](#deployment-script-options).
+   > See [additional supported parameters](#deployment-script-options).
 
 3. Follow the prompts to assign a name to the resource group of the deployment and a name to the website. The script deploys the Microservices and their Azure platform dependencies into the resource group in your Azure subscription. It also registers an Application in your Azure Active Directory (AAD) tenant to support OAUTH based authentication, this requires the [Application Developer](https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/directory-assign-admin-roles#application-developer) role.
    Deployment will take several minutes. An example of what you'd see once the solution is successfully deployed:
@@ -52,7 +52,7 @@ The platform and simulation can also be deployed using the deploy script.
 
 ### Execution Policy
 
-If you receive a message that the execution policy not being set you can set the execution policy when starting the powershell session:
+If you receive a message that the execution policy not being set, you can set the execution policy when starting the PowerShell session:
 
 ```pwsh
 pwsh -ExecutionPolicy Unrestricted
@@ -117,6 +117,8 @@ Start the deployment
    ./deploy.ps1 -aadConfig aad.json
    ```
 
+If you need additional reply URLs, you may add them manually as this does not require AAD admin rights.
+
 ### Missing Script dependencies
 
 On **Windows**, the script uses Powershell, which comes with Windows. The deploy batch file uses it to install all required modules.
@@ -132,11 +134,11 @@ On non - **Ubuntu** Linux or in case you run into issues follow the guidance in 
 
 ### Deploy from Linux other than Ubuntu
 
-To install all necessary requirements on other Linux distributions follow these steps:
+To install all necessary requirements on other Linux distributions, follow these steps:
 
 1. First [install PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell-core-on-linux?view=powershell-7). Follow the instructions for your Linux distribution.
 
-2. Open powershell using `sudo pwsh`.
+2. Open PowerShell using `sudo pwsh`.
 
 3. Install the required Azure Az Powershell module:
 

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -96,7 +96,19 @@ If the deployment fails or if you see the following error when trying to sign-in
 > **Need admin approval**  
 > \<APPLICATION\> needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it.
 
-**Option 1**: Create your own AAD tenant, in which you are the admin
+**Option 1** (recommended for production): Ask your AAD admin to grant tenant-wide admin consent for your application, there might be a process or tool for this in your enterprise environment.
+
+**Option 2** (recommended for production): An AAD admin can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from the deployment. The output of the script is a file containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
+
+   ```pwsh
+   cd deploy/scripts
+   ./aad-register.ps1 -Name <application-name> -ReplyUrl https://<name>.azurewebsites.net/ -Output aad.json
+   ./deploy.ps1 -aadConfig aad.json
+   ```
+
+If you need additional reply URLs, you may add them manually as this does not require AAD admin rights.
+
+**Option 3** (recommended as PoC): Create your [own AAD tenant](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-create-new-tenant), in which you are the admin
   - Azure Portal: Create a resource -> Azure Active Directory  
   - After about 1 min, click the link to manage the directory, or click on your account profile at the top right of the Azure Portal -> Switch directory, then select it from *All Directories*
   - Copy the Tenant ID
@@ -106,18 +118,6 @@ Start the deployment
    ```pwsh
    ./deploy -authTenantId <NEW_AAD_TENANT_ID>`
    ```
-
-**Option 2**: Ask your AAD admin to grant tenant-wide admin consent for your application, there might be a process or tool for this in your enterprise environment
-
-**Option 3**: An AAD admin can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from the deployment. The output of the script is a file containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
-
-   ```pwsh
-   cd deploy/scripts
-   ./aad-register.ps1 -Name <application-name> -ReplyUrl https://<name>.azurewebsites.net/ -Output aad.json
-   ./deploy.ps1 -aadConfig aad.json
-   ```
-
-If you need additional reply URLs, you may add them manually as this does not require AAD admin rights.
 
 ### Missing Script dependencies
 

--- a/readme.md
+++ b/readme.md
@@ -21,24 +21,24 @@ We have also built an application running on Azure that lets you access the serv
 ## Getting started
 
 Clone the repository:
-```bash
-git clone https://github.com/Azure/Industrial-IoT
-cd Industrial-IoT
-```
+  ```bash
+  git clone https://github.com/Azure/Industrial-IoT
+  cd Industrial-IoT
+  ```
 
 Start the deployment
 
 On Windows:
-```pwsh
-.\deploy
-```
+  ```pwsh
+  .\deploy
+  ```
 
 On Linux:
-```bash
-./deploy.sh
-```
+  ```bash
+  ./deploy.sh
+  ```
 
-See [detailed instructions](docs/deploy/howto-deploy-all-in-one.md) and [additional deployment options](docs/deploy/readme.md).
+For more information, see the [detailed instructions](docs/deploy/howto-deploy-all-in-one.md) and [additional deployment options](docs/deploy/readme.md).
 
 ## Learn more
 


### PR DESCRIPTION
* Added parameter authTenantId to deploy.ps1 to specify AAD tenant used for authentication (PCS_AUTH_TENANT)
* When using authTenantId for user authentication, key vault uses PCS_MSI_TENANT
* Modified AadUserKeyVaultConfig.cs -> TenantId to prefer PCS_MSI_TENANT and fallback to PCS_AUTH_TENANT to allow local debugging using VS
* Added parameter tenantId to dpeloy.ps1 to filter subscriptions based on specified tenant
* Added documentation of new parameters and options on how to solve consent granting issue
* Tested the following scenarios:
1. Deploy to MS subscription specifying authTenantId for new custom AAD
2. Deploy to OPCWALL subscription using default AAD
* Verified that key vault contained valid access policies for managed ID and my user account (for debugging in VS)
* Verified that app service configuration contained both PCS_MSI_TENANT and PCS_AUTH_TENANT
* Verified that app registrations contained reply_urls and owner set correctly
* Verified that cloud version runs, login possible and assets visible
* Verified that local version runs from VS, login possible and assets visible
* Verified that using parameter tenantId, only subscriptions in that tenant are shown in the list
* Verified that deploy.ps1 shows ClientId instead ObjectId in registration confirmation messages