### PR TITLE
bind mounts for layered Iot Edge deployments

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Deploy/IoTHubPublisherDeployment.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Deploy/IoTHubPublisherDeployment.cs
@@ -89,19 +89,35 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Deploy {
                 createOptions = _serializer.SerializeToString(new {
                     Hostname = "publisher",
                     Cmd = new[] {
-                    "--aa"
+                        "PkiRootPath=/mount/pki",
+                        "--aa"
+                    },
+                    HostConfig = new {
+                        Binds = new [] {
+                            "/mount:/mount"
+                        }
                     }
                 }).Replace("\"", "\\\"");
-            } else {
+            }
+            else {
                 createOptions = _serializer.SerializeToString(new {
                     User = "ContainerAdministrator",
                     Hostname = "publisher",
                     Cmd = new[] {
-                    "--aa"
-                }
+                        "PkiRootPath=/mount/pki",
+                        "--aa"
+                    },
+                    HostConfig = new {
+                        Mounts = new[] {
+                            new {
+                                Type = "bind",
+                                Source = "C:\\\\ProgramData\\\\iotedge",
+                                Target = "C:\\\\mount"
+                            }
+                        }
+                    }
                 }).Replace("\"", "\\\"");
             }
-
 
             var server = string.IsNullOrEmpty(_config.DockerServer) ?
                 "mcr.microsoft.com" : _config.DockerServer;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Deploy/IoTHubDiscovererDeployment.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Deploy/IoTHubDiscovererDeployment.cs
@@ -91,6 +91,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Deploy {
             if (isLinux) {
                 // Linux
                 createOptions = _serializer.SerializeToString(new {
+                    Hostname = "discovery",
+                    Cmd = new[] {
+                        "PkiRootPath=/mount/pki"
+                    },
                     NetworkingConfig = new {
                         EndpointsConfig = new {
                             host = new {
@@ -99,16 +103,30 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Deploy {
                     },
                     HostConfig = new {
                         NetworkMode = "host",
-                        CapAdd = new[] { "NET_ADMIN" }
-                    },
-                    Hostname = "discovery"
+                        CapAdd = new[] { "NET_ADMIN" },
+                        Binds = new[] {
+                            "/mount:/mount"
+                        }
+                    }
                 });
             }
             else {
                 // Windows
                 createOptions = _serializer.SerializeToString(new {
                     User = "ContainerAdministrator",
-                    Hostname = "discovery"
+                    Hostname = "discovery",
+                    Cmd = new[] {
+                        "PkiRootPath=/mount/pki",
+                    },
+                    HostConfig = new {
+                        Mounts = new[] {
+                            new {
+                                Type = "bind",
+                                Source = "C:\\\\ProgramData\\\\iotedge",
+                                Target = "C:\\\\mount"
+                            }
+                        }
+                    }
                 });
             }
             createOptions = createOptions.Replace("\"", "\\\"");

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/src/Deploy/IoTHubSupervisorDeployment.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/src/Deploy/IoTHubSupervisorDeployment.cs
@@ -82,20 +82,39 @@ namespace Microsoft.Azure.IIoT.OpcUa.Twin.Deploy {
                 ";
             }
 
-
             // Configure create options per os specified
             string createOptions;
             if (isLinux) {
                 // Linux
                 createOptions = _serializer.SerializeToString(new {
-                    Hostname = "twin"
+                    Hostname = "twin",
+                    Cmd = new[] {
+                        "PkiRootPath=/mount/pki"
+                    },
+                    HostConfig = new {
+                        Binds = new[] {
+                            "/mount:/mount"
+                        }
+                    }
                 });
             }
             else {
                 // Windows
                 createOptions = _serializer.SerializeToString(new {
                     User = "ContainerAdministrator",
-                    Hostname = "twin"
+                    Hostname = "twin",
+                    Cmd = new[] {
+                        "PkiRootPath=/mount/pki",
+                    },
+                    HostConfig = new {
+                        Mounts = new[] {
+                            new {
+                                Type = "bind",
+                                Source = "C:\\\\ProgramData\\\\iotedge",
+                                Target = "C:\\\\mount"
+                            }
+                        }
+                    }
                 });
             }
             createOptions = createOptions.Replace("\"", "\\\"");


### PR DESCRIPTION
* added host bind mounts for layered IoT Edge deployments
* the PkiRootPath is set to the same mount storage for all edge modules so that the modules can share the same pki store