### PR TITLE
Fixing parsing of version in deployment scripts.

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -31,12 +31,5 @@ echo AzureAD installed.
 set test=
 pushd %current-path%\deploy\scripts
 
-echo %*|find "-version" >nul
-if errorlevel 1 (
-    echo Using preview version.
-    %PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %* -version preview
-) else (
-    echo Using provided version.
-    %PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %*
-)
+%PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %*
 popd

--- a/deploy.cmd
+++ b/deploy.cmd
@@ -31,7 +31,7 @@ echo AzureAD installed.
 set test=
 pushd %current-path%\deploy\scripts
 
-echo %*|findstr /r /c:"^-version " /c:" -version ">nul
+echo %*|find "-version" >nul
 if errorlevel 1 (
     echo Using preview version.
     %PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %* -version preview

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,7 +66,7 @@ fi
 
 # Call powershell script
 curdir="$( cd "$(dirname "$0")" ; pwd -P )"
-version=' -version'
+version='-version'
 if [[ "$@" == *"$version"* ]]; then
   echo "Using provided version..."
   pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,11 +66,4 @@ fi
 
 # Call powershell script
 curdir="$( cd "$(dirname "$0")" ; pwd -P )"
-version='-version'
-if [[ "$@" == *"$version"* ]]; then
-  echo "Using provided version..."
-  pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"
-else
-  echo "Using preview version..."
-  pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@" -version preview
-fi
+pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
  .SYNOPSIS
     Deploys Industrial IoT services to Azure.
 
@@ -65,7 +65,7 @@
 
 param(
     [ValidateSet("minimum", "local", "services", "simulation", "app", "all")] [string] $type = "all",
-    [string] $version,
+    [string] $version = "preview",
     [string] $applicationName,
     [string] $resourceGroupName,
     [string] $resourceGroupLocation,
@@ -1155,6 +1155,8 @@ $script:requiredProviders = @(
     "microsoft.compute",
     "microsoft.containerregistry"
 )
+
+Write-Host "Using '$($script:version)' version..."
 
 Select-RepositoryAndBranch
 Write-Host "Signing in ..."


### PR DESCRIPTION
The code has been tested with the following commands on Windows:

```bash
.\deploy.cmd -version "2.7.199"
.\deploy.cmd -version "2.7.199" -type all
.\deploy.cmd -type all -version "2.7.199"
.\deploy.cmd -version
```

The code has been tested with the following commands on Linux:

```bash
./deploy.sh -version "2.7.199"
./deploy.sh -version "2.7.199" -type all
./deploy.sh -type all -version "2.7.199"
./deploy.sh -version
```