### PR TITLE
Fixing parsing of version in deployment scripts. (#892)

### DIFF
--- a/deploy.cmd
+++ b/deploy.cmd
@@ -31,12 +31,5 @@ echo AzureAD installed.
 set test=
 pushd %current-path%\deploy\scripts
 
-echo %*|find " -version" >nul
-if errorlevel 1 (
-    echo Using preview version.
-    %PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %* -version preview
-) else (
-    echo Using provided version.
-    %PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %*
-)
+%PWSH% -ExecutionPolicy Unrestricted ./deploy.ps1 %*
 popd

--- a/deploy.sh
+++ b/deploy.sh
@@ -66,11 +66,4 @@ fi
 
 # Call powershell script
 curdir="$( cd "$(dirname "$0")" ; pwd -P )"
-version=' -version'
-if [[ "$@" == *"$version"* ]]; then
-  echo "Using provided version..."
-  pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"
-else
-  echo "Using preview version..."
-  pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@" -version preview
-fi
+pwsh -File $curdir/deploy/scripts/deploy.ps1 "$@"

--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
  .SYNOPSIS
     Deploys Industrial IoT services to Azure
 
@@ -62,7 +62,7 @@
 
 param(
     [ValidateSet("minimum", "local", "services", "simulation", "app", "all")] [string] $type = "all",
-    [string] $version,
+    [string] $version = "preview",
     [string] $applicationName,
     [string] $resourceGroupName,
     [string] $resourceGroupLocation,
@@ -1088,6 +1088,8 @@ $script:requiredProviders = @(
     "microsoft.compute",
     "microsoft.containerregistry"
 )
+
+Write-Host "Using '$($script:version)' version..."
 
 Select-RepositoryAndBranch
 Write-Host "Signing in ..."


### PR DESCRIPTION
Applying changes in (#892) for `2.7.20x` release.

Changes:
* Fixing parsing of version in deployment scripts.
* Moved logic of default version to deploy.ps1.