### PR TITLE
Improvements to diag info

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
@@ -918,7 +918,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 DiagnosticsInterval = model.DiagnosticsInterval,
                 MaxMessageSize = model.MaxMessageSize,
-                MaxOutgressMessages = model.MaxOutgressMessages
+                MaxEgressMessageQueue = model.MaxEgressMessageQueue
             };
         }
 
@@ -935,7 +935,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 MaxMessageSize = model.MaxMessageSize,
                 DiagnosticsInterval = model.DiagnosticsInterval,
-                MaxOutgressMessages = model.MaxOutgressMessages
+                MaxEgressMessageQueue = model.MaxEgressMessageQueue
             };
         }
 

--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         public int? MaxMessageSize { get; set; }
 
         /// <summary>
-        /// Max IoT D2C outgress message buffer size
+        /// Max IoT D2C egress message queue
         /// </summary>
-        [DataMember(Name = "maxOutgressMessages", Order = 4,
+        [DataMember(Name = "maxEgressMessages", Order = 4,
             EmitDefaultValue = false)]
-        public int? MaxOutgressMessages { get; set; }
+        public int? MaxEgressMessageQueue { get; set; }
     }
 }

--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Models/EngineConfigurationApiModel.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// <summary>
         /// Max IoT D2C egress message queue
         /// </summary>
-        [DataMember(Name = "maxEgressMessages", Order = 4,
+        [DataMember(Name = "maxEgressMessageQueue", Order = 4,
             EmitDefaultValue = false)]
         public int? MaxEgressMessageQueue { get; set; }
     }

--- a/common/src/Microsoft.Azure.IIoT.Abstractions/src/PcsVariable.cs
+++ b/common/src/Microsoft.Azure.IIoT.Abstractions/src/PcsVariable.cs
@@ -289,5 +289,8 @@ namespace Microsoft.Azure.IIoT {
         /// <summary> Log file path environment variable </summary>
         public const string PCS_LOGS_PATH =
             "PCS_LOGS_PATH";
+        /// <summary> The maximum size of the (IoT D2C) message egress queue </summary>
+        public const string PCS_MAX_EGRESS_MESSAGE_QUEUE =
+            "PCS_DEFAULT_PUBLISH_MAX_EGRESS_MESSAGE_QUEUE";
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// </summary>
         /// <param name="valueCount"></param>
         private string GetValuePercentage(double valueCount) =>
-            $"{valueCount / _messageTrigger.ValueChangesCount:P0}";
+            $"{(_messageTrigger.ValueChangesCount > 0? valueCount / _messageTrigger.ValueChangesCount : 0):P0}";
 
         private readonly int _dataSetMessageBufferSize = 1;
         private readonly int _networkMessageBufferSize = 1;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
 
             diagInfo.AppendLine("  v Ingress BatchBlock queue           : {batchDataSetMessageBlockOutputCount,14:0} batches");
             diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages");
-            diagInfo.AppendLine("  | Encoder processing                 : {notificationsProcessingCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder processed                  : {notificationsProcessedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder dropped                    : {notificationsDroppedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
@@ -192,7 +191,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages");
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
-            diagInfo.AppendLine("  | Egress IoT Hub sending             : {messagesSendingCount,14:n0} messages");
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values");
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";
@@ -209,9 +207,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 _batchDataSetMessageBlock.OutputCount, // batchDataSetMessageBlockOutputCount
                 _encodingBlock.InputCount, _encodingBlock.OutputCount, // encodingBlockInputCount | encodingBlockOutputCount
                 // Account for report inaccuracies due to timing.
-                _messageTrigger.ValueChangesCount > _messageEncoder.NotificationsProcessedCount
-                    ? _messageTrigger.ValueChangesCount - _messageEncoder.NotificationsProcessedCount
-                    : 0,
                 Math.Min(_messageEncoder.NotificationsProcessedCount,
                     _messageTrigger.ValueChangesCount), // NotificationsProcessedCount
                 _messageEncoder.NotificationsDroppedCount,
@@ -221,10 +216,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 chunkSizeAverage,
                 _batchNetworkMessageBlock.OutputCount, // batchNetworkMessageBlockOutputCount
                 _sinkBlock.InputCount, // sinkBlockInputCount
-                // Account for report inaccuracies due to timing.
-                _messageEncoder.MessagesProcessedCount > _messageSink.SentMessagesCount
-                    ? _messageEncoder.MessagesProcessedCount - _messageSink.SentMessagesCount
-                    : 0,
                 _sinkBlockInputDroppedCount,
                 _messageSink.SentMessagesCount, sentMessagesPerSecFormatted,
                 // Account for report inaccuracies due to timing.

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             _batchTriggerInterval = _config.BatchTriggerInterval.GetValueOrDefault(TimeSpan.Zero);
             _diagnosticsOutputTimer = new Timer(DiagnosticsOutputTimer_Elapsed);
             _batchTriggerIntervalTimer = new Timer(BatchTriggerIntervalTimer_Elapsed);
-            _maxEgressMessageQueue = _config.MaxEgressMessageQueue.GetValueOrDefault(8192); // = 4 GB / 2 / (256 * 1024)
+            _maxEgressMessageQueue = _config.MaxEgressMessageQueue.GetValueOrDefault(4096); // = 2 GB / 2 / (256 * 1024)
             _logger.Information($"Max. egress message queue: {_maxEgressMessageQueue} messages ({_maxEgressMessageQueue * 256 / 1024} MB)");
         }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -187,14 +187,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  | Ingress OPC ValueChanges           : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
 
             diagInfo.AppendLine("  v Ingress BatchBlock queue           : {batchDataSetMessageBlockOutputCount,14:0} batches");
-            diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages" + $" (~{_encodingBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:#} OPC values)");
+            diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages" + $" (~{_encodingBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)");
             diagInfo.AppendLine("  | Encoder processed                  : {notificationsProcessedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder dropped                    : {notificationsDroppedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message        : {AvgNotificationsPerMessage,14:0} OPC values/message");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercentFormatted}");
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
-            diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:#} OPC values)");
+            diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)");
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             _batchTriggerInterval = _config.BatchTriggerInterval.GetValueOrDefault(TimeSpan.Zero);
             _diagnosticsOutputTimer = new Timer(DiagnosticsOutputTimer_Elapsed);
             _batchTriggerIntervalTimer = new Timer(BatchTriggerIntervalTimer_Elapsed);
-            _maxOutgressMessages = _config.MaxOutgressMessages.GetValueOrDefault(200);
+            _maxEgressMessageQueue = _config.MaxEgressMessageQueue.GetValueOrDefault(8192); // = 4 GB / 2 / (256 * 1024)
         }
 
         /// <inheritdoc/>
@@ -88,12 +88,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 IsRunning = true;
                 _encodingBlock = new TransformManyBlock<DataSetMessageModel[], NetworkMessageModel>(
                     async input => {
+                        _notificationsProcessingCount = input.Sum(m => m.Notifications.Count());
                         try {
                             if (_dataSetMessageBufferSize == 1) {
-                                return await _messageEncoder.EncodeAsync(input, _maxEncodedMessageSize).ConfigureAwait(false);
+                                return await _messageEncoder.EncodeAsync(input, _maxEncodedMessageSize - _encodedMessageSizeOverhead).ConfigureAwait(false);
                             }
                             else {
-                                return await _messageEncoder.EncodeBatchAsync(input, _maxEncodedMessageSize).ConfigureAwait(false);
+                                return await _messageEncoder.EncodeBatchAsync(input, _maxEncodedMessageSize - _encodedMessageSizeOverhead).ConfigureAwait(false);
                             }
                         }
                         catch (Exception e) {
@@ -102,23 +103,24 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     },
                     new ExecutionDataflowBlockOptions {
-                        CancellationToken = cancellationToken
+                        CancellationToken = cancellationToken,
                     });
 
                 _batchDataSetMessageBlock = new BatchBlock<DataSetMessageModel>(
                     _dataSetMessageBufferSize,
                     new GroupingDataflowBlockOptions {
-                        CancellationToken = cancellationToken
+                        CancellationToken = cancellationToken,
                     });
 
                 _batchNetworkMessageBlock = new BatchBlock<NetworkMessageModel>(
                     _networkMessageBufferSize,
                     new GroupingDataflowBlockOptions {
-                        CancellationToken = cancellationToken
+                        CancellationToken = cancellationToken,
                     });
 
                 _sinkBlock = new ActionBlock<NetworkMessageModel[]>(
                     async input => {
+                        _messagesSendingCount = input.Length;
                         if (input != null && input.Any()) {
                             await _messageSink.SendAsync(input).ConfigureAwait(false);
                         }
@@ -128,8 +130,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     },
                     new ExecutionDataflowBlockOptions {
-                        CancellationToken = cancellationToken
+                        CancellationToken = cancellationToken,
                     });
+
                 _batchDataSetMessageBlock.LinkTo(_encodingBlock);
                 _encodingBlock.LinkTo(_batchNetworkMessageBlock);
                 _batchNetworkMessageBlock.LinkTo(_sinkBlock);
@@ -140,7 +143,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 }
 
                 await _messageTrigger.RunAsync(cancellationToken).ConfigureAwait(false);
-
             }
             finally {
                 IsRunning = false;
@@ -176,45 +178,57 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("\n  DIAGNOSTICS INFORMATION for          : {host}");
             diagInfo.AppendLine("  # Ingestion duration                 : {duration,14:dd\\:hh\\:mm\\:ss} (dd:hh:mm:ss)");
             string dataChangesPerSecFormatted = _messageTrigger.DataChangesCount > 0 && totalDuration > 0 ? $"({dataChangesPerSec:0.##}/s)" : "";
-            diagInfo.AppendLine("  # Ingress DataChanges (from OPC)     : {dataChangesCount,14:n0} {dataChangesPerSecFormatted}");
+            diagInfo.AppendLine("  | Ingress OPC DataChanges            : {dataChangesCount,14:n0} {dataChangesPerSecFormatted}");
             string valueChangesPerSecFormatted = _messageTrigger.ValueChangesCount > 0 && totalDuration > 0 ? $"({valueChangesPerSec:0.##}/s)" : "";
-            diagInfo.AppendLine("  # Ingress ValueChanges (from OPC)    : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
+            diagInfo.AppendLine("  | Ingress OPC ValueChanges           : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
 
-            diagInfo.AppendLine("  # Ingress BatchBlock buffer size     : {batchDataSetMessageBlockOutputCount,14:0}");
-            diagInfo.AppendLine("  # Encoding Block input/output size   : {encodingBlockInputCount,14:0} | {encodingBlockOutputCount:0}");
-            diagInfo.AppendLine("  # Encoder Notifications processed    : {notificationsProcessedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder Notifications dropped      : {notificationsDroppedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder IoT Messages processed     : {messagesProcessedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder avg Notifications/Message  : {notificationsPerMessage,14:0}");
-            diagInfo.AppendLine("  # Encoder avg IoT Message body size  : {messageSizeAverage,14:n0} {messageSizeAveragePercentFormatted}");
-            diagInfo.AppendLine("  # Encoder avg IoT Chunk (4 KB) usage : {chunkSizeAverage,14:0.#}");
-            diagInfo.AppendLine("  # Estimated IoT Chunks (4 KB) per day: {estimatedMsgChunksPerDay,14:n0}");
-            diagInfo.AppendLine("  # Outgress Batch Block buffer size   : {batchNetworkMessageBlockOutputCount,14:0}");
-            diagInfo.AppendLine("  # Outgress input buffer count        : {sinkBlockInputCount,14:n0}");
-            diagInfo.AppendLine("  # Outgress input buffer dropped      : {sinkBlockInputDroppedCount,14:n0}");
+            diagInfo.AppendLine("  v Ingress BatchBlock queue           : {batchDataSetMessageBlockOutputCount,14:0} batches");
+            diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages");
+            diagInfo.AppendLine("  | Encoder processing                 : {notificationsProcessingCount,14:n0} OPC values");
+            diagInfo.AppendLine("  | Encoder processed                  : {notificationsProcessedCount,14:n0} OPC values");
+            diagInfo.AppendLine("  | Encoder dropped                    : {notificationsDroppedCount,14:n0} OPC values");
+            diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
+            diagInfo.AppendLine("  | Encoder avg IoT Hub message        : {AvgNotificationsPerMessage,14:0} OPC values/message");
+            diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercentFormatted}");
+            diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
+            diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages");
+            diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
+            diagInfo.AppendLine("  | Egress IoT Hub sending             : {messagesSendingCount,14:n0} messages");
+            diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values");
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";
-            diagInfo.AppendLine("  # Outgress IoT message count         : {messageSinkSentMessagesCount,14:n0} {sentMessagesPerSecFormatted}");
-            diagInfo.AppendLine("  # Connection retries                 : {connectionRetries,14:0}");
+            diagInfo.AppendLine("  v Egress IoT Hub sent                : {SentMessagesCount,14:n0} messages {sentMessagesPerSecFormatted}");
+            diagInfo.AppendLine("  # Estimated egress                   : {estimatedNotificationsSent,14:n0} OPC values");
+            diagInfo.AppendLine("  # Estimated IoT Hub usage            : {estimatedMsgChunksPerDay,14:n0} 4-KB-chunks per day");
+            diagInfo.AppendLine("  # Connection retries                 : {NumberOfConnectionRetries,14:0}");
 
             _logger.Information(diagInfo.ToString(),
-                Name,
-                TimeSpan.FromSeconds(totalDuration),
+                Name, // host
+                TimeSpan.FromSeconds(totalDuration), // duration
                 _messageTrigger.DataChangesCount, dataChangesPerSecFormatted,
                 _messageTrigger.ValueChangesCount, valueChangesPerSecFormatted,
-                _batchDataSetMessageBlock.OutputCount,
-                _encodingBlock.InputCount, _encodingBlock.OutputCount,
+                _batchDataSetMessageBlock.OutputCount, // batchDataSetMessageBlockOutputCount
+                _encodingBlock.InputCount, _encodingBlock.OutputCount, // encodingBlockInputCount | encodingBlockOutputCount
+                _messageEncoder.NotificationsProcessedCount < _messageTrigger.ValueChangesCount &&
+                _messageEncoder.NotificationsProcessedCount + (ulong)_notificationsProcessingCount < _messageTrigger.ValueChangesCount
+                    ? _notificationsProcessingCount
+                    : 0,
                 _messageEncoder.NotificationsProcessedCount,
                 _messageEncoder.NotificationsDroppedCount,
                 _messageEncoder.MessagesProcessedCount,
                 _messageEncoder.AvgNotificationsPerMessage,
                 _messageEncoder.AvgMessageSize, messageSizeAveragePercentFormatted,
                 chunkSizeAverage,
-                estimatedMsgChunksPerDay,
-                _batchNetworkMessageBlock.OutputCount,
-                _sinkBlock.InputCount,
+                _batchNetworkMessageBlock.OutputCount, // batchNetworkMessageBlockOutputCount
+                _sinkBlock.InputCount, // sinkBlockInputCount
+                _messageSink.SentMessagesCount < _messageEncoder.MessagesProcessedCount &&
+                _messageSink.SentMessagesCount + (ulong)_messagesSendingCount < _messageEncoder.MessagesProcessedCount
+                    ? _messagesSendingCount
+                    : 0,
                 _sinkBlockInputDroppedCount,
                 _messageSink.SentMessagesCount, sentMessagesPerSecFormatted,
+                _messageEncoder.AvgNotificationsPerMessage * _messageSink.SentMessagesCount, // estimatedNotificationsSent
+                estimatedMsgChunksPerDay,
                 _messageTrigger.NumberOfConnectionRetries);
 
             string deviceId = _identity.DeviceId ?? "";
@@ -278,8 +292,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 }
             }
 
-            if(_sinkBlock.InputCount >= _maxOutgressMessages) {
-                _sinkBlockInputDroppedCount++;
+            if(_sinkBlock.InputCount >= _maxEgressMessageQueue) {
+                _sinkBlockInputDroppedCount += (ulong)args.Notifications.Count();
             }
             else {
                 _batchDataSetMessageBlock.Post(args);
@@ -292,6 +306,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private readonly TimeSpan _batchTriggerInterval;
 
         private readonly int _maxEncodedMessageSize = 256 * 1024;
+        private readonly int _encodedMessageSizeOverhead = 1 * 1024;
 
         private readonly IEngineConfiguration _config;
         private readonly IMessageSink _messageSink;
@@ -311,12 +326,22 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private ActionBlock<NetworkMessageModel[]> _sinkBlock;
 
         /// <summary>
-        /// Define the maximum size of messages
+        /// Maximum size of message output queue.
         /// </summary>
-        private readonly int _maxOutgressMessages;
+        private readonly int _maxEgressMessageQueue;
 
         /// <summary>
-        /// Counts the amount of messages that couldn't be send to IoTHub
+        /// Number of notifications being encoded.
+        /// </summary>
+        private int _notificationsProcessingCount;
+
+        /// <summary>
+        /// Number of messages being sent.
+        /// </summary>
+        private int _messagesSendingCount;
+
+        /// <summary>
+        /// Amount of messages that couldn't be sent to IoT Hub.
         /// </summary>
         private ulong _sinkBlockInputDroppedCount;
 
@@ -337,10 +362,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             "Opc DataChanges/second delivered for processing", kGaugeConfig);
         private static readonly Gauge kIoTHubQueueBuffer = Metrics.CreateGauge(
             "iiot_edge_publisher_iothub_queue_size",
-            "IoT messages queued sending", kGaugeConfig); 
+            "IoT messages queued sending", kGaugeConfig);
             private static readonly Gauge kIoTHubQueueBufferDroppedCount = Metrics.CreateGauge(
             "iiot_edge_publisher_iothub_queue_dropped_count",
-            "IoT messages dropped", kGaugeConfig); 
+            "IoT messages dropped", kGaugeConfig);
         private static readonly Gauge kSentMessagesCount = Metrics.CreateGauge(
             "iiot_edge_publisher_sent_iot_messages",
             "IoT messages sent to hub", kGaugeConfig);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -198,12 +198,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
             string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages" + sinkBlockInputValues);
-            string egressDroppedPercent = _sinkBlockInputDroppedCount > 0 ? $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})" : "";
+            string egressDroppedPercent = _sinkBlockInputDroppedCount > 0 ? $" ({GetValuePercentage(_sinkBlockInputDroppedCount)})" : "";
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + egressDroppedPercent);
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";
             diagInfo.AppendLine("  v Egress IoT Hub sent                : {SentMessagesCount,14:n0} messages {sentMessagesPerSecFormatted}");
-            diagInfo.AppendLine("  # Calculated IoT Hub egress          : {estimatedNotificationsSent,14:n0} OPC values" + $" ({estimatedNotificationsSent / _messageTrigger.ValueChangesCount:P0})");
+            diagInfo.AppendLine("  # Calculated IoT Hub egress          : {estimatedNotificationsSent,14:n0} OPC values" + $" ({GetValuePercentage(estimatedNotificationsSent)})");
             diagInfo.AppendLine("  # Estimated IoT Hub usage            : {estimatedMsgChunksPerDay,14:n0} 4-KB chunks per day");
             diagInfo.AppendLine("  # Connection retries                 : {NumberOfConnectionRetries,14:0}");
 
@@ -298,6 +298,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 _batchDataSetMessageBlock.Post(args);
             }
         }
+
+        /// <summary>
+        /// Gets the percentage of a number of values
+        /// in relation the total ValueChanges.
+        /// </summary>
+        /// <param name="valueCount"></param>
+        private string GetValuePercentage(double valueCount) =>
+            $"{valueCount / _messageTrigger.ValueChangesCount:P0}";
 
         private readonly int _dataSetMessageBufferSize = 1;
         private readonly int _networkMessageBufferSize = 1;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -166,8 +166,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             double valueChangesPerSec = _messageTrigger.ValueChangesCount / totalDuration;
             double dataChangesPerSec = _messageTrigger.DataChangesCount / totalDuration;
             double sentMessagesPerSec = totalDuration > 0 ? _messageSink.SentMessagesCount / totalDuration : 0;
-            double messageSizeAveragePercent = Math.Round(_messageEncoder.AvgMessageSize / _maxEncodedMessageSize * 100);
-            string messageSizeAveragePercentFormatted = $"({messageSizeAveragePercent}%)";
+            string messageSizeAveragePercent = $"({_messageEncoder.AvgMessageSize / _maxEncodedMessageSize:P0})";
             double chunkSizeAverage = _messageEncoder.AvgMessageSize / (4 * 1024);
             double estimatedMsgChunksPerDay = Math.Ceiling(chunkSizeAverage) * sentMessagesPerSec * 60 * 60 * 24;
 
@@ -193,7 +192,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  | Encoder dropped                    : {notificationsDroppedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message        : {AvgNotificationsPerMessage,14:0} OPC values/message");
-            diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercentFormatted}");
+            diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercent}");
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
             string batchNetworkOutputValues = _batchNetworkMessageBlock.OutputCount > 0 ? $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
@@ -219,7 +218,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 _messageEncoder.NotificationsDroppedCount,
                 _messageEncoder.MessagesProcessedCount,
                 _messageEncoder.AvgNotificationsPerMessage,
-                _messageEncoder.AvgMessageSize, messageSizeAveragePercentFormatted,
+                _messageEncoder.AvgMessageSize, messageSizeAveragePercent,
                 chunkSizeAverage,
                 _batchNetworkMessageBlock.OutputCount, // batchNetworkMessageBlockOutputCount
                 _sinkBlock.InputCount, // sinkBlockInputCount

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)");
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
-            diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
+            diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";
             diagInfo.AppendLine("  v Egress IoT Hub sent                : {SentMessagesCount,14:n0} messages {sentMessagesPerSecFormatted}");

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -196,7 +196,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
             string batchNetworkOutputValues = _batchNetworkMessageBlock.OutputCount > 0 ? $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
-            diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
+            string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
+            diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages" + sinkBlockInputValues);
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB chunks");
             string batchNetworkOutputValues = _batchNetworkMessageBlock.OutputCount > 0 ? $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
-            string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values, {_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage / _messageTrigger.ValueChangesCount:P0})" : "";
+            string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages" + sinkBlockInputValues);
             string egressDroppedPercent = _sinkBlockInputDroppedCount > 0 ? $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})" : "";
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + egressDroppedPercent);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -187,14 +187,16 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  | Ingress OPC ValueChanges           : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
 
             diagInfo.AppendLine("  v Ingress BatchBlock queue           : {batchDataSetMessageBlockOutputCount,14:0} batches");
-            diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages" + $" (~{_encodingBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)");
+            string batchDataOutputValues = _encodingBlock.OutputCount > 0 ? $" (~{_encodingBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
+            diagInfo.AppendLine("  | Encoding block input | output queue: {encodingBlockInputCount,14:0} batches | {encodingBlockOutputCount:0} messages" + batchDataOutputValues);
             diagInfo.AppendLine("  | Encoder processed                  : {notificationsProcessedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder dropped                    : {notificationsDroppedCount,14:n0} OPC values");
             diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message        : {AvgNotificationsPerMessage,14:0} OPC values/message");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercentFormatted}");
             diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
-            diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)");
+            string batchNetworkOutputValues = _batchNetworkMessageBlock.OutputCount > 0 ? $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
+            diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages");
             diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -193,17 +193,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             diagInfo.AppendLine("  | Encoder IoT Hub processed          : {messagesProcessedCount,14:n0} messages");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message        : {AvgNotificationsPerMessage,14:0} OPC values/message");
             diagInfo.AppendLine("  | Encoder avg IoT Hub message body   : {AvgMessageSize,14:n0} bytes {messageSizeAveragePercent}");
-            diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB-chunks");
+            diagInfo.AppendLine("  v Encoder avg IoT Hub usage          : {chunkSizeAverage,14:0.#} 4-KB chunks");
             string batchNetworkOutputValues = _batchNetworkMessageBlock.OutputCount > 0 ? $" (~{_batchNetworkMessageBlock.OutputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
             diagInfo.AppendLine("  | Egress BatchBlock output queue     : {batchNetworkMessageBlockOutputCount,14:0} messages" + batchNetworkOutputValues);
-            string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values)" : "";
+            string sinkBlockInputValues = _sinkBlock.InputCount > 0 ? $" (~{_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage:n0} OPC values, {_sinkBlock.InputCount * _messageEncoder.AvgNotificationsPerMessage / _messageTrigger.ValueChangesCount:P0})" : "";
             diagInfo.AppendLine("  | Egress IoT Hub queue               : {sinkBlockInputCount,14:n0} messages" + sinkBlockInputValues);
-            diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})");
+            string egressDroppedPercent = _sinkBlockInputDroppedCount > 0 ? $" ({(double)_sinkBlockInputDroppedCount / _messageTrigger.ValueChangesCount:P0})" : "";
+            diagInfo.AppendLine("  | Egress dropped                     : {sinkBlockInputDroppedCount,14:n0} OPC values" + egressDroppedPercent);
 
             string sentMessagesPerSecFormatted = _messageSink.SentMessagesCount > 0 && totalDuration > 0 ? $"({sentMessagesPerSec:0.##}/s)" : "";
             diagInfo.AppendLine("  v Egress IoT Hub sent                : {SentMessagesCount,14:n0} messages {sentMessagesPerSecFormatted}");
             diagInfo.AppendLine("  # Calculated IoT Hub egress          : {estimatedNotificationsSent,14:n0} OPC values" + $" ({estimatedNotificationsSent / _messageTrigger.ValueChangesCount:P0})");
-            diagInfo.AppendLine("  # Estimated IoT Hub usage            : {estimatedMsgChunksPerDay,14:n0} 4-KB-chunks per day");
+            diagInfo.AppendLine("  # Estimated IoT Hub usage            : {estimatedMsgChunksPerDay,14:n0} 4-KB chunks per day");
             diagInfo.AppendLine("  # Connection retries                 : {NumberOfConnectionRetries,14:0}");
 
             _logger.Information(diagInfo.ToString(),

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/FileSystemMessageSink.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/FileSystemMessageSink.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     public class FileSystemMessageSink : IMessageSink {
 
         /// <inheritdoc/>
-        public long SentMessagesCount { get; private set; }
+        public ulong SentMessagesCount { get; private set; }
 
         /// <summary>
         /// Create sink

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IoTHubMessageSink.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IoTHubMessageSink.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     public class IoTHubMessageSink : IMessageSink, IDisposable {
 
         /// <inheritdoc/>
-        public long SentMessagesCount { get; private set; }
+        public ulong SentMessagesCount { get; private set; }
 
         /// <summary>
         /// Create IoT hub message sink
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     sw.Stop();
                     _logger.Verbose("Sent {count} messages in {time} to IoTHub.", messagesCount, sw.Elapsed);
                 }
-                SentMessagesCount += messagesCount;
+                SentMessagesCount += (ulong)messagesCount;
                 kMessagesSent.WithLabels(IotHubMessageSinkGuid, IotHubMessageSinkStartTime).Set(SentMessagesCount);
             }
             catch (Exception ex) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IoTHubMessageSink.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IoTHubMessageSink.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             return msg;
         }
 
-        private const long kMessageCounterResetThreshold = long.MaxValue - 10000;
+        private const ulong kMessageCounterResetThreshold = ulong.MaxValue - 10000;
         private readonly ILogger _logger;
         private readonly IClientAccessor _clientAccessor;
         private readonly string IotHubMessageSinkGuid = Guid.NewGuid().ToString();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Opc.Ua.PubSub;
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            var chunk = new List<MonitoredItemMessage>(notifications.Count());
+            var chunk = new Collection<MonitoredItemMessage>();
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;
@@ -177,7 +178,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            var chunk = new List<MonitoredItemMessage>(notifications.Count());
+            var chunk = new Collection<MonitoredItemMessage>();
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Opc.Ua.PubSub;
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -97,7 +96,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            var chunk = new Collection<MonitoredItemMessage>();
+            var chunk = new List<MonitoredItemMessage>(notifications.Count());
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;
@@ -178,7 +177,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            var chunk = new Collection<MonitoredItemMessage>();
+            var chunk = new List<MonitoredItemMessage>(notifications.Count());
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
     using Microsoft.Azure.IIoT.OpcUa.Protocol;
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
-    using Microsoft.Extensions.Logging;
     using Opc.Ua;
     using Opc.Ua.Encoders;
     using Opc.Ua.Extensions;
@@ -20,6 +19,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Serilog;
 
     /// <summary>
     /// Publisher monitored item message encoder
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
                         NotificationsDroppedCount++;
-                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
@@ -189,12 +189,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
                         NotificationsDroppedCount++;
-                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
                         messageCompleted = maxMessageSize < (messageSize + notificationSize);
-
                         if (!messageCompleted) {
                             chunk.Add(notification);
                             NotificationsProcessedCount++;
@@ -261,7 +260,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 if (encoded.Body.Length > maxMessageSize) {
                     // Message too large, drop it.
                     NotificationsDroppedCount++;
-                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                    _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount++;
@@ -305,7 +304,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 if (encoded.Body.Length > maxMessageSize) {
                     // Message too large, drop it.
                     NotificationsDroppedCount++;
-                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                    _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount++;
@@ -331,7 +330,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 // Declare all notifications in messages as dropped.
                 int totalNotifications = messages.Sum(m => m?.Notifications?.Count() ?? 0);
                 NotificationsDroppedCount += (uint)totalNotifications;
-                _logger.LogWarning("Namespace is empty, dropped {totalNotifications} values");
+                _logger.Warning("Namespace is empty, dropped {totalNotifications} values");
                 yield break;
             }
             foreach (var message in messages) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
     using Microsoft.Azure.IIoT.OpcUa.Protocol;
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
+    using Microsoft.Extensions.Logging;
     using Opc.Ua;
     using Opc.Ua.Encoders;
     using Opc.Ua.Extensions;
@@ -29,16 +30,24 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         public uint NotificationsDroppedCount { get; private set; }
 
         /// <inheritdoc/>
-        public uint NotificationsProcessedCount { get; private set; }
+        public ulong NotificationsProcessedCount { get; private set; }
 
         /// <inheritdoc/>
-        public uint MessagesProcessedCount { get; private set; }
+        public ulong MessagesProcessedCount { get; private set; }
 
         /// <inheritdoc/>
         public double AvgNotificationsPerMessage { get; private set; }
 
         /// <inheritdoc/>
         public double AvgMessageSize { get; private set; }
+
+        /// <inheritdoc/>
+        private readonly ILogger _logger;
+
+        /// <inheritdoc/>
+        public MonitoredItemMessageEncoder(ILogger logger) {
+            _logger = logger;
+        }
 
         /// <inheritdoc/>
         public Task<IEnumerable<NetworkMessageModel>> EncodeAsync(
@@ -88,7 +97,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            maxMessageSize -= 2048; // reserve 2k for header
             var chunk = new Collection<MonitoredItemMessage>();
             while (processing) {
                 var notification = current.Current;
@@ -104,9 +112,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     helperEncoder.Close();
                     var notificationSize = Encoding.UTF8.GetByteCount(helperWriter.ToString());
                     if (notificationSize > maxMessageSize) {
-                        // we cannot handle this notification. Drop it.
-                        // TODO Trace
+                        // Message too large, drop it.
                         NotificationsDroppedCount++;
+                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
@@ -170,7 +178,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            maxMessageSize -= 2048; // reserve 2k for header
             var chunk = new Collection<MonitoredItemMessage>();
             while (processing) {
                 var notification = current.Current;
@@ -180,9 +187,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     helperEncoder.WriteEncodeable(null, notification);
                     var notificationSize = helperEncoder.CloseAndReturnBuffer().Length;
                     if (notificationSize > maxMessageSize) {
-                        // we cannot handle this notification. Drop it.
-                        // TODO Trace
+                        // Message too large, drop it.
                         NotificationsDroppedCount++;
+                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
@@ -252,9 +259,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     MessageSchema = MessageSchemaTypes.MonitoredItemMessageJson
                 };
                 if (encoded.Body.Length > maxMessageSize) {
-                    // this message is too large to be processed. Drop it
-                    // TODO Trace
+                    // Message too large, drop it.
                     NotificationsDroppedCount++;
+                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount++;
@@ -296,9 +303,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     MessageSchema = MessageSchemaTypes.MonitoredItemMessageBinary
                 };
                 if (encoded.Body.Length > maxMessageSize) {
-                    // this message is too large to be processed. Drop it
-                    // TODO Trace
+                    // Message too large, drop it.
                     NotificationsDroppedCount++;
+                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount++;
@@ -321,10 +328,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             IEnumerable<DataSetMessageModel> messages, MessageEncoding encoding,
             ServiceMessageContext context) {
             if (context?.NamespaceUris == null) {
-                // declare all notifications in messages dropped 
-                foreach (var message in messages) {
-                    NotificationsDroppedCount += (uint)(message?.Notifications?.Count() ?? 0);
-                }
+                // Declare all notifications in messages as dropped.
+                int totalNotifications = messages.Sum(m => m?.Notifications?.Count() ?? 0);
+                NotificationsDroppedCount += (uint)totalNotifications;
+                _logger.LogWarning("Namespace is empty, dropped {totalNotifications} values");
                 yield break;
             }
             foreach (var message in messages) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Opc.Ua.PubSub;
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            var chunk = new List<NetworkMessage>();
+            var chunk = new Collection<NetworkMessage>();
             int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;
@@ -180,7 +181,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            var chunk = new List<NetworkMessage>(notifications.Count());
+            var chunk = new Collection<NetworkMessage>();
             int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Protocol;
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
-    using Microsoft.Extensions.Logging;
     using Opc.Ua;
     using Opc.Ua.Encoders;
     using Opc.Ua.Extensions;
@@ -21,6 +20,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Serilog;
 
     /// <summary>
     /// Creates pub/sub encoded messages
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
                         NotificationsDroppedCount += (uint)notificationsPerMessage;
-                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
                         NotificationsDroppedCount += (uint)notificationsPerMessage;
-                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 if (encoded.Body.Length > maxMessageSize) {
                     // Message too large, drop it.
                     NotificationsDroppedCount += (uint)notificationsPerMessage;
-                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                    _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount += (ulong)notificationsPerMessage;
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 if (encoded.Body.Length > maxMessageSize) {
                     // Message too large, drop it.
                     NotificationsDroppedCount += (uint)notificationsPerMessage;
-                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
+                    _logger.Warning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
                 NotificationsProcessedCount += (ulong)notificationsPerMessage;
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 // Declare all notifications in messages as dropped.
                 int totalNotifications = messages.Sum(m => m?.Notifications?.Count() ?? 0);
                 NotificationsDroppedCount += (uint)totalNotifications;
-                _logger.LogWarning("Namespace is empty, dropped {totalNotifications} values");
+                _logger.Warning("Namespace is empty, dropped {totalNotifications} values");
                 yield break;
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Opc.Ua.PubSub;
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Text;
@@ -97,7 +96,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            var chunk = new Collection<NetworkMessage>();
+            var chunk = new List<NetworkMessage>();
             int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;
@@ -181,7 +180,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            var chunk = new Collection<NetworkMessage>();
+            var chunk = new List<NetworkMessage>(notifications.Count());
             int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Protocol;
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
+    using Microsoft.Extensions.Logging;
     using Opc.Ua;
     using Opc.Ua.Encoders;
     using Opc.Ua.Extensions;
@@ -25,21 +26,28 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     /// Creates pub/sub encoded messages
     /// </summary>
     public class NetworkMessageEncoder : IMessageEncoder {
-
         /// <inheritdoc/>
         public uint NotificationsDroppedCount { get; private set; }
 
         /// <inheritdoc/>
-        public uint NotificationsProcessedCount { get; private set; }
+        public ulong NotificationsProcessedCount { get; private set; }
 
         /// <inheritdoc/>
-        public uint MessagesProcessedCount { get; private set; }
+        public ulong MessagesProcessedCount { get; private set; }
 
         /// <inheritdoc/>
         public double AvgNotificationsPerMessage { get; private set; }
 
         /// <inheritdoc/>
         public double AvgMessageSize { get; private set; }
+
+        /// <inheritdoc/>
+        private readonly ILogger _logger;
+
+        /// <inheritdoc/>
+        public NetworkMessageEncoder(ILogger logger) {
+            _logger = logger;
+        }
 
         /// <inheritdoc/>
         public Task<IEnumerable<NetworkMessageModel>> EncodeAsync(
@@ -89,9 +97,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 2; // array brackets
-            maxMessageSize -= 2048; // reserve 2k for header
             var chunk = new Collection<NetworkMessage>();
-            ulong notificationsPerMessage = 0;
+            int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;
@@ -105,18 +112,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     notification.Encode(helperEncoder);
                     helperEncoder.Close();
                     var notificationSize = Encoding.UTF8.GetByteCount(helperWriter.ToString());
+                    notificationsPerMessage = notification.Messages.Sum(m => m.Payload.Count);
                     if (notificationSize > maxMessageSize) {
-                        // we cannot handle this notification. Drop it.
-                        // TODO Trace
-                        NotificationsDroppedCount++;
+                        // Message too large, drop it.
+                        NotificationsDroppedCount += (uint)notificationsPerMessage;
+                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
                         messageCompleted = maxMessageSize < (messageSize + notificationSize);
                         if (!messageCompleted) {
-                            NotificationsProcessedCount++;
                             chunk.Add(notification);
-                            notificationsPerMessage += (ulong)notification.Messages.Sum(m => m.Payload.Count);
+                            NotificationsProcessedCount += (ulong)notificationsPerMessage;
                             processing = current.MoveNext();
                             messageSize += notificationSize + (processing ? 1 : 0);
                         }
@@ -130,7 +137,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         UseUriEncoding = true,
                         UseReversibleEncoding = false
                     };
-                    foreach(var element in chunk) { 
+                    foreach (var element in chunk) {
                         encoder.WriteEncodeable(null, element);
                     }
                     encoder.Close();
@@ -145,7 +152,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         (MessagesProcessedCount + 1);
                     AvgNotificationsPerMessage = (AvgNotificationsPerMessage * MessagesProcessedCount +
                         notificationsPerMessage) / (MessagesProcessedCount + 1);
-                        MessagesProcessedCount++;
+                    MessagesProcessedCount++;
                     chunk.Clear();
                     messageSize = 2;
                     notificationsPerMessage = 0;
@@ -174,9 +181,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             var current = notifications.GetEnumerator();
             var processing = current.MoveNext();
             var messageSize = 4; // array length size
-            maxMessageSize -= 2048; // reserve 2k for header
             var chunk = new Collection<NetworkMessage>();
-            ulong notificationsPerMessage = 0;
+            int notificationsPerMessage = 0;
             while (processing) {
                 var notification = current.Current;
                 var messageCompleted = false;
@@ -184,19 +190,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     var helperEncoder = new BinaryEncoder(encodingContext);
                     helperEncoder.WriteEncodeable(null, notification);
                     var notificationSize = helperEncoder.CloseAndReturnBuffer().Length;
+                    notificationsPerMessage = notification.Messages.Sum(m => m.Payload.Count);
                     if (notificationSize > maxMessageSize) {
-                        // we cannot handle this notification. Drop it.
-                        // TODO Trace
-                        NotificationsDroppedCount++;
+                        // Message too large, drop it.
+                        NotificationsDroppedCount += (uint)notificationsPerMessage;
+                        _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                         processing = current.MoveNext();
                     }
                     else {
                         messageCompleted = maxMessageSize < (messageSize + notificationSize);
-
                         if (!messageCompleted) {
                             chunk.Add(notification);
-                            notificationsPerMessage += (ulong)notification.Messages.Sum(m => m.Payload.Count);
-                            NotificationsProcessedCount++;
+                            NotificationsProcessedCount += (ulong)notificationsPerMessage;
                             processing = current.MoveNext();
                             messageSize += notificationSize;
                         }
@@ -243,7 +248,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 yield break;
             }
             foreach (var networkMessage in notifications) {
-                ulong notificationsPerMessage = (ulong)networkMessage.Messages.Sum(m => m.Payload.Count);
+                int notificationsPerMessage = networkMessage.Messages.Sum(m => m.Payload.Count);
                 var writer = new StringWriter();
                 var encoder = new JsonEncoderEx(writer, encodingContext) {
                     UseAdvancedEncoding = true,
@@ -260,12 +265,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     MessageSchema = MessageSchemaTypes.NetworkMessageJson
                 };
                 if (encoded.Body.Length > maxMessageSize) {
-                    // this message is too large to be processed. Drop it
-                    // TODO Trace
-                    NotificationsDroppedCount++;
+                    // Message too large, drop it.
+                    NotificationsDroppedCount += (uint)notificationsPerMessage;
+                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
-                NotificationsProcessedCount++;
+                NotificationsProcessedCount += (ulong)notificationsPerMessage;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /
                     (MessagesProcessedCount + 1);
                 AvgNotificationsPerMessage = (AvgNotificationsPerMessage * MessagesProcessedCount + notificationsPerMessage) /
@@ -294,7 +299,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             }
 
             foreach (var networkMessage in notifications) {
-                ulong notificationsPerMessage = (ulong)networkMessage.Messages.Sum(m => m.Payload.Count);
+                int notificationsPerMessage = networkMessage.Messages.Sum(m => m.Payload.Count);
                 var encoder = new BinaryEncoder(encodingContext);
                 encoder.WriteBoolean(null, false); // is not Batch
                 encoder.WriteEncodeable(null, networkMessage);
@@ -306,12 +311,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     MessageSchema = MessageSchemaTypes.NetworkMessageUadp
                 };
                 if (encoded.Body.Length > maxMessageSize) {
-                    // this message is too large to be processed. Drop it
-                    // TODO Trace
-                    NotificationsDroppedCount++;
+                    // Message too large, drop it.
+                    NotificationsDroppedCount += (uint)notificationsPerMessage;
+                    _logger.LogWarning("Message too large, dropped {notificationsPerMessage} values");
                     yield break;
                 }
-                NotificationsProcessedCount++;
+                NotificationsProcessedCount += (ulong)notificationsPerMessage;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /
                     (MessagesProcessedCount + 1);
                 AvgNotificationsPerMessage = (AvgNotificationsPerMessage * MessagesProcessedCount + notificationsPerMessage) /
@@ -332,10 +337,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             IEnumerable<DataSetMessageModel> messages, MessageEncoding encoding,
             ServiceMessageContext context) {
             if (context?.NamespaceUris == null) {
-                // declare all notifications in messages dropped 
-                foreach (var message in messages) {
-                    NotificationsDroppedCount += (uint)(message?.Notifications?.Count() ?? 0);
-                }
+                // Declare all notifications in messages as dropped.
+                int totalNotifications = messages.Sum(m => m?.Notifications?.Count() ?? 0);
+                NotificationsDroppedCount += (uint)totalNotifications;
+                _logger.LogWarning("Namespace is empty, dropped {totalNotifications} values");
                 yield break;
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             Subscription?.NumberOfConnectionRetries ?? 0;
 
         /// <inheritdoc/>
-        public int ValueChangesCount { get; private set; } = 0;
+        public ulong ValueChangesCount { get; private set; } = 0;
 
         /// <inheritdoc/>
-        public int DataChangesCount { get; private set; } = 0;
+        public ulong DataChangesCount { get; private set; } = 0;
 
         /// <inheritdoc/>
         public event EventHandler<DataSetMessageModel> OnMessage;
@@ -286,7 +286,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                             _outer.ValueChangesCount = 0;
                         }
 
-                        _outer.ValueChangesCount += message.Notifications.Count();
+                        _outer.ValueChangesCount += (ulong)message.Notifications.Count();
                         _outer.DataChangesCount++;
                         _outer.OnMessage?.Invoke(sender, message);
                     }
@@ -312,6 +312,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private readonly List<DataSetWriterSubscription> _subscriptions;
         private readonly WriterGroupModel _writerGroup;
         private readonly ISubscriptionManager _subscriptionManager;
-        private const int kNumberOfInvokedMessagesResetThreshold = int.MaxValue - 10000;
+        private const ulong kNumberOfInvokedMessagesResetThreshold = ulong.MaxValue - 10000;
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 DiagnosticsInterval = model.Engine?.DiagnosticsInterval,
                 WriterGroup = model.WriterGroup,
                 MaxMessageSize = model.Engine?.MaxMessageSize,
-                MaxOutgressMessages = model.Engine?.MaxOutgressMessages
+                MaxEgressMessageQueue = model.Engine?.MaxOutgressMessages
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 DiagnosticsInterval = model.Engine?.DiagnosticsInterval,
                 WriterGroup = model.WriterGroup,
                 MaxMessageSize = model.Engine?.MaxMessageSize,
-                MaxEgressMessageQueue = model.Engine?.MaxOutgressMessages
+                MaxEgressMessageQueue = model.Engine?.MaxEgressMessageQueue
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
 
         /// <summary>
         /// Maximum size of egress message queue
-        /// Default: 8192 messages @ 256 KB = 2 GB of memory.
         /// </summary>
         int? MaxEgressMessageQueue { get; }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
         TimeSpan? BatchTriggerInterval { get; }
 
         /// <summary>
-        /// Maximum mesage size for the encoded messages 
+        /// Maximum mesage size for the encoded messages
         /// typically the IoT Hub's mas D2C message size
         /// </summary>
         int? MaxMessageSize { get; }
@@ -33,9 +33,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
         TimeSpan? DiagnosticsInterval { get; }
 
         /// <summary>
-        /// Define the maximum number of messages in outgress buffer, 
-        /// Default: 200 messages with 256KB ends 
-        /// up in 50 MB memory consumed
+        /// Maximum size of egress message queue
+        /// Default: 8192 messages @ 256 KB = 2 GB of memory.
         /// </summary>
         int? MaxEgressMessageQueue { get; }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IEngineConfiguration.cs
@@ -37,6 +37,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
         /// Default: 200 messages with 256KB ends 
         /// up in 50 MB memory consumed
         /// </summary>
-        int? MaxOutgressMessages { get; }
+        int? MaxEgressMessageQueue { get; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageEncoder.cs
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         /// <summary>
         /// Number of successfully processed notifications from OPC client
         /// </summary>
-        uint NotificationsProcessedCount { get; }
+        ulong NotificationsProcessedCount { get; }
 
         /// <summary>
         /// Number of successfully processed messages
         /// </summary>
-        uint MessagesProcessedCount { get; }
+        ulong MessagesProcessedCount { get; }
 
         /// <summary>
         /// Average notifications in a message

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageSink.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageSink.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         /// <summary>
         /// Messages sent so far
         /// </summary>
-        long SentMessagesCount { get; }
+        ulong SentMessagesCount { get; }
 
         /// <summary>
         /// Send network message

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
@@ -28,13 +28,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         /// The number of all monitored items value changes
         /// that have been invoked by this message source.
         /// </summary>
-        int ValueChangesCount { get; }
+        ulong ValueChangesCount { get; }
 
         /// <summary>
-        /// The number of all dataChange Notifications 
+        /// The number of all dataChange Notifications
         /// that have been invoked by this message source.
         /// </summary>
-        int DataChangesCount { get; }
+        ulong DataChangesCount { get; }
 
         /// <summary>
         /// Writer events

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/LegacyCliModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/LegacyCliModel.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
         public int? MaxMessageSize { get; set; }
 
         /// <summary>
-        /// Define the maximum amount of the IoT D2C messages
+        /// Maximum size of the IoT D2C egress message queue.
         /// </summary>
-        public int? MaxOutgressMessages { get; set; }
+        public int? MaxEgressMessageQueue { get; set; }
 
         /// <summary>
         /// The time to flush the log file to the disc.

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Runtime {
 
         /// <inheritdoc/>
         public string PublisherId { get; set; }
-        
+
         /// <inheritdoc/>
         public int? MaxEgressMessageQueue { get; set; }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
@@ -33,6 +33,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Runtime {
         public string PublisherId { get; set; }
         
         /// <inheritdoc/>
-        public int? MaxOutgressMessages { get; set; }
+        public int? MaxEgressMessageQueue { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                             BatchTriggerInterval = _config.BatchTriggerInterval,
                             DiagnosticsInterval = _config.DiagnosticsInterval,
                             MaxMessageSize = _config.MaxMessageSize,
-                            MaxOutgressMessages = _config.MaxOutgressMessages
+                            MaxOutgressMessages = _config.MaxEgressMessageQueue
                         },
                         WriterGroup = new WriterGroupModel {
                             MessageType = legacyCliModel.MessageEncoding,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                             BatchTriggerInterval = _config.BatchTriggerInterval,
                             DiagnosticsInterval = _config.DiagnosticsInterval,
                             MaxMessageSize = _config.MaxMessageSize,
-                            MaxOutgressMessages = _config.MaxEgressMessageQueue
+                            MaxEgressMessageQueue = _config.MaxEgressMessageQueue
                         },
                         WriterGroup = new WriterGroupModel {
                             MessageType = legacyCliModel.MessageEncoding,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -49,15 +49,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
         });
 
         /// <summary>
-        /// Read default max outgress message buffer size from environment
+        /// Read default max egress message queue size from environment
         /// </summary>
-        internal Lazy<int> DefaultMaxOutgressMessages => new Lazy<int>(() => {
+        internal Lazy<int> DefaultMaxEgressMessageQueue => new Lazy<int>(() => {
             var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_MAX_OUTGRESS_MESSAGES");
-            if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var maxOutgressMessages) &&
-                maxOutgressMessages > 1 && maxOutgressMessages <= 25000) {
-                return maxOutgressMessages;
+            if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var maxEgressMessageQueue) &&
+                maxEgressMessageQueue > 1 && maxEgressMessageQueue <= 25000) {
+                return maxEgressMessageQueue;
             }
-            return 200; //default
+            return 8192; // Default (8192 * 256 KB = 2 GB).
         });
 
         /// <summary>
@@ -274,13 +274,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                             BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                             DiagnosticsInterval = TimeSpan.FromSeconds(60),
                             MaxMessageSize = 0,
-                            MaxOutgressMessages = DefaultMaxOutgressMessages.Value
+                            MaxEgressMessageQueue = DefaultMaxEgressMessageQueue.Value
                     };
                     }
                     else {
                         publishJob.Engine.BatchTriggerInterval = DefaultBatchTriggerInterval.Value;
                         publishJob.Engine.BatchSize = DefaultBatchSize.Value;
-                        publishJob.Engine.MaxOutgressMessages = DefaultMaxOutgressMessages.Value;
+                        publishJob.Engine.MaxEgressMessageQueue = DefaultMaxEgressMessageQueue.Value;
                     }
                     return publishJob;
                 }
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                     BatchTriggerInterval = DefaultBatchTriggerInterval.Value,
                     DiagnosticsInterval = TimeSpan.FromSeconds(60),
                     MaxMessageSize = 0,
-                    MaxOutgressMessages = DefaultMaxOutgressMessages.Value
+                    MaxEgressMessageQueue = DefaultMaxEgressMessageQueue.Value
         },
                 ConnectionString = null
             };

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
                 maxEgressMessageQueue > 1 && maxEgressMessageQueue <= 25000) {
                 return maxEgressMessageQueue;
             }
-            return 8192; // Default (8192 * 256 KB = 2 GB).
+            return 4096; // Default (4096 * 256 KB = 1 GB).
         });
 
         /// <summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Clients {
         /// Read default max egress message queue size from environment
         /// </summary>
         internal Lazy<int> DefaultMaxEgressMessageQueue => new Lazy<int>(() => {
-            var env = Environment.GetEnvironmentVariable("PCS_DEFAULT_PUBLISH_MAX_OUTGRESS_MESSAGES");
+            var env = Environment.GetEnvironmentVariable(PcsVariable.PCS_MAX_EGRESS_MESSAGE_QUEUE);
             if (!string.IsNullOrEmpty(env) && int.TryParse(env, out var maxEgressMessageQueue) &&
                 maxEgressMessageQueue > 1 && maxEgressMessageQueue <= 25000) {
                 return maxEgressMessageQueue;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 BatchTriggerInterval = model.BatchTriggerInterval,
                 DiagnosticsInterval = model.DiagnosticsInterval,
                 MaxMessageSize = model.MaxMessageSize,
-                MaxOutgressMessages = model.MaxOutgressMessages
+                MaxEgressMessageQueue = model.MaxEgressMessageQueue
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
@@ -32,10 +32,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         public TimeSpan? DiagnosticsInterval { get; set; }
 
         /// <summary>
-        /// Define the maximum size of outgress message buffer
-        /// Default: 200 messages with 256KB ends 
-        /// up in 50 MB memory consumed
+        /// Maximum size of egress message queue
+        /// Default: 8192 messages @ 256 KB = 2 GB of memory.
         /// </summary>
-        public int? MaxOutgressMessages { get; set; }
+        public int? MaxEgressMessageQueue { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/EngineConfigurationModel.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
 
         /// <summary>
         /// Maximum size of egress message queue
-        /// Default: 8192 messages @ 256 KB = 2 GB of memory.
         /// </summary>
         public int? MaxEgressMessageQueue { get; set; }
     }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// Flag to demand full featured message creation from publisher
         /// </summary>
         public const string FullFeaturedMessage = "FullFeaturedMessage";
-        
+
         /// <summary>
         /// Key for the default sampling interval in milliseconds.
         /// </summary>
@@ -93,14 +93,14 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public const string BatchTriggerInterval = "BatchTriggerInterval";
 
         /// <summary>
-        /// Key for the max (IoT Hub D2C)message size 
+        /// Key for the max (IoT Hub D2C)message size
         /// </summary>
         public const string MaxMessageSize = "MaxMessageSize";
 
         /// <summary>
-        /// Key for the max (IoT Hub D2C) messages
+        /// Key for the max (IoT Hub D2C) egress message queue.
         /// </summary>
-        public const string MaxOutgressMessages = "MaxOutgressMessages";
+        public const string MaxEgressMessageQueue = "MaxEgressMessageQueue";
 
         /// <summary>
         /// Key for the scale test monitored items clones count .

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         "event setting of nodes without a skip first event setting.",
                         (bool b) => this[LegacyCliConfigKeys.SkipFirstDefault] = b.ToString() },
 
-                    { "fm|fullfeaturedmessage=", "The full featured mode for messages (all fields filled in)." + 
+                    { "fm|fullfeaturedmessage=", "The full featured mode for messages (all fields filled in)." +
                         "Default is 'true', for legacy compatibility use 'false'",
                         (bool b) => this[LegacyCliConfigKeys.FullFeaturedMessage] = b.ToString() },
 
@@ -144,8 +144,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         (int k) => this[LegacyCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
                     { "ms|iothubmessagesize=", "The maximum size of the (IoT D2C) message.",
                         (int i) => this[LegacyCliConfigKeys.MaxMessageSize] = i.ToString() },
-                    { "om|maxoutgressmessages=", "The maximum size of the (IoT D2C) message outgress buffer",
-                        (int i) => this[LegacyCliConfigKeys.MaxOutgressMessages] = i.ToString() },
+                    { "em|maxegressmessagequeue=", "The maximum size of the (IoT D2C) message egress queue.",
+                        (int i) => this[LegacyCliConfigKeys.MaxEgressMessageQueue] = i.ToString() },
 
                     // testing purposes
                     { "sc|scaletestcount=", "The number of monitored item clones in scale tests.",
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
 #pragma warning restore 67
 
         /// <summary>
-        /// The batch size 
+        /// The batch size
         /// </summary>
         public int? BatchSize => LegacyCliModel.BatchSize;
 
@@ -228,14 +228,14 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public TimeSpan? DiagnosticsInterval => LegacyCliModel.DiagnosticsInterval;
 
         /// <summary>
-        /// the Maximum (IoT D2C) message size 
+        /// the Maximum (IoT D2C) message size
         /// </summary>
         public int? MaxMessageSize => LegacyCliModel.MaxMessageSize;
 
         /// <summary>
         /// The Maximum (IoT D2C) message buffer size
         /// </summary>
-        public int? MaxEgressMessageQueue => LegacyCliModel.MaxOutgressMessages;
+        public int? MaxEgressMessageQueue => LegacyCliModel.MaxEgressMessageQueue;
 
         /// <summary>
         /// The model of the CLI arguments.
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 BatchTriggerInterval = GetValueOrDefault<TimeSpan>(LegacyCliConfigKeys.BatchTriggerInterval, TimeSpan.FromSeconds(10)),
                 MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.MaxMessageSize, 0),
                 ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, 1),
-                MaxOutgressMessages = GetValueOrDefault(LegacyCliConfigKeys.MaxOutgressMessages, 200)
+                MaxEgressMessageQueue = GetValueOrDefault(LegacyCliConfigKeys.MaxEgressMessageQueue, 8192) // 8192 * 256 KB = 2 GB.
             };
         }
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 BatchTriggerInterval = GetValueOrDefault<TimeSpan>(LegacyCliConfigKeys.BatchTriggerInterval, TimeSpan.FromSeconds(10)),
                 MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.MaxMessageSize, 0),
                 ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, 1),
-                MaxEgressMessageQueue = GetValueOrDefault(LegacyCliConfigKeys.MaxEgressMessageQueue, 8192) // 8192 * 256 KB = 2 GB.
+                MaxEgressMessageQueue = GetValueOrDefault(LegacyCliConfigKeys.MaxEgressMessageQueue, 4096) // 4096 * 256 KB = 1 GB.
             };
         }
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// The Maximum (IoT D2C) message buffer size
         /// </summary>
-        public int? MaxOutgressMessages => LegacyCliModel.MaxOutgressMessages;
+        public int? MaxEgressMessageQueue => LegacyCliModel.MaxOutgressMessages;
 
         /// <summary>
         /// The model of the CLI arguments.


### PR DESCRIPTION
* Reformat diag info for easier readability and consistency
* Added units to diag info values
* Corrected term "outgress" to "egress" including option em|maxegressmessagequeue
* Changed default egress queue from 20 (max 50 MB) to 8192 (max 2 GB), as it behaved better during local debugging in VS, otherwise too many messages are dropped
* Some cosmetic improvements

![image](https://user-images.githubusercontent.com/1353540/89899845-2602d380-dbe3-11ea-81bd-478493960678.png)
