### PR TITLE
Direct dependabot clutter to a 'nuget' branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 20
+    open-pull-requests-limit: 25
+    # Raise pull requests in worker branch nuget
+    target-branch: "nuget"    


### PR DESCRIPTION
This will allow to consolidate the nuget package updates