### PR TITLE
Allow environment variable configuration of batch size and interval. 

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -23,6 +23,32 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
     public sealed class PublisherJobService : IPublishServices<string> {
 
         /// <summary>
+        /// Read default batch trigger interval from environment.
+        /// </summary>
+        internal Lazy<TimeSpan> DefaultBatchTriggerInterval => new Lazy<TimeSpan>(() => {
+            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_JOB_BATCH_INTERVAL");
+            if (!string.IsNullOrEmpty(env)) {
+                if (int.TryParse(env, out var milliseconds) &&
+                    milliseconds >= 100 && milliseconds <= 3600000) {
+                    return TimeSpan.FromMilliseconds(milliseconds);
+                }
+            }
+            return TimeSpan.FromMilliseconds(500); // default
+        });
+
+        /// <summary>
+        /// Read default batch trigger size from environment.
+        /// </summary>
+        internal Lazy<int> DefaultBatchSize => new Lazy<int>(() => {
+            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_JOB_BATCH_SIZE");
+            if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var size) &&
+                size > 1 && size <= 1000) {
+                return size;
+            }
+            return 50; // default
+        });
+
+        /// <summary>
         /// Create client
         /// </summary>
         /// <param name="endpoints"></param>
@@ -229,6 +255,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 var publishJob = (WriterGroupJobModel)_serializer.DeserializeJobConfiguration(
                     job.JobConfiguration, job.JobConfigurationType);
                 if (publishJob != null) {
+
+                    if (publishJob.Engine == null) {
+                        publishJob.Engine = new EngineConfigurationModel {
+                            BatchSize = DefaultBatchSize.Value,
+                            BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
+                            DiagnosticsInterval = TimeSpan.FromSeconds(60),
+                            MaxMessageSize = 0
+                        };
+                    }
+                    else {
+                        publishJob.Engine.BatchTriggerInterval = DefaultBatchTriggerInterval.Value;
+                        publishJob.Engine.BatchSize = DefaultBatchSize.Value;
+                    }
                     return publishJob;
                 }
             }
@@ -252,9 +291,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                                 NetworkMessageContentMask.DataSetMessageHeader
                     },
                 },
-                Engine = new EngineConfigurationModel() {
-                    BatchSize = 50,
-                    BatchTriggerInterval = TimeSpan.FromSeconds(10),
+                Engine = new EngineConfigurationModel {
+                    BatchSize = DefaultBatchSize.Value,
+                    BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                     DiagnosticsInterval = TimeSpan.FromSeconds(60),
                     MaxMessageSize = 0
                 },
@@ -348,7 +387,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 };
                 variables = dataSetWriter.DataSet.DataSetSource.PublishedVariables.PublishedData;
                 publishJob.WriterGroup.DataSetWriters.Add(dataSetWriter);
-
             }
 
             // Add to published variable list items

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.7",
-  "versionHeightOffset": -1,
+  "versionHeightOffset": 180,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/\\d+\\.\\d+"

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.7",
-  "versionHeightOffset": 180,
+  "versionHeightOffset": 9,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/\\d+\\.\\d+"


### PR DESCRIPTION
The following environment variables can be set to configure the batch trigger interval and batch size.
The environment variable PCS_DEFAULT_PUBLISH_JOB_BATCH_INTERVAL can be set as milliseconds from 100 to 3,600,000 ms.  Other values (e.g. <= 0) will result in the default value of 10,000 ms (10 seconds).
The environment variable PCS_DEFAULT_PUBLISH_JOB_BATCH_SIZE can be set as a value between 2 and 1000.   Every other value will result in the default of 50 subscription notifications per batch being set.
The environment variables must be set on the Publisher container Pod to affect the settings in all job configurations from this point on that are performed using the Publisher REST API.  (iot/opc-publisher-service).
The change is in the PublisherJobService Adapter, which adapts from 2.7 REST API to internal Publisher configuration API.  The engine configuration that had hardcoded settings in them in 2.7 release will be updated to read both values out of the environment and set them in the configuration.