### PR TITLE
fix bug: Fails when more 468 values are added to publisher

### DIFF
--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// Key for the max (IoT Hub D2C)message size
         /// </summary>
-        public const string MaxMessageSize = "MaxMessageSize";
+        public const string IoTHubMaxMessageSize = "IoTHubMaxMessageSize";
 
         /// <summary>
         /// Key for the max (IoT Hub D2C) egress message queue (deprecated, use MaxEgressMessageQueue instead).

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                     { "si|iothubsendinterval=", "The trigger batching interval in seconds.",
                         (int k) => this[LegacyCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
                     { "ms|iothubmessagesize=", "The maximum size of the (IoT D2C) message.",
-                        (int i) => this[LegacyCliConfigKeys.MaxMessageSize] = i.ToString() },
+                        (int i) => this[LegacyCliConfigKeys.IoTHubMaxMessageSize] = i.ToString() },
 
                     { "om|maxoutgressmessages=", "The maximum size of the (IoT D2C) message egress queue (deprecated, use em|maxegressmessagequeue instead).",
                         (int i) => this[LegacyCliConfigKeys.MaxOutgressMessages] = i.ToString() },
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 TrustedIssuerCertificatesPath = GetValueOrDefault(LegacyCliConfigKeys.OpcIssuerCertStorePath, "pki/issuer"),
                 BatchSize = GetValueOrDefault(LegacyCliConfigKeys.BatchSize, 50),
                 BatchTriggerInterval = GetValueOrDefault<TimeSpan>(LegacyCliConfigKeys.BatchTriggerInterval, TimeSpan.FromSeconds(10)),
-                MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.MaxMessageSize, 0),
+                MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.IoTHubMaxMessageSize, 0),
                 ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, 1),
                 MaxEgressMessageQueue = ContainsKey(LegacyCliConfigKeys.MaxEgressMessageQueue)
                     ? GetValueOrDefault(LegacyCliConfigKeys.MaxEgressMessageQueue, 4096) // 4096 * 256 KB = 1 GB.


### PR DESCRIPTION
the root cause of this bug is the explicit setting of the parameter --ms=0.
This parameter should configure the message size for IoTHuB, but it wrongly set also the message size in the publisher/client connection.  
This parameter was wrongly used to set the MaxMessageSize in TransportQuotaConfig in EndpointConfiguration