### PR TITLE
Reactivate transparent gateway mode

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Default/IoTSdkFactory.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Default/IoTSdkFactory.cs
@@ -73,6 +73,12 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Client {
                     deviceId = _cs.DeviceId;
                     moduleId = _cs.ModuleId;
                     ehubHost = _cs.GatewayHostName ?? ehubHost;
+
+                    if (string.IsNullOrWhiteSpace(_cs.GatewayHostName) && !string.IsNullOrWhiteSpace(ehubHost)) {
+                        _cs = IotHubConnectionStringBuilder.Create(
+                            config.EdgeHubConnectionString + ";GatewayHostName=" + ehubHost);
+                    }
+
                 }
             }
             catch (Exception e) {


### PR DESCRIPTION
Applying changes by @koepalex in this [PR](https://github.com/Azure/Industrial-IoT/pull/694) on `master`.

Changes:
* Extend ConnectionString to handle GatewayHostName
* Revert "Extend ConnectionString to handle GatewayHostName": This reverts commit 00593ad625a42b2b0b8ee06bc61cbae9414659ae.
* Quickfix - adding gateway host name to connection string if set via environment variable
* Set GatewayHostName only if not already contained in connection string