### PR TITLE
Bumped several Microsoft.AspNetCore.* NuGet packages from 3.1.5 to 3.1.9.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.AspNetCore.SignalR/src/Microsoft.Azure.IIoT.AspNetCore.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore.SignalR/src/Microsoft.Azure.IIoT.AspNetCore.SignalR.csproj
@@ -8,8 +8,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
@@ -5,11 +5,11 @@
     <Description>Azure Industrial IoT common ASP.net Core abstractions and utilities</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />

--- a/common/src/Microsoft.Azure.IIoT.Http.SignalR/src/Microsoft.Azure.IIoT.Http.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Http.SignalR/src/Microsoft.Azure.IIoT.Http.SignalR.csproj
@@ -5,9 +5,9 @@
     <Description>Azure Industrial IoT SignalR messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Serializers.MessagePack\src\Microsoft.Azure.IIoT.Serializers.MessagePack.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
@@ -5,8 +5,8 @@
     <Description>Azure Industrial IoT SignalR messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.5.0" />

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
@@ -8,10 +8,10 @@
     <PackageReference Include="Blazored.SessionStorage" Version="1.0.12" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.9" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.447" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.9" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/tests/Microsoft.Azure.IIoT.Services.OpcUa.Vault.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Vault/tests/Microsoft.Azure.IIoT.Services.OpcUa.Vault.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Moq" Version="4.14.3" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
Versions of the following NuGet packages have been bumped from `3.1.5` to `3.1.9`:
* Authentication:
  * `Microsoft.AspNetCore.Authentication.AzureAD.UI`
  * `Microsoft.AspNetCore.Authentication.OpenIdConnect`
  * `Microsoft.AspNetCore.Authentication.JwtBearer`
* Components:
  * `Microsoft.AspNetCore.Components.Web`
* DataProtection:
  * `Microsoft.AspNetCore.DataProtection.AzureKeyVault`
  * `Microsoft.AspNetCore.DataProtection.AzureStorage`
* Mvc:
  * `Microsoft.AspNetCore.Mvc.NewtonsoftJson`
  * `Microsoft.AspNetCore.Mvc.Testing`
* SignalR:
  * `Microsoft.AspNetCore.SignalR.Client`
  * `Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson`
  * `Microsoft.AspNetCore.SignalR.Protocols.MessagePack`