### PR TITLE
Enabling configuration of batch size and interval.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
@@ -917,7 +917,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 BatchSize = model.BatchSize,
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 DiagnosticsInterval = model.DiagnosticsInterval,
-                MaxMessageSize = model.MaxMessageSize
+                MaxMessageSize = model.MaxMessageSize,
+                MaxOutgressMessages = model.MaxOutgressMessages
             };
         }
 
@@ -933,7 +934,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 BatchSize = model.BatchSize,
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 MaxMessageSize = model.MaxMessageSize,
-                DiagnosticsInterval = model.DiagnosticsInterval
+                DiagnosticsInterval = model.DiagnosticsInterval,
+                MaxOutgressMessages = model.MaxOutgressMessages
             };
         }
 

--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
@@ -42,5 +42,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
             EmitDefaultValue = false)]
         public int? MaxMessageSize { get; set; }
 
+        /// <summary>
+        /// Max IoT D2C outgress message buffer size
+        /// </summary>
+        [DataMember(Name = "maxOutgressMessages", Order = 4,
+            EmitDefaultValue = false)]
+        public int? MaxOutgressMessages { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -87,9 +87,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 IsRunning = true;
                 _encodingBlock = new TransformManyBlock<DataSetMessageModel[], NetworkMessageModel>(
                     async input => {
-                        if (_batchTriggerInterval > TimeSpan.Zero) {
-                            _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
-                        }
                         try {
                             if (_dataSetMessageBufferSize == 1) {
                                 return await _messageEncoder.EncodeAsync(input, _maxEncodedMessageSize).ConfigureAwait(false);
@@ -256,6 +253,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// </summary>
         /// <param name="state"></param>
         private void BatchTriggerIntervalTimer_Elapsed(object state) {
+            if (_batchTriggerInterval > TimeSpan.Zero) {
+                _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
+            }
             _batchDataSetMessageBlock?.TriggerBatch();
         }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 PublisherId = publisherId,
                 DiagnosticsInterval = model.Engine?.DiagnosticsInterval,
                 WriterGroup = model.WriterGroup,
-                MaxMessageSize = model.Engine?.MaxMessageSize
+                MaxMessageSize = model.Engine?.MaxMessageSize,
+                MaxOutgressMessages = model.Engine?.MaxOutgressMessages
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
@@ -31,5 +31,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
         /// Diagnostics interval
         /// </summary>
         TimeSpan? DiagnosticsInterval { get; }
+
+        /// <summary>
+        /// Define the maximum number of messages in outgress buffer, 
+        /// Default: 200 messages with 256KB ends 
+        /// up in 50 MB memory consumed
+        /// </summary>
+        int? MaxOutgressMessages { get; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/LegacyCliModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/LegacyCliModel.cs
@@ -82,6 +82,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
         public int? MaxMessageSize { get; set; }
 
         /// <summary>
+        /// Define the maximum amount of the IoT D2C messages
+        /// </summary>
+        public int? MaxOutgressMessages { get; set; }
+
+        /// <summary>
         /// The time to flush the log file to the disc.
         /// </summary>
         public TimeSpan? LogFileFlushTimeSpan { get; set; }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
@@ -31,5 +31,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Runtime {
 
         /// <inheritdoc/>
         public string PublisherId { get; set; }
+        
+        /// <inheritdoc/>
+        public int? MaxOutgressMessages { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -132,7 +132,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                             BatchSize = _config.BatchSize,
                             BatchTriggerInterval = _config.BatchTriggerInterval,
                             DiagnosticsInterval = _config.DiagnosticsInterval,
-                            MaxMessageSize = _config.MaxMessageSize
+                            MaxMessageSize = _config.MaxMessageSize,
+                            MaxOutgressMessages = _config.MaxOutgressMessages
                         },
                         WriterGroup = new WriterGroupModel {
                             MessageType = legacyCliModel.MessageEncoding,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -23,6 +23,32 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
     public sealed class PublisherJobService : IPublishServices<string> {
 
         /// <summary>
+        /// Read default batch trigger interval from environment.
+        /// </summary>
+        internal Lazy<TimeSpan> DefaultBatchTriggerInterval => new Lazy<TimeSpan>(() => {
+            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_JOB_BATCH_INTERVAL");
+            if (!string.IsNullOrEmpty(env)) {
+                if (int.TryParse(env, out var milliseconds) &&
+                    milliseconds >= 100 && milliseconds <= 3600000) {
+                    return TimeSpan.FromMilliseconds(milliseconds);
+                }
+            }
+            return TimeSpan.FromMilliseconds(500); // default
+        });
+
+        /// <summary>
+        /// Read default batch trigger size from environment.
+        /// </summary>
+        internal Lazy<int> DefaultBatchSize => new Lazy<int>(() => {
+            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_JOB_BATCH_SIZE");
+            if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var size) &&
+                size > 1 && size <= 1000) {
+                return size;
+            }
+            return 50; // default
+        });
+
+        /// <summary>
         /// Create client
         /// </summary>
         /// <param name="endpoints"></param>
@@ -229,6 +255,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 var publishJob = (WriterGroupJobModel)_serializer.DeserializeJobConfiguration(
                     job.JobConfiguration, job.JobConfigurationType);
                 if (publishJob != null) {
+
+                    if (publishJob.Engine == null) {
+                        publishJob.Engine = new EngineConfigurationModel {
+                            BatchSize = DefaultBatchSize.Value,
+                            BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
+                            DiagnosticsInterval = TimeSpan.FromSeconds(60),
+                            MaxMessageSize = 0
+                        };
+                    }
+                    else {
+                        publishJob.Engine.BatchTriggerInterval = DefaultBatchTriggerInterval.Value;
+                        publishJob.Engine.BatchSize = DefaultBatchSize.Value;
+                    }
                     return publishJob;
                 }
             }
@@ -252,9 +291,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                                 NetworkMessageContentMask.DataSetMessageHeader
                     },
                 },
-                Engine = new EngineConfigurationModel() {
-                    BatchSize = 50,
-                    BatchTriggerInterval = TimeSpan.FromSeconds(10),
+                Engine = new EngineConfigurationModel {
+                    BatchSize = DefaultBatchSize.Value,
+                    BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                     DiagnosticsInterval = TimeSpan.FromSeconds(60),
                     MaxMessageSize = 0
                 },
@@ -348,7 +387,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 };
                 variables = dataSetWriter.DataSet.DataSetSource.PublishedVariables.PublishedData;
                 publishJob.WriterGroup.DataSetWriters.Add(dataSetWriter);
-
             }
 
             // Add to published variable list items

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -49,6 +49,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
         });
 
         /// <summary>
+        /// Read default max outgress message buffer size from environment
+        /// </summary>
+        internal Lazy<int> DefaultMaxOutgressMessages => new Lazy<int>(() => {
+            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_MAX_OUTGRESS_MESSAGES");
+            if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var maxOutgressMessages) &&
+                maxOutgressMessages > 1 && maxOutgressMessages <= 25000) {
+                return maxOutgressMessages;
+            }
+            return 200; //default
+        });
+
+        /// <summary>
         /// Create client
         /// </summary>
         /// <param name="endpoints"></param>
@@ -261,12 +273,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                             BatchSize = DefaultBatchSize.Value,
                             BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                             DiagnosticsInterval = TimeSpan.FromSeconds(60),
-                            MaxMessageSize = 0
-                        };
+                            MaxMessageSize = 0,
+                            MaxOutgressMessages = DefaultMaxOutgressMessages.Value
+                    };
                     }
                     else {
                         publishJob.Engine.BatchTriggerInterval = DefaultBatchTriggerInterval.Value;
                         publishJob.Engine.BatchSize = DefaultBatchSize.Value;
+                        publishJob.Engine.MaxOutgressMessages = DefaultMaxOutgressMessages.Value;
                     }
                     return publishJob;
                 }
@@ -295,8 +309,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                     BatchSize = DefaultBatchSize.Value,
                     BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                     DiagnosticsInterval = TimeSpan.FromSeconds(60),
-                    MaxMessageSize = 0
-                },
+                    MaxMessageSize = 0,
+                    MaxOutgressMessages = DefaultMaxOutgressMessages.Value
+        },
                 ConnectionString = null
             };
         }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 BatchSize = model.BatchSize,
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 DiagnosticsInterval = model.DiagnosticsInterval,
-                MaxMessageSize = model.MaxMessageSize
+                MaxMessageSize = model.MaxMessageSize,
+                MaxOutgressMessages = model.MaxOutgressMessages
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
@@ -30,5 +30,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         /// Diagnostics setting
         /// </summary>
         public TimeSpan? DiagnosticsInterval { get; set; }
+
+        /// <summary>
+        /// Define the maximum size of outgress message buffer
+        /// Default: 200 messages with 256KB ends 
+        /// up in 50 MB memory consumed
+        /// </summary>
+        public int? MaxOutgressMessages { get; set; }
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
@@ -98,6 +98,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public const string MaxMessageSize = "MaxMessageSize";
 
         /// <summary>
+        /// Key for the max (IoT Hub D2C) messages
+        /// </summary>
+        public const string MaxOutgressMessages = "MaxOutgressMessages";
+
+        /// <summary>
         /// Key for the scale test monitored items clones count .
         /// </summary>
         public const string ScaleTestCount = "ScaleTestCount";

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -144,6 +144,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         (int k) => this[LegacyCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
                     { "ms|iothubmessagesize=", "The maximum size of the (IoT D2C) message.",
                         (int i) => this[LegacyCliConfigKeys.MaxMessageSize] = i.ToString() },
+                    { "om|maxoutgressmessages=", "The maximum size of the (IoT D2C) message outgress buffer",
+                        (int i) => this[LegacyCliConfigKeys.MaxOutgressMessages] = i.ToString() },
 
                     // testing purposes
                     { "sc|scaletestcount=", "The number of monitored item clones in scale tests.",
@@ -231,6 +233,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public int? MaxMessageSize => LegacyCliModel.MaxMessageSize;
 
         /// <summary>
+        /// The Maximum (IoT D2C) message buffer size
+        /// </summary>
+        public int? MaxOutgressMessages => LegacyCliModel.MaxOutgressMessages;
+
+        /// <summary>
         /// The model of the CLI arguments.
         /// </summary>
         public LegacyCliModel LegacyCliModel { get; }
@@ -286,7 +293,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 BatchSize = GetValueOrDefault(LegacyCliConfigKeys.BatchSize, 50),
                 BatchTriggerInterval = GetValueOrDefault<TimeSpan>(LegacyCliConfigKeys.BatchTriggerInterval, TimeSpan.FromSeconds(10)),
                 MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.MaxMessageSize, 0),
-                ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, 1)
+                ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, 1),
+                MaxOutgressMessages = GetValueOrDefault(LegacyCliConfigKeys.MaxOutgressMessages, 200)
             };
         }
 


### PR DESCRIPTION
This is cumulative PR for batching related changes that happened on `release/2.7.180` branch:

From @koepalex: Drop iot hub messages if exceed the maximum limit (#652):

* Drop iot hub messages if exceed the maximum limit
* limit for outgoing ioT Hub messages set to 200 (hardcoded) which equals 50 MB memory
* extend diagnostics output with number of dropped messages
* Make max number of IoT D2C messages configurable
* configurable via environment variable `PCS_DEFAULT_PUBLISH_MAX_OUTGRESS_MESSAGES`
* configurable via cli parameter `mom` or `maxoutgressmessages`
* implemented review comments
* aligned XML comments
* cli parameter shot form changed from _mom_ to **om**

From @mregen: Fix for batch trigger interval timer, which is not properly recharged under certain conditions. (#654)

* Under certain conditions the batch interval timer is not properly recharged.
* Fix by recharging timer on every timer callback instead of recharge in the Dataflow callback.

From @mregen: Allow environment variable configuration of batch size and interval. (#650)

* The following environment variables can be set to configure the batch trigger interval and batch size.
  The environment variable `PCS_DEFAULT_PUBLISH_JOB_BATCH_INTERVAL` can be set as milliseconds from 100 to 3,600,000 ms.  Other values (e.g. <= 0) will result in the default value of 10,000 ms (10 seconds).
  The environment variable `PCS_DEFAULT_PUBLISH_JOB_BATCH_SIZE` can be set as a value between 2 and 1000.   Every other value will result in the default of 50 subscription notifications per batch being set.
  The environment variables must be set on the Publisher container Pod to affect the settings in all job configurations from this point on that are performed using the Publisher REST API.  (iot/opc-publisher-service).
  The change is in the PublisherJobService Adapter, which adapts from 2.7 REST API to internal Publisher configuration API.  The engine configuration that had hardcoded settings in them in 2.7 release will be updated to read both values out of the environment and set them in the configuration.