### PR TITLE
Temporary fix for SDL Task.

### DIFF
--- a/tools/templates/sdl.yml
+++ b/tools/templates/sdl.yml
@@ -14,7 +14,8 @@ jobs:
     displayName: 'Install .NET Core SDK'
     inputs:
       packageType: sdk
-      version: 3.1.x
+      # temporary fix. need to revert back to 3.1.x
+      version: 3.1.302
       includePreviewVersions: false
       installationPath: $(Agent.ToolsDirectory)/dotnet
   - task: PowerShell@2


### PR DESCRIPTION
Hard-coded .NET version as `3.1.302` for SDL Task. Need to revert change back to `3.1.x` after [this](https://developercommunity.visualstudio.com/content/problem/1145815/net-coremsbuild-tooling-not-finding-right-version.html) bug is fixed.
