### PR TITLE
Changed HttpClient class to throw HttpRequestException on timeout.

### DIFF
--- a/Industrial-IoT.sln
+++ b/Industrial-IoT.sln
@@ -238,7 +238,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cli", "cli", "{77FE1A6E-074
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.Services.Processor.Onboarding", "services\src\Microsoft.Azure.IIoT.Services.Processor.Onboarding\src\Microsoft.Azure.IIoT.Services.Processor.Onboarding.csproj", "{422C4B02-BC9F-4494-893F-7214F8FB17E1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.IIoT.OpcUa.Twin.Test", "components\opc-ua\src\Microsoft.Azure.IIoT.OpcUa.Twin\tests\Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj", "{6F5D5CE2-57A3-4116-8A82-72120C9461C6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.OpcUa.Twin.Tests", "components\opc-ua\src\Microsoft.Azure.IIoT.OpcUa.Twin\tests\Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj", "{6F5D5CE2-57A3-4116-8A82-72120C9461C6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.Agent.Framework.Tests", "common\src\Microsoft.Azure.IIoT.Agent.Framework\tests\Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj", "{63F1C41D-6D07-4F0D-967C-CBF3752139A0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -992,6 +994,14 @@ Global
 		{6F5D5CE2-57A3-4116-8A82-72120C9461C6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6F5D5CE2-57A3-4116-8A82-72120C9461C6}.Release|x64.ActiveCfg = Release|Any CPU
 		{6F5D5CE2-57A3-4116-8A82-72120C9461C6}.Release|x64.Build.0 = Release|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1108,6 +1118,7 @@ Global
 		{77FE1A6E-0741-4B3E-AC22-89164498E8AA} = {30938473-53C1-4981-BFAB-B6309147FF24}
 		{422C4B02-BC9F-4494-893F-7214F8FB17E1} = {ADB416A3-C375-4362-B2C0-3A35DA4CB5F8}
 		{6F5D5CE2-57A3-4116-8A82-72120C9461C6} = {1266F300-8BD2-4F1E-BA88-911F5F3AC36C}
+		{63F1C41D-6D07-4F0D-967C-CBF3752139A0} = {BBEE26AC-8733-469B-B816-0A54EA99FC59}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F09EFCEA-59F6-4A16-9CB6-7E865A3F62D8}

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IJobOrchestratorEndpointConfig.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IJobOrchestratorEndpointConfig.cs
@@ -4,15 +4,21 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
+    using System;
 
     /// <summary>
     /// Configuration of job orchestrator api endpoint
     /// </summary>
-    public interface IJobOrchestratorEndpoint {
+    public interface IJobOrchestratorEndpointConfig {
 
         /// <summary>
         /// Returns job orchestrator url
         /// </summary>
         string JobOrchestratorUrl { get; }
+
+        /// <summary>
+        /// Job orchestrator URL synchronization interval
+        /// </summary>
+        TimeSpan JobOrchestratorUrlSyncInterval { get; }
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Jobs/Hub/JobOrchestratorEndpointSync.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Jobs/Hub/JobOrchestratorEndpointSync.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -21,12 +21,12 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
         /// Create writer
         /// </summary>
         /// <param name="twins"></param>
-        /// <param name="endpoint"></param>
+        /// <param name="config"></param>
         /// <param name="serializer"></param>
         /// <param name="logger"></param>
         public JobOrchestratorEndpointSync(IIoTHubTwinServices twins,
-            IJobOrchestratorEndpoint endpoint, IJsonSerializer serializer, ILogger logger) {
-            _endpoint = endpoint ?? throw new ArgumentNullException(nameof(endpoint));
+            IJobOrchestratorEndpointConfig config, IJsonSerializer serializer, ILogger logger) {
+            _config = config ?? throw new ArgumentNullException(nameof(config));
             _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
             _twins = twins ?? throw new ArgumentNullException(nameof(twins));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -36,7 +36,13 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
         /// <inheritdoc/>
         public void Dispose() {
             Try.Async(StopAsync).Wait();
+
             _updateTimer.Dispose();
+
+            // _cts might be null if StartAsync() was never called.
+            if (!(_cts is null)) {
+                _cts.Dispose();
+            }
         }
 
         /// <inheritdoc/>
@@ -52,8 +58,13 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
         public Task StopAsync() {
             if (_cts != null) {
                 _cts.Cancel();
-                _updateTimer.Change(0, Timeout.Infinite);
             }
+
+            lock(_timerLock) {
+                // Disabling future invocation of timer callback.
+                _updateTimer.Change(Timeout.Infinite, Timeout.Infinite);
+            }
+
             return Task.CompletedTask;
         }
 
@@ -61,23 +72,29 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
         /// Timer operation
         /// </summary>
         /// <param name="sender"></param>
-        private async void OnUpdateTimerFiredAsync(object sender) {
-            try {
-                _cts.Token.ThrowIfCancellationRequested();
-                _logger.Information("Updating orchestrator urls...");
-                await UpdateOrchestratorUrlAsync(_cts.Token);
-                _logger.Information("Orchestrator Url update finished.");
+        private void OnUpdateTimerFiredAsync(object sender) {
+            lock(_timerLock) {
+                try {
+                    _cts.Token.ThrowIfCancellationRequested();
+                    _logger.Information("Updating orchestrator urls...");
+                    UpdateOrchestratorUrlAsync(_cts.Token).Wait();
+                    _logger.Information("Orchestrator Url update finished.");
+                }
+                catch (OperationCanceledException ex) {
+                    if (_cts.IsCancellationRequested) {
+                        // Cancel was called.
+                        return;
+                    }
+
+                    // Some operation timed out.
+                    _logger.Error(ex, "Failed to update orchestrator urls.");
+                }
+                catch (Exception ex) {
+                    _logger.Error(ex, "Failed to update orchestrator urls.");
+                }
+
+                _updateTimer.Change(_config.JobOrchestratorUrlSyncInterval, Timeout.InfiniteTimeSpan);
             }
-            catch (OperationCanceledException) {
-                // Cancel was called - dispose cancellation token
-                _cts.Dispose();
-                _cts = null;
-                return;
-            }
-            catch (Exception ex) {
-                _logger.Error(ex, "Failed to update orchestrator urls.");
-            }
-            _updateTimer.Change(TimeSpan.FromMinutes(1), Timeout.InfiniteTimeSpan);
         }
 
         /// <summary>
@@ -85,7 +102,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
         /// </summary>
         /// <returns></returns>
         public async Task UpdateOrchestratorUrlAsync(CancellationToken ct) {
-            var url = _endpoint.JobOrchestratorUrl?.TrimEnd('/');
+            var url = _config.JobOrchestratorUrl?.TrimEnd('/');
             if (string.IsNullOrEmpty(url)) {
                 return;
             }
@@ -115,13 +132,12 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs {
             _logger.Information("Job orchestrator url updated to {url} on all twins.", url);
         }
 
-        private readonly IJobOrchestratorEndpoint _endpoint;
+        private readonly IJobOrchestratorEndpointConfig _config;
         private readonly IJsonSerializer _serializer;
         private readonly IIoTHubTwinServices _twins;
         private readonly ILogger _logger;
         private readonly Timer _updateTimer;
-#pragma warning disable IDE0069 // Disposable fields should be disposed
         private CancellationTokenSource _cts;
-#pragma warning restore IDE0069 // Disposable fields should be disposed
+        private readonly object _timerLock = new object();
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Jobs/Runtime/JobOrchestratorEndpointConfig.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Jobs/Runtime/JobOrchestratorEndpointConfig.cs
@@ -6,29 +6,36 @@
 namespace Microsoft.Azure.IIoT.Agent.Framework.Jobs.Runtime {
     using Microsoft.Azure.IIoT.Utils;
     using Microsoft.Extensions.Configuration;
+    using System;
     using System.Net;
     using System.Net.Sockets;
 
     /// <summary>
     /// Default endpoint configuration
     /// </summary>
-    public class JobOrchestratorApiConfig : ConfigBase, IJobOrchestratorEndpoint {
+    public class JobOrchestratorEndpointConfig : ConfigBase, IJobOrchestratorEndpointConfig {
 
         /// <summary>
         /// Property keys
         /// </summary>
         private const string kJobOrchestratorUrlKey = "JobOrchestratorUrl";
+        private const string kJobOrchestratorUrlSyncIntervalKey = "JobOrchestratorUrlSyncInterval";
 
         /// <inheritdoc/>
         public string JobOrchestratorUrl => GetStringOrDefault(kJobOrchestratorUrlKey,
             () => GetStringOrDefault(PcsVariable.PCS_PUBLISHER_ORCHESTRATOR_SERVICE_URL,
                 () => GetDefaultUrl("9051", "edge/publisher")));
 
+        /// <inheritdoc/>
+        public TimeSpan JobOrchestratorUrlSyncInterval =>
+            GetDurationOrDefault(kJobOrchestratorUrlSyncIntervalKey,
+                () => TimeSpan.FromMinutes(1));
+
         /// <summary>
         /// Create endpoint config
         /// </summary>
         /// <param name="configuration"></param>
-        public JobOrchestratorApiConfig(IConfiguration configuration) :
+        public JobOrchestratorEndpointConfig(IConfiguration configuration) :
             base(configuration) {
         }
 

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Jobs/Hub/JobOrchestratorEndpointSyncTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Jobs/Hub/JobOrchestratorEndpointSyncTests.cs
@@ -1,0 +1,232 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Agent.Framework.Tests.Jobs.Hub {
+    using Autofac;
+    using Autofac.Extras.Moq;
+    using Microsoft.Azure.IIoT.Agent.Framework.Jobs;
+    using Microsoft.Azure.IIoT.Agent.Framework.Jobs.Runtime;
+    using Microsoft.Azure.IIoT.Hub;
+    using Microsoft.Azure.IIoT.Hub.Models;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// Test to check execution logic of JobOrchestratorEndpointSync service.
+    /// </summary>
+    public class JobOrchestratorEndpointSyncTests {
+
+        [Fact]
+        public async Task StartStopTestAsync() {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["JobOrchestratorUrl"] = "https://so.me/end/point/";
+            configuration["JobOrchestratorUrlSyncInterval"] = "00:00:00.010";
+
+            using (var mock = Setup(null, configuration)) {
+                var syncService = mock.Create<JobOrchestratorEndpointSync>();
+                await syncService.StartAsync();
+                await Task.Delay(100);
+                await syncService.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(OperationCanceledException))]
+        [InlineData(typeof(HttpRequestException))]
+        public async Task QueryThrowsTestAsync(Type exceptionType) {
+
+            var queryCounter = 0;
+            var patchCounter = 0;
+            var cts = new CancellationTokenSource();
+
+            var ioTHubTwinServicesMock = new Mock<IIoTHubTwinServices>();
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => {
+                    queryCounter++;
+                    if (queryCounter >= 5) {
+                        cts.Cancel();
+                    }
+
+                    var ex = (Exception)Activator.CreateInstance(exceptionType);
+                    throw ex;
+                });
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => {
+                    patchCounter++;
+                    return Task.FromResult(new DeviceTwinModel());
+                });
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["JobOrchestratorUrl"] = "https://so.me/end/point/";
+            configuration["JobOrchestratorUrlSyncInterval"] = "00:00:00.001";
+
+            using (var mock = Setup(ioTHubTwinServicesMock, configuration)) {
+                var syncService = mock.Create<JobOrchestratorEndpointSync>();
+                await syncService.StartAsync();
+                await SilentTaskDelayAsync(1000, cts.Token);
+                await syncService.StopAsync();
+
+                Assert.InRange(queryCounter, 5, 1000);
+                Assert.Equal(0, patchCounter);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(OperationCanceledException))]
+        [InlineData(typeof(HttpRequestException))]
+        public async Task PatchThrowsTestAsync(Type exceptionType) {
+
+            var jobOrchestratorUrl = "https://so.me/end/point/";
+            var jobOrchestratorInterval = "00:00:00.001";
+            var queryCounter = 0;
+            var patchCounter = 0;
+            var cts = new CancellationTokenSource();
+            IJsonSerializer jsonSerializer = null;
+
+            var ioTHubTwinServicesMock = new Mock<IIoTHubTwinServices>();
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => {
+                    queryCounter++;
+                    var o = jsonSerializer?.FromObject(new {
+                        Properties = new {
+                            Desired = new { }
+                        }
+                    });
+                    return Task.FromResult(new QueryResultModel {
+                        Result = new List<VariantValue> {
+                            o
+                        }
+                    });
+                });
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => {
+                    patchCounter++;
+                    if (patchCounter >= 5) {
+                        cts.Cancel();
+                    }
+
+                    // Check that job orchestrator endpoint is set correctly.
+                    Assert.Equal(jobOrchestratorUrl, device.Properties.Desired[TwinProperties.JobOrchestratorUrl]);
+
+                    var ex = (Exception)Activator.CreateInstance(exceptionType);
+                    throw ex;
+                });
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["JobOrchestratorUrl"] = jobOrchestratorUrl;
+            configuration["JobOrchestratorUrlSyncInterval"] = jobOrchestratorInterval;
+
+            using (var mock = Setup(ioTHubTwinServicesMock, configuration)) {
+                var syncService = mock.Create<JobOrchestratorEndpointSync>();
+                jsonSerializer = mock.Container.Resolve<IJsonSerializer>();
+
+                await syncService.StartAsync();
+                await SilentTaskDelayAsync(1000, cts.Token);
+                await syncService.StopAsync();
+
+                Assert.InRange(queryCounter, 5, 1000);
+                Assert.InRange(patchCounter, 5, 1000);
+            }
+        }
+
+        /// <summary>
+        /// Call Task.Delay() and silently ignore OperationCanceledException
+        /// errors if cancellation was requested.
+        /// </summary>
+        /// <param name="millisecondsDelay"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        private static async Task SilentTaskDelayAsync(
+            int millisecondsDelay,
+            CancellationToken ct = default
+        ) {
+            try {
+                await Task.Delay(millisecondsDelay, ct);
+            }
+            catch (OperationCanceledException) {
+                if (!ct.IsCancellationRequested) {
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Setup mock
+        /// </summary>
+        /// <param name="ioTHubTwinServicesMock"></param>
+        /// <param name="configuration"></param>
+        private static AutoMock Setup(
+            Mock<IIoTHubTwinServices> ioTHubTwinServicesMock = null,
+            IConfiguration configuration = null
+        ) {
+            var mock = AutoMock.GetLoose(builder => {
+                // Use empty configuration root if one is not passed.
+                var conf = configuration ?? new ConfigurationBuilder()
+                    .AddInMemoryCollection()
+                    .Build();
+
+                // Setup configuration
+                builder.RegisterInstance(conf)
+                    .As<IConfiguration>()
+                    .SingleInstance();
+
+                var syncConfig = new JobOrchestratorEndpointConfig(conf);
+                builder.RegisterInstance(syncConfig)
+                    .AsImplementedInterfaces()
+                    .SingleInstance();
+
+                // Setup JSON serializer
+                builder.RegisterType<NewtonSoftJsonConverters>()
+                    .As<IJsonSerializerConverterProvider>();
+                builder.RegisterType<NewtonSoftJsonSerializer>()
+                    .As<IJsonSerializer>();
+
+                // Setup IIoTHubTwinServices mock
+                if (ioTHubTwinServicesMock is null) {
+                    var ioTHubTwinServices = new Mock<IIoTHubTwinServices>();
+
+                    ioTHubTwinServices
+                        .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                        .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => Task.FromResult(new QueryResultModel()));
+
+                    ioTHubTwinServices
+                        .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                        .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => Task.FromResult(new DeviceTwinModel()));
+
+                    builder.RegisterMock(ioTHubTwinServices);
+                }
+                else {
+                    builder.RegisterMock(ioTHubTwinServicesMock);
+                }
+
+                builder.RegisterType<JobOrchestratorEndpointSync>()
+                    .AsSelf(); ;
+            });
+            return mock;
+        }
+    }
+}

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Diagnostics.Debug\src\Microsoft.Azure.IIoT.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Serializers.NewtonSoft\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj" />
+    <ProjectReference Include="..\src\Microsoft.Azure.IIoT.Agent.Framework.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+</Project>

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Hub/Auth/Services/TwinIdentityTokenUpdaterTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Hub/Auth/Services/TwinIdentityTokenUpdaterTests.cs
@@ -1,0 +1,251 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Core.Tests.Hub.Auth.Services {
+    using Autofac;
+    using Autofac.Extras.Moq;
+    using Microsoft.Azure.IIoT.Auth;
+    using Microsoft.Azure.IIoT.Auth.IoTHub;
+    using Microsoft.Azure.IIoT.Crypto.Default;
+    using Microsoft.Azure.IIoT.Hub;
+    using Microsoft.Azure.IIoT.Hub.Auth.Models;
+    using Microsoft.Azure.IIoT.Hub.Models;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class TwinIdentityTokenUpdaterTests {
+
+        [Fact]
+        public async Task StartStopTestAsync() {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["TokenLifetime"] = "00:00:00.015";
+            configuration["UpdateInterval"] = "00:00:00.005";
+
+            using (var mock = Setup(null, configuration)) {
+                var syncService = mock.Create<TwinIdentityTokenUpdater>();
+                await syncService.StartAsync();
+                await Task.Delay(100);
+                await syncService.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(OperationCanceledException))]
+        [InlineData(typeof(HttpRequestException))]
+        public async Task QueryThrowsTestAsync(Type exceptionType) {
+
+            var queryCounter = 0;
+            var patchCounter = 0;
+            var cts = new CancellationTokenSource();
+
+            var ioTHubTwinServicesMock = new Mock<IIoTHubTwinServices>();
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => {
+                    queryCounter++;
+                    if (queryCounter >= 5) {
+                        cts.Cancel();
+                    }
+
+                    var ex = (Exception)Activator.CreateInstance(exceptionType);
+                    throw ex;
+                });
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => {
+                    patchCounter++;
+                    return Task.FromResult(new DeviceTwinModel());
+                });
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["TokenLifetime"] = "00:00:00.003";
+            configuration["UpdateInterval"] = "00:00:00.001";
+
+            using (var mock = Setup(ioTHubTwinServicesMock, configuration)) {
+                var syncService = mock.Create<TwinIdentityTokenUpdater>();
+                await syncService.StartAsync();
+                await SilentTaskDelayAsync(1000, cts.Token);
+                await syncService.StopAsync();
+
+                Assert.InRange(queryCounter, 5, 1000);
+                Assert.Equal(0, patchCounter);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(OperationCanceledException))]
+        [InlineData(typeof(HttpRequestException))]
+        public async Task PatchThrowsTestAsync(Type exceptionType) {
+
+            var iterations = 10;
+            var tokenLength = 10;
+            var tokenLifetime = "00:00:00.003";
+            var updateInterval = "00:00:00.001";
+            var deviceId = "testDeviceId";
+            var queryCounter = 0;
+            var patchCounter = 0;
+            var cts = new CancellationTokenSource();
+            IJsonSerializer jsonSerializer = null;
+
+            var ioTHubTwinServicesMock = new Mock<IIoTHubTwinServices>();
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => {
+                    queryCounter++;
+                    var o = jsonSerializer?.FromObject(new {
+                        DeviceId = deviceId,
+                        Properties = new {
+                            Desired = new { }
+                        }
+                    });
+                    return Task.FromResult(new QueryResultModel {
+                        Result = new List<VariantValue> {
+                            o
+                        }
+                    });
+                });
+
+            ioTHubTwinServicesMock
+                .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => {
+                    patchCounter++;
+                    if (patchCounter >= iterations) {
+                        cts.Cancel();
+                    }
+
+                    var tokenVariant = device.Properties.Desired[Constants.IdentityTokenPropertyName];
+                    //var token = jsonSerializer.Deserialize<IdentityTokenTwinModel>(tokenVariant.ToString());
+                    //var token = (IdentityTokenTwinModel)tokenVariant.Value;
+                    var token = tokenVariant.ConvertTo<IdentityTokenTwinModel>();
+
+                    Assert.Equal(deviceId, token.Identity);
+                    byte[] tokeKeyBytes = Convert.FromBase64String(token.Key);
+                    string tokeKey = Encoding.UTF8.GetString(tokeKeyBytes);
+                    Assert.Equal(tokenLength, tokeKey.Length);
+                    Assert.True(token.Expires <= DateTime.UtcNow.Add(TimeSpan.Parse(tokenLifetime)));
+
+                    var ex = (Exception)Activator.CreateInstance(exceptionType);
+                    throw ex;
+                });
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["TokenLength"] = $"{tokenLength}";
+            configuration["TokenLifetime"] = tokenLifetime;
+            configuration["UpdateInterval"] = updateInterval;
+
+            using (var mock = Setup(ioTHubTwinServicesMock, configuration)) {
+                var syncService = mock.Create<TwinIdentityTokenUpdater>();
+                jsonSerializer = mock.Container.Resolve<IJsonSerializer>();
+
+                await syncService.StartAsync();
+                await SilentTaskDelayAsync(1000, cts.Token);
+                await syncService.StopAsync();
+
+                Assert.InRange(queryCounter, iterations, 1000);
+                Assert.InRange(patchCounter, iterations, 1000);
+            }
+        }
+
+        /// <summary>
+        /// Call Task.Delay() and silently ignore OperationCanceledException
+        /// errors if cancellation was requested.
+        /// </summary>
+        /// <param name="millisecondsDelay"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        private static async Task SilentTaskDelayAsync(
+            int millisecondsDelay,
+            CancellationToken ct = default
+        ) {
+            try {
+                await Task.Delay(millisecondsDelay, ct);
+            }
+            catch (OperationCanceledException) {
+                if (!ct.IsCancellationRequested) {
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Setup mock
+        /// </summary>
+        /// <param name="ioTHubTwinServicesMock"></param>
+        /// <param name="configuration"></param>
+        private static AutoMock Setup(
+            Mock<IIoTHubTwinServices> ioTHubTwinServicesMock = null,
+            IConfiguration configuration = null
+        ) {
+            var mock = AutoMock.GetLoose(builder => {
+                // Use empty configuration root if one is not passed.
+                var conf = configuration ?? new ConfigurationBuilder()
+                    .AddInMemoryCollection()
+                    .Build();
+
+                // Setup configuration
+                builder.RegisterInstance(conf)
+                    .As<IConfiguration>()
+                    .SingleInstance();
+
+                var syncConfig = new IdentityTokenUpdaterConfig(conf);
+                builder.RegisterInstance(syncConfig)
+                    .AsImplementedInterfaces()
+                    .SingleInstance();
+
+                // Setup JSON serializer
+                builder.RegisterType<NewtonSoftJsonConverters>()
+                    .As<IJsonSerializerConverterProvider>();
+                builder.RegisterType<NewtonSoftJsonSerializer>()
+                    .As<IJsonSerializer>();
+
+                // Setup IPasswordGenerator
+                builder.RegisterType<PasswordGenerator>()
+                    .AsImplementedInterfaces()
+                    .SingleInstance();
+
+                // Setup IIoTHubTwinServices mock
+                if (ioTHubTwinServicesMock is null) {
+                    var ioTHubTwinServices = new Mock<IIoTHubTwinServices>();
+
+                    ioTHubTwinServices
+                        .Setup(e => e.QueryAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+                        .Returns((string query, string continuation, int? pageSize, CancellationToken ct) => Task.FromResult(new QueryResultModel()));
+
+                    ioTHubTwinServices
+                        .Setup(e => e.PatchAsync(It.IsAny<DeviceTwinModel>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                        .Returns((DeviceTwinModel device, bool force, CancellationToken ct) => Task.FromResult(new DeviceTwinModel()));
+
+                    builder.RegisterMock(ioTHubTwinServices);
+
+                }
+                else {
+                    builder.RegisterMock(ioTHubTwinServicesMock);
+                }
+
+                builder.RegisterType<TwinIdentityTokenUpdater>()
+                    .AsSelf(); ;
+            });
+            return mock;
+        }
+    }
+}

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Utils/RetryTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Utils/RetryTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.IIoT.Core.Tests.Utils {
     public class RetryTests {
 
         [Fact]
-        public async void TestWithExponentialBackoffAsync() {
+        public async Task TestWithExponentialBackoffAsync() {
             var loggerMock = new Mock<ILogger>();
             var logger = loggerMock.Object;
 
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.IIoT.Core.Tests.Utils {
         }
 
         [Fact]
-        public async void TestWithExponentialBackoffCTAsync() {
+        public async Task TestWithExponentialBackoffCTAsync() {
             var loggerMock = new Mock<ILogger>();
             var logger = loggerMock.Object;
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Services/ActivationSyncHostTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Services/ActivationSyncHostTests.cs
@@ -1,0 +1,139 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Registry.Tests.Services {
+    using Autofac;
+    using Autofac.Extras.Moq;
+    using Microsoft.Azure.IIoT.OpcUa.Registry.Runtime;
+    using Microsoft.Azure.IIoT.OpcUa.Registry.Services;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class ActivationSyncHostTests {
+
+        [Fact]
+        public async Task StartStopTestAsync() {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["SyncInterval"] = "00:00:00.010";
+
+            using (var mock = Setup(null, configuration)) {
+                var syncService = mock.Create<ActivationSyncHost>();
+                await syncService.StartAsync();
+                await Task.Delay(100);
+                await syncService.StopAsync();
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(OperationCanceledException))]
+        [InlineData(typeof(HttpRequestException))]
+        public async Task SynchronizeActivationThrowsTestAsync(Type exceptionType) {
+
+            var callCounter = 0;
+            var cts = new CancellationTokenSource();
+
+            var endpointActivation = new Mock<IEndpointActivation>();
+
+            endpointActivation
+                .Setup(e => e.SynchronizeActivationAsync(It.IsAny<CancellationToken>()))
+                .Returns((CancellationToken ct) => {
+                    callCounter++;
+                    if (callCounter >= 5) {
+                        cts.Cancel();
+                    }
+
+                    var ex = (Exception)Activator.CreateInstance(exceptionType);
+                    throw ex;
+                });
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["SyncInterval"] = "00:00:00.001";
+
+            using (var mock = Setup(endpointActivation, configuration)) {
+                var syncService = mock.Create<ActivationSyncHost>();
+                await syncService.StartAsync();
+                await SilentTaskDelayAsync(1000, cts.Token);
+                await syncService.StopAsync();
+
+                Assert.InRange(callCounter, 5, 1000);
+            }
+        }
+
+        /// <summary>
+        /// Call Task.Delay() and silently ignore OperationCanceledException
+        /// errors if cancellation was requested.
+        /// </summary>
+        /// <param name="millisecondsDelay"></param>
+        /// <param name="ct"></param>
+        /// <returns></returns>
+        private static async Task SilentTaskDelayAsync(
+            int millisecondsDelay,
+            CancellationToken ct = default
+        ) {
+            try {
+                await Task.Delay(millisecondsDelay, ct);
+            }
+            catch (OperationCanceledException) {
+                if (!ct.IsCancellationRequested) {
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Setup mock
+        /// </summary>
+        /// <param name="endpointActivationMock"></param>
+        /// <param name="configuration"></param>
+        private static AutoMock Setup(
+            Mock<IEndpointActivation> endpointActivationMock = null,
+            IConfiguration configuration = null
+        ) {
+            var mock = AutoMock.GetLoose(builder => {
+                // Use empty configuration root if one is not passed.
+                var conf = configuration ?? new ConfigurationBuilder()
+                    .AddInMemoryCollection()
+                    .Build();
+
+                // Setup configuration
+                builder.RegisterInstance(conf)
+                    .As<IConfiguration>()
+                    .SingleInstance();
+
+                var syncConfig = new ActivationSyncConfig(conf);
+                builder.RegisterInstance(syncConfig)
+                    .AsImplementedInterfaces()
+                    .SingleInstance();
+
+                // Setup IEndpointActivation mock
+                if (endpointActivationMock is null) {
+                    var endpointActivation = new Mock<IEndpointActivation>();
+
+                    endpointActivation
+                        .Setup(e => e.SynchronizeActivationAsync(It.IsAny<CancellationToken>()))
+                        .Returns((CancellationToken ct) => Task.CompletedTask);
+
+                    builder.RegisterMock(endpointActivation);
+                }
+                else {
+                    builder.RegisterMock(endpointActivationMock);
+                }
+
+                builder.RegisterType<ActivationSyncHost>()
+                    .AsSelf(); ;
+            });
+            return mock;
+        }
+    }
+}

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Runtime/Config.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Runtime/Config.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime {
     /// Alerting agent configuration
     /// </summary>
     public class Config : DiagnosticsConfig, IIoTHubConfig, IServiceBusConfig,
-        IIdentityTokenUpdaterConfig, IActivationSyncConfig, IJobOrchestratorEndpoint,
+        IIdentityTokenUpdaterConfig, IActivationSyncConfig, IJobOrchestratorEndpointConfig,
         IMetricServerConfig {
 
         /// <inheritdoc/>
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime {
         public TimeSpan SyncInterval => _sync.SyncInterval;
         /// <inheritdoc/>
         public string JobOrchestratorUrl => _edge.JobOrchestratorUrl;
-
+        /// <inheritdoc/>
+        public TimeSpan JobOrchestratorUrlSyncInterval => _edge.JobOrchestratorUrlSyncInterval;
         /// <inheritdoc/>
         public int TokenLength => _id.TokenLength;
         /// <inheritdoc/>
@@ -42,7 +43,6 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime {
         public TimeSpan TokenStaleInterval => _id.TokenStaleInterval;
         /// <inheritdoc/>
         public TimeSpan UpdateInterval => _id.UpdateInterval;
-
         /// <inheritdoc/>
         public int Port => 9505;
 
@@ -57,13 +57,13 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.Runtime {
             _hub = new IoTHubConfig(configuration);
             _id = new IdentityTokenUpdaterConfig(configuration);
             _sync = new ActivationSyncConfig(configuration);
-            _edge = new JobOrchestratorApiConfig(configuration);
+            _edge = new JobOrchestratorEndpointConfig(configuration);
         }
 
         private readonly IServiceBusConfig _sb;
         private readonly IIoTHubConfig _hub;
         private readonly IdentityTokenUpdaterConfig _id;
-        private readonly JobOrchestratorApiConfig _edge;
+        private readonly JobOrchestratorEndpointConfig _edge;
         private readonly ActivationSyncConfig _sync;
     }
 }


### PR DESCRIPTION
Applying changes in #731 on `release/2.7.180` branch.

Changes:
* Changed `HttpClient` class to throw `HttpRequestException` on timeout.
* Passing linked cancellation token downstream.
* Changed `OperationCanceledException` exception handling to check for token cancellation.
* Made job orchestrator URL synchronization interval configurable.
* Added tests for exception handling in `JobOrchestratorEndpointSync` class.
* Added tests for exception handling in `ActivationSyncHostclass`.
* Added tests for exception handling in `TwinIdentityTokenUpdater` class.
* Fixed minor bug in `JobOrchestratorEndpointSync`.
* Fixing a race condition on Dispose() in `JobOrchestratorEndpointSync`.
* Fixing a race condition on Dispose() in `ActivationSyncHost`.
* Fixing a race condition on Dispose() in `TwinIdentityTokenUpdater`.
* Minor refactoring.