### PR TITLE
BOM missing from ps1

### DIFF
--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
  .SYNOPSIS
     Deploys Industrial IoT services to Azure
 

--- a/thirdpartynotices.txt
+++ b/thirdpartynotices.txt
@@ -5769,27 +5769,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ---------------------------------------------------------
 
-Portable.BouncyCastle 1.8.5.2 - MIT
-
-
-(c) 2008 VeriSign, Inc.
-(c) 2000-2019 Legion of the Bouncy Castle Inc.
-Copyright (c) 2000 - 2017 The Legion of the Bouncy Castle Inc. (http://www.bouncycastle.org)
-
-MIT License
-
-Copyright (c) <year> <copyright holders>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
----------------------------------------------------------
-
----------------------------------------------------------
-
 YamlDotNet 6.0.0 - MIT
 
 

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.7",
-  "versionHeightOffset": 9,
+  "versionHeightOffset": 8,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/\\d+\\.\\d+"

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
   "version": "2.7",
-  "versionHeightOffset": 8,
+  "versionHeightOffset": 7,
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/heads/release/\\d+\\.\\d+"


### PR DESCRIPTION
The BOM got removed from the deploy.ps1 script and would not parse anymore.   Adding it back.