### PR TITLE
IAI: Added principalType to role assignment.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/deployments/jumpbox-vm.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/deployments/jumpbox-vm.json
@@ -324,7 +324,8 @@
             "properties": {
                 "roleDefinitionId": "[variables(parameters('aksBuiltInRoleType'))]",
                 "principalId": "[reference(variables('virtualMachineId'), '2017-12-01', 'Full').identity.principalId]",
-                "scope": "[resourceGroup().id]"
+                "scope": "[resourceGroup().id]",
+                "principalType": "ServicePrincipal"
             }
         },
         {
@@ -338,7 +339,8 @@
             "properties": {
                 "roleDefinitionId": "[variables(parameters('storageBuiltInRoleType'))]",
                 "principalId": "[reference(variables('virtualMachineId'), '2017-12-01', 'Full').identity.principalId]",
-                "scope": "[resourceGroup().id]"
+                "scope": "[resourceGroup().id]",
+                "principalType": "ServicePrincipal"
             }
         },
         {


### PR DESCRIPTION
To fix a known issue with delay of Service Principal creation, we have added  `principalType` field in role assignment properties.

Here are a few relevant links that point to this solution:
* Stack Overflow: [Sometimes ARM template will throw PrincipalNotFound Error when Working with User-assigned Managed Identity](https://stackoverflow.com/questions/60516853/sometimes-arm-template-will-throw-principalnotfound-error-when-working-with-user)
* Microsoft Docs: [Add Azure role assignments using Azure Resource Manager templates](https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-template#new-service-principal)