### PR TITLE
Fix OPC Publisher keeps restarting

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/ModuleFramework.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/ModuleFramework.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework {
     using Microsoft.Azure.IIoT.Tasks.Default;
     using Microsoft.Azure.IIoT.Tasks;
     using Autofac;
+    using Microsoft.Azure.IIoT.Http.Default;
 
     /// <summary>
     /// Injected module framework module
@@ -47,6 +48,8 @@ namespace Microsoft.Azure.IIoT.Module.Framework {
                 .AsImplementedInterfaces().SingleInstance()
                 .IfNotRegistered(typeof(ITaskScheduler));
 #endif
+            // Http client
+            builder.RegisterModule<HttpClientModule>();
 
             // Register edgelet client (uses http)
             builder.RegisterType<EdgeletClient>()


### PR DESCRIPTION
-regression due to recent cleanup effort, adding missing DI dependency for IHttpClient causing restarts
https://msazure.visualstudio.com/One/_workitems/edit/9048620