### PR TITLE
upgrading iotedge version in layered deployment

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.IIoT.Hub.Services {
         /// </summary>
         /// <param name="version"></param>
         /// <returns></returns>
-        private IDictionary<string, IDictionary<string, object>> GetEdgeBase(string version = "1.0.9.4") {
+        private IDictionary<string, IDictionary<string, object>> GetEdgeBase(string version = "1.0.10") {
             return _serializer.Deserialize<IDictionary<string, IDictionary<string, object>>>(@"
 {
     ""$edgeAgent"": {


### PR DESCRIPTION
- Upgrading iotedge version to 1.0.10 
    - As of release 1.0.10, metrics are automatically exposed by default on http port 9600 of the Edge Hub and Edge Agent.
    - To disable metrics exposed by Edge Hub and Edge Agent, please set _MetricsEnabled_ environment variable to false.