### PR TITLE
Revert param and env name for compat with 2.7.183

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Abstractions/src/PcsVariable.cs
+++ b/common/src/Microsoft.Azure.IIoT.Abstractions/src/PcsVariable.cs
@@ -294,6 +294,6 @@ namespace Microsoft.Azure.IIoT {
             "PCS_LOGS_PATH";
         /// <summary> The maximum size of the (IoT D2C) message egress queue </summary>
         public const string PCS_MAX_EGRESS_MESSAGE_QUEUE =
-            "PCS_DEFAULT_PUBLISH_MAX_EGRESS_MESSAGE_QUEUE";
+            "PCS_DEFAULT_PUBLISH_MAX_OUTGRESS_MESSAGES";
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         (int k) => this[LegacyCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
                     { "ms|iothubmessagesize=", "The maximum size of the (IoT D2C) message.",
                         (int i) => this[LegacyCliConfigKeys.MaxMessageSize] = i.ToString() },
-                    { "em|maxegressmessagequeue=", "The maximum size of the (IoT D2C) message egress queue.",
+                    { "om|maxoutgressmessages=", "The maximum size of the (IoT D2C) message egress queue.",
                         (int i) => this[LegacyCliConfigKeys.MaxEgressMessageQueue] = i.ToString() },
 
                     // testing purposes


### PR DESCRIPTION
* Revert egress to outgress in param name and environment variable to avoid breaking change with 2.7.180/183
* Egress wording stays otherwise