### PR TITLE
Ignore failure to open a web browser in deploy.ps1.

### DIFF
--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -1030,10 +1030,17 @@ Function New-Deployment() {
             #
             Write-EnvironmentVariables -deployment $deployment
 
-            if (![string]::IsNullOrEmpty($website)) {
-                # Try open application
-                Start-Process $website -ErrorAction SilentlyContinue | Out-Null
+            # Try to open $website in a web browser.
+            try {
+                if (![string]::IsNullOrEmpty($website)) {
+                    # Try open application
+                    Start-Process $website -ErrorAction SilentlyContinue | Out-Null
+                }
             }
+            catch {
+                # Ignore if there is no web browser available.
+            }
+
             return
         }
         catch {


### PR DESCRIPTION
After this change, failure to open a web browser to access Engineering Tool will not cause deployment to fail. The URL of the Engineering Tool is already printed to output before we try to open a web browser, so no additional logs are added in case of error. The log with the URL looks like this:

```
The deployed application can be found at:
https://kakostan-wsl-test-100.azurewebsites.net
```