### PR TITLE
Avoid NullReferenceException in ModuleProcess

### DIFF
--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/ModuleProcess.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/ModuleProcess.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
                     }
                     finally {
                         await workerSupervisor.StopAsync();
-                        await sessionManager?.StopAsync();
+                        await (sessionManager?.StopAsync() ?? Task.CompletedTask);
                         await module.StopAsync();
                         OnRunning?.Invoke(this, false);
                         kPublisherModuleStart.WithLabels(


### PR DESCRIPTION
**Issue:**
SessionManager can be null, the current handling `await sessionManager?.StopAsync()` isn't sufficient, because the await will be called on null, which causes NullReferenceException.

**Solution:**
Await empty task, if sessionManager is null.