### PR TITLE
Using same API version as client SDKs.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Client/IoTHubHttpClientBase.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Client/IoTHubHttpClientBase.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.IIoT.Hub.Client {
             }
         }
 
-        private const string kApiVersion = "2020-03-01";
+        private const string kApiVersion = "2020-03-13";
         private const string kClientId = "AzureIIoT";
 
         /// <summary>Max retry count</summary>


### PR DESCRIPTION
Using same API version as client SDKs.

This is to fix the error that we saw in North Europe and later in Southeast Asia that cause IoT Hub REST API calls to return with the following error:

```
{
  "Message":"ErrorCode:InvalidProtocolVersion;BadRequest",
  "ExceptionMessage":"Tracking ID:113a1b7dd04946059412a08842d2be71-G:6-TimeStamp:09/07/2020 14:46:08"
}
```