### PR TITLE
IAI: Upgraded AKS to 1.18 and platform to 2.7.199.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration {
         // Defaults
         public static string _defaultRepoUrl = "https://microsoft.github.io/charts/repo";
         public static string _defaultChartVersion = "0.3.1";
-        public static string _defaultImageTag = "2.7.170";
+        public static string _defaultImageTag = "2.7.199";
 
         /// <summary> Helm repository URL </summary>
         public string RepoUrl { get; set; }

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION_FALLBACK = "1.16.10";
-        public const string KUBERNETES_VERSION_MAJ_MIN = "1.16";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.18.10";
+        public const string KUBERNETES_VERSION_MAJ_MIN = "1.18";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -42,8 +42,6 @@
 
     <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
 
-    <PackageReference Include="KubernetesClient" Version="3.0.7" />
-
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.Designer.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.Designer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 2.7.170.
+        ///   Looks up a localized string similar to 2.7.199.
         /// </summary>
         internal static string VALUE_VERSION_IIOT {
             get {

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.resx
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.resx
@@ -142,6 +142,6 @@
     <value>Microsoft.Azure.IIoT.Deployment</value>
   </data>
   <data name="VALUE_VERSION_IIOT" xml:space="preserve">
-    <value>2.7.170</value>
+    <value>2.7.199</value>
   </data>
 </root>

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
@@ -112,16 +112,16 @@
     // azure-industrial-iot Helm chart version
     "ChartVersion": "0.3.1",
     // Azure IIoT components image tag
-    "ImageTag": "2.7.170"
+    "ImageTag": "2.7.199"
   },
 
   // Provides definitions of applications and Service Principals to be used.
   // Those definitions will be used instead of creating new application
   // registrations and Service Principals for deployment of Azure resources.
-  // 
+  //
   // This is useful in ResourceDeployment mode. Execution in
   // ApplicationRegistration run mode will output JSON object for this property.
-  // 
+  //
   // Properties correspond to that of application registration and Service
   // Principal manifests. Definition of application properties can be found
   // here:

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -30,7 +30,7 @@
 
 `Microsoft.Azure.IIoT.Deployment` is a command line application for deploying Azure Industrial IoT solution.
 It takes care of deploying Azure infrastructure resources and microservices of Azure Industrial IoT solution.
-By default, it deploys `2.7.170` version of Azure Industrial IoT microservices.
+By default, it deploys `2.7.199` version of Azure Industrial IoT microservices.
 
 The main difference compared to the [script based deployment](howto-deploy-all-in-one.md) option is that
 from an infrastructure perspective `Microsoft.Azure.IIoT.Deployment` deploys microservices to an Azure
@@ -462,7 +462,7 @@ Command line argument key-value pairs can be specified with:
 | `ResourceGroup:Region`      | Check bellow for list of supported Azure regions.   | Region where new Resource Group should be created.                                           |                                           |
 | `Helm:RepoUrl`              | Should be URL.                                      | Helm repository URL for `azure-industrial-iot` Helm chart.                                   | `https://microsoft.github.io/charts/repo` |
 | `Helm:ChartVersion`         |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.3.1`                                   |
-| `Helm:ImageTag`             |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.7.170`                                 |
+| `Helm:ImageTag`             |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.7.199`                                 |
 | `ApplicationRegistration`   | Object, see [Special Notes](#special-notes) bellow. | Provides definitions of existing Applications and Service Principals to be used.             |                                           |
 | `SaveEnvFile`               | If set, should be `true` or `false`.                | Defines whether to create .env file after successful deployment or not.                      |                                           |
 | `NoCleanup`                 | If set, should be `true` or `false`.                | Defines whether to perform cleanup if an error occurs during deployment.                     |                                           |
@@ -643,7 +643,7 @@ Alternatively, you can run the following commands:
 [documentation](../../deploy/helm/azure-industrial-iot/README.md).
 
 By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.3.1` version of `azure-industrial-iot` Helm chart
-with `2.7.170` version of Azure Industrial IoT components. Both chart version and components version can be
+with `2.7.199` version of Azure Industrial IoT components. Both chart version and components version can be
 changed using configuration parameters. Please check `Helm:ChartVersion` and `Helm:ImageTag` parameters for
 that.
 


### PR DESCRIPTION
Changes:
* Removed unused `KubernetesClient` NuGet.
* Bumped AKS version to `1.18`, fallback version is `1.18.10`.
* Bumped deployed platform version to `2.7.199` from `2.7.170`.

Note: AKS is [deprecating](https://github.com/Azure/AKS/releases/tag/2020-10-26) `1.16.*` versions of Kubernetes.