### PR TITLE
Bump Microsoft.Extensions.* packages from 3.1.5 to 3.1.9.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.9" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.9" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="System.Runtime.Caching" Version="4.7.0" />
   </ItemGroup>


### PR DESCRIPTION
Versions of the following NuGet packages have been bumped from `3.1.5` to `3.1.9`:

* `Microsoft.Extensions.Caching.Abstractions`
* `Microsoft.Extensions.Hosting`
* `Microsoft.Extensions.Http`
* `Microsoft.Extensions.Diagnostics.HealthChecks`