### PR TITLE
WorkerSupervisor enable the reduction of Worker 

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         }
 
         /// <inheritdoc/>
-        public int NumberOfWorker => _instances.Count;
+        public int NumberOfWorkers => _instances.Count;
 
         /// <summary>
         /// Create worker
@@ -77,11 +77,11 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         }
 
         /// <summary>
-        /// Stop worker
+        /// Stop a single worker
         /// </summary>
         /// <returns>awaitable task</returns>
         private async Task StopWorker() {
-            // sort worker, so that worker in state stopped, stoping or WaitingForJob will terminate first 
+            // sort workers, so that a worker in state Stopped, Stopping or WaitingForJob will terminated first 
             var worker = _instances.OrderBy(kvp => kvp.Key.Status).First();
             var workerId = worker.Key.WorkerId;
             _logger.Information("Stopping worker with id {WorkerId}", workerId);

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -83,7 +83,9 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         private async Task StopWorker() {
             // sort worker, so that worker in state stopped, stoping or WaitingForJob will terminate first 
             var worker = _instances.OrderBy(kvp => kvp.Key.Status).First();
-
+            var workerId = worker.Key.WorkerId;
+            _logger.Information("Stopping worker with id {WorkerId}", workerId);
+            
             await worker.Key.StopAsync();
             worker.Value.Dispose();
             _instances.Remove(worker.Key);

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -26,12 +26,13 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         /// <param name="lifetimeScope"></param>
         /// <param name="agentConfigProvider"></param>
         /// <param name="logger"></param>
+        /// <param name="timerDelay">The time the supervisor is waiting before ensure worker</param>
         public WorkerSupervisor(ILifetimeScope lifetimeScope,
-            IAgentConfigProvider agentConfigProvider, ILogger logger) {
+            IAgentConfigProvider agentConfigProvider, ILogger logger, int timerDelay = 10) {
             _lifetimeScope = lifetimeScope;
             _agentConfigProvider = agentConfigProvider;
             _logger = logger;
-            _ensureWorkerRunningTimer = new Timer(TimeSpan.FromSeconds(10).TotalMilliseconds);
+            _ensureWorkerRunningTimer = new Timer(TimeSpan.FromSeconds(timerDelay).TotalMilliseconds);
             _ensureWorkerRunningTimer.Elapsed += EnsureWorkerRunningTimer_ElapsedAsync;
         }
 

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         /// </summary>
         /// <returns>awaitable task</returns>
         private async Task StopWorker() {
-            // sort workers, so that a worker in state Stopped, Stopping or WaitingForJob will terminated first 
+            // sort workers, so that a worker in state Stopped, Stopping or WaitingForJob will terminate first 
             var worker = _instances.OrderBy(kvp => kvp.Key.Status).First();
             var workerId = worker.Key.WorkerId;
             _logger.Information("Stopping worker with id {WorkerId}", workerId);

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         /// Create worker
         /// </summary>
         /// <returns></returns>
-        public Task<IWorker> CreateWorker() {
+        private Task<IWorker> CreateWorker() {
             var maxWorkers = _agentConfigProvider.Config?.MaxWorkers ?? kDefaultWorkers;
             if (_instances.Count >= maxWorkers) {
                 throw new MaxWorkersReachedException(maxWorkers);
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         /// Stop worker
         /// </summary>
         /// <returns>awaitable task</returns>
-        public async Task StopWorker() {
+        private async Task StopWorker() {
             // sort worker, so that worker in state stopped, stoping or WaitingForJob will terminate first 
             var worker = _instances.OrderBy(kvp => kvp.Key.Status).First();
 

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Agent/Default/WorkerSupervisor.cs
@@ -26,13 +26,18 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Agent {
         /// <param name="lifetimeScope"></param>
         /// <param name="agentConfigProvider"></param>
         /// <param name="logger"></param>
-        /// <param name="timerDelay">The time the supervisor is waiting before ensure worker</param>
+        /// <param name="timerDelayInSeconds">The time the supervisor is waiting before ensure worker</param>
         public WorkerSupervisor(ILifetimeScope lifetimeScope,
-            IAgentConfigProvider agentConfigProvider, ILogger logger, int timerDelay = 10) {
+            IAgentConfigProvider agentConfigProvider, ILogger logger, int timerDelayInSeconds = 10) {
+
+            if (timerDelayInSeconds <= 0) {
+                timerDelayInSeconds = 10;
+            }
+
             _lifetimeScope = lifetimeScope;
             _agentConfigProvider = agentConfigProvider;
             _logger = logger;
-            _ensureWorkerRunningTimer = new Timer(TimeSpan.FromSeconds(timerDelay).TotalMilliseconds);
+            _ensureWorkerRunningTimer = new Timer(TimeSpan.FromSeconds(timerDelayInSeconds).TotalMilliseconds);
             _ensureWorkerRunningTimer.Elapsed += EnsureWorkerRunningTimer_ElapsedAsync;
         }
 

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IWorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IWorkerSupervisor.cs
@@ -12,16 +12,8 @@ namespace Microsoft.Azure.IIoT.Agent.Framework {
     public interface IWorkerSupervisor : IHostProcess {
 
         /// <summary>
-        /// Create worker
+        /// The amount of worker currently running
         /// </summary>
-        /// <returns></returns>
-        Task<IWorker> CreateWorker();
-
-        /// <summary>
-        /// Stop worker
-        /// </summary>
-        /// <param name="workerId"></param>
-        /// <returns></returns>
-        Task StopWorker(string workerId);
+        int NumberOfWorker { get; }
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IWorkerSupervisor.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IWorkerSupervisor.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.IIoT.Agent.Framework {
     public interface IWorkerSupervisor : IHostProcess {
 
         /// <summary>
-        /// The amount of worker currently running
+        /// The amount of workers currently running
         /// </summary>
-        int NumberOfWorker { get; }
+        int NumberOfWorkers { get; }
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -69,7 +69,7 @@
             var agentConfigMock = new Mock<IAgentConfigProvider>();
             var loggerMock = new Mock<ILogger>();
 
-            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfigMock.Object, loggerMock.Object);
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfigMock.Object, loggerMock.Object, kSupervisorDelay);
 
             // start host process
             var sut = workerSupervisor as IWorkerSupervisor;
@@ -90,7 +90,7 @@
             var agentConfig = new TestAgentConfigProvider();
             var loggerMock = new Mock<ILogger>();
 
-            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object, kSupervisorDelay);
 
             // start host process
             var sut = workerSupervisor as IWorkerSupervisor;
@@ -113,7 +113,7 @@
             var agentConfig = new TestAgentConfigProvider();
             var loggerMock = new Mock<ILogger>();
 
-            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object, kSupervisorDelay);
 
             // start host process
             var sut = workerSupervisor as IWorkerSupervisor;
@@ -141,7 +141,7 @@
                 It.Is<int>(i => i == kDefaultMaxWorker)))
                 .Verifiable();
 
-            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object, kSupervisorDelay);
 
             // start host process
             var sut = workerSupervisor as IWorkerSupervisor;
@@ -167,7 +167,7 @@
             var agentConfig = new TestAgentConfigProvider();
             var loggerMock = new Mock<ILogger>();
 
-            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object, kSupervisorDelay);
 
             // start host process
             var sut = workerSupervisor as IWorkerSupervisor;
@@ -197,7 +197,8 @@
             return container;
         }
 
-        private const int kDefaultDelay = 15000; //Internal timer which creates the Worker run every 10 seconds
+        private const int kDefaultDelay = 2000; //Internal timer which creates the Worker run every 10 seconds
         private const int kDefaultMaxWorker = 5;
+        private const int kSupervisorDelay = 1;
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -77,7 +77,7 @@
             await sut.StartAsync();
 
             // Test
-            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorker);
+            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorkers);
 
             // clean up
             await sut.StopAsync();
@@ -101,7 +101,7 @@
             const int numberOfWorker = 9;
             agentConfig.SetMaxWorker(numberOfWorker);
             await Task.Delay(kDefaultDelay); //Internal timer which creates the Worker run every 10 seconds
-            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorkers);
 
             // clean up
             await sut.StopAsync();
@@ -124,7 +124,7 @@
             const int numberOfWorker = 2;
             agentConfig.SetMaxWorker(numberOfWorker);
             await Task.Delay(kDefaultDelay); //Internal timer which creates the Worker run every 10 seconds
-            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorkers);
 
             // clean up
             await sut.StopAsync();
@@ -153,7 +153,7 @@
             agentConfig.SetMaxWorker(numberOfWorker);
 
             await Task.Delay(kDefaultDelay); 
-            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorker);
+            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorkers);
             loggerMock.Verify();
 
             // clean up
@@ -178,12 +178,12 @@
             int numberOfWorker = 8; //Increase
             agentConfig.SetMaxWorker(numberOfWorker);
             await Task.Delay(kDefaultDelay);
-            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorkers);
 
             numberOfWorker = 6; //Decrease
             agentConfig.SetMaxWorker(numberOfWorker);
             await Task.Delay(kDefaultDelay);
-            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorkers);
 
             // clean up
             await sut.StopAsync();

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -1,8 +1,11 @@
-﻿namespace Microsoft.Azure.IIoT.Agent.Framework.Tests.Worker {
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.Agent.Framework.Tests.Worker {
     using Microsoft.Azure.IIoT.Agent.Framework.Agent;
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using Xunit;
     using Moq;
     using Autofac;

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -197,7 +197,7 @@
             return container;
         }
 
-        private const int kDefaultDelay = 2000; //Internal timer which creates the Worker run every 10 seconds
+        private const int kDefaultDelay = 2000;
         private const int kDefaultMaxWorker = 5;
         private const int kSupervisorDelay = 1;
     }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -1,0 +1,174 @@
+﻿namespace Microsoft.Azure.IIoT.Agent.Framework.Tests.Worker {
+    using Microsoft.Azure.IIoT.Agent.Framework.Agent;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using Xunit;
+    using Moq;
+    using Autofac;
+    using Serilog;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.IIoT.Agent.Framework.Models;
+
+    public class WorkerSupervisorTests {
+
+        private class TestWorker : IWorker {
+
+            public TestWorker(int workerInstance) {
+                WorkerId = $"Agent_{workerInstance}";
+                Status = WorkerStatus.Stopped;
+            }
+
+            public string WorkerId { get; private set;}
+
+            public WorkerStatus Status { get; private set; }
+
+            public event JobFinishedEventHandler OnJobCompleted;
+            public event JobCanceledEventHandler OnJobCanceled;
+            public event JobStartedEventHandler OnJobStarted;
+
+            public Task StartAsync() {
+                Status = WorkerStatus.WaitingForJob;
+                var args = new JobInfoEventArgs(new JobInfoModel());
+                OnJobStarted?.Invoke(this, args);
+                Status = WorkerStatus.ProcessingJob;
+                Task.Delay(10);
+                OnJobCompleted?.Invoke(this, args);
+                return Task.Delay(1);
+            }
+
+            public Task StopAsync() {
+                Status = WorkerStatus.Stopping;
+                var args = new JobInfoEventArgs(new JobInfoModel());
+                OnJobCanceled?.Invoke(this, args);
+
+                Status = WorkerStatus.Stopped;
+                return Task.Delay(1);
+            }
+        }
+
+        private class TestAgentConfigProvider : IAgentConfigProvider {
+            public TestAgentConfigProvider() {
+                Config = new AgentConfigModel();
+            }
+            public AgentConfigModel Config { get; set; }
+
+            public event ConfigUpdatedEventHandler OnConfigUpdated;
+
+            public void SetMaxWorker(int numberOfWorker) {
+
+                Config.MaxWorkers = numberOfWorker;
+                OnConfigUpdated?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        [Fact]
+        public async Task Test_001_DefaultConfiguration_Expect_FiveWorker() {
+
+            using var container = GetAutofacTestConfiguration();
+            var agentConfigMock = new Mock<IAgentConfigProvider>();
+            var loggerMock = new Mock<ILogger>();
+
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfigMock.Object, loggerMock.Object);
+
+            // start host process
+            var sut = workerSupervisor as IWorkerSupervisor;
+            Assert.NotNull(sut);
+            await sut.StartAsync();
+
+            // Test
+            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorker);
+
+            // clean up
+            await sut.StopAsync();
+        }
+
+        [Fact]
+        public async Task Test_002_IncreaseMaxWorker_Expect_WorkerSpawned() {
+            
+            using var container = GetAutofacTestConfiguration();
+            var agentConfig = new TestAgentConfigProvider();
+            var loggerMock = new Mock<ILogger>();
+
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+
+            // start host process
+            var sut = workerSupervisor as IWorkerSupervisor;
+            Assert.NotNull(sut);
+            await sut.StartAsync();
+
+            // Test
+            const int numberOfWorker = 9;
+            agentConfig.SetMaxWorker(numberOfWorker);
+            await Task.Delay(kDefaultDelay); //Internal timer which creates the Worker run every 10 seconds
+            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+
+            // clean up
+            await sut.StopAsync();
+        }
+
+        [Fact]
+        public async Task Test_003_DecreaseMaxWorker_Expect_WorkerTermination() {
+            using var container = GetAutofacTestConfiguration();
+            var agentConfig = new TestAgentConfigProvider();
+            var loggerMock = new Mock<ILogger>();
+
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+
+            // start host process
+            var sut = workerSupervisor as IWorkerSupervisor;
+            Assert.NotNull(sut);
+            await sut.StartAsync();
+
+            // Test
+            const int numberOfWorker = 2;
+            agentConfig.SetMaxWorker(numberOfWorker);
+            await Task.Delay(kDefaultDelay); //Internal timer which creates the Worker run every 10 seconds
+            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+
+            // clean up
+            await sut.StopAsync();
+        }
+
+        [Fact]
+        public async Task Test_004_NegativeMaxWorker_Expect_Exception() {
+
+            using var container = GetAutofacTestConfiguration();
+            var agentConfig = new TestAgentConfigProvider();
+            var loggerMock = new Mock<ILogger>();
+            loggerMock.Setup(l => l.Error(
+                It.Is<string>(s => s.Contains("MaxWorker")), 
+                It.Is<int>(i => i == kDefaultMaxWorker)))
+                .Verifiable();
+
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+
+            // start host process
+            var sut = workerSupervisor as IWorkerSupervisor;
+            Assert.NotNull(sut);
+            await sut.StartAsync();
+
+            // Test
+            const int numberOfWorker = -4;
+            agentConfig.SetMaxWorker(numberOfWorker);
+
+            await Task.Delay(kDefaultDelay); 
+            Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorker);
+            loggerMock.Verify();
+
+            // clean up
+            await sut.StopAsync();
+        }
+
+        private IContainer GetAutofacTestConfiguration() {
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<TestWorker>().As<IWorker>();
+            var container = containerBuilder.Build();
+
+            return container;
+        }
+
+        private const int kDefaultDelay = 15000; //Internal timer which creates the Worker run every 10 seconds
+        private const int kDefaultMaxWorker = 5;
+    }
+}

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -131,7 +131,7 @@
         }
 
         [Fact]
-        public async Task Test_004_NegativeMaxWorker_Expect_Exception() {
+        public async Task Test_004_NegativeMaxWorker_Expect_UseDefaultValue() {
 
             using var container = GetAutofacTestConfiguration();
             var agentConfig = new TestAgentConfigProvider();
@@ -155,6 +155,35 @@
             await Task.Delay(kDefaultDelay); 
             Assert.Equal(kDefaultMaxWorker, sut.NumberOfWorker);
             loggerMock.Verify();
+
+            // clean up
+            await sut.StopAsync();
+        }
+
+        [Fact]
+        public async Task Test_005_IncreaseAndDecreaseMaxWorker_Expect_Exception() {
+
+            using var container = GetAutofacTestConfiguration();
+            var agentConfig = new TestAgentConfigProvider();
+            var loggerMock = new Mock<ILogger>();
+
+            var workerSupervisor = new WorkerSupervisor(container.BeginLifetimeScope(), agentConfig, loggerMock.Object);
+
+            // start host process
+            var sut = workerSupervisor as IWorkerSupervisor;
+            Assert.NotNull(sut);
+            await sut.StartAsync();
+
+            // Test
+            int numberOfWorker = 8; //Increase
+            agentConfig.SetMaxWorker(numberOfWorker);
+            await Task.Delay(kDefaultDelay);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
+
+            numberOfWorker = 6; //Decrease
+            agentConfig.SetMaxWorker(numberOfWorker);
+            await Task.Delay(kDefaultDelay);
+            Assert.Equal(numberOfWorker, sut.NumberOfWorker);
 
             // clean up
             await sut.StopAsync();

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Worker/WorkerSupervisorTests.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Tests.Worker {
         }
 
         [Fact]
-        public async Task Test_005_IncreaseAndDecreaseMaxWorker_Expect_Exception() {
+        public async Task Test_005_IncreaseAndDecreaseMaxWorker_Expect_AdoptionOfWorker() {
 
             using var container = GetAutofacTestConfiguration();
             var agentConfig = new TestAgentConfigProvider();


### PR DESCRIPTION
**Issue:**
The number of Worker within publisher can't be reduced. 
Calling *PATCH /registry/v2/publishers/{publisherId}* with smaller number of MaxWorker will not result in terminating worker. Example payload:

```json
{
  "configuration": {
    "maxWorkers": 4
  }
}
```

**Solution:**
WorkerSupervisor have to also reduce number of Worker within EnsureWorker method.

**Others:**
* Updated IWorkerSupervisor interface
  * Removed `CreateWorker` because it wasn't used externally
  * Removed `StopWorker(WorkerId)` because it wasn't used externally
  * Added getter `int NumberOfWorker` to be used from tests
* Added tests for WorkerSupervisor