### PR TITLE
Dynamic changes to published nodes json file (under linux)

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/src/Default/NewtonSoftJsonSerializer.cs
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/src/Default/NewtonSoftJsonSerializer.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Azure.IIoT.Serializers.NewtonSoft {
                     return jsonSerializer.Deserialize(reader, type);
                 }
             }
+            catch (JsonSerializationException ex) {
+                throw new SerializerException(ex.Message, ex);
+            }
             catch (JsonReaderException ex) {
                 throw new SerializerException(ex.Message, ex);
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -192,13 +192,16 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                                     });
                             }
                         }
-                        _agentConfig.MaxWorkers = availableJobs.Count;
-                        ThreadPool.GetMinThreads(out var workerThreads, out var asyncThreads);
-                        if (_agentConfig.MaxWorkers > workerThreads ||
-                            _agentConfig.MaxWorkers > asyncThreads) {
-                            var result = ThreadPool.SetMinThreads(_agentConfig.MaxWorkers.Value, _agentConfig.MaxWorkers.Value);
-                            _logger.Information("Thread pool changed to: worker {worker}, async {async} threads {succeeded}",
-                                _agentConfig.MaxWorkers.Value, _agentConfig.MaxWorkers.Value, result ? "succeeded" : "failed");
+                        if (_agentConfig.MaxWorkers < availableJobs.Count && availableJobs.Count > 1) {
+                            _agentConfig.MaxWorkers = availableJobs.Count;
+
+                            ThreadPool.GetMinThreads(out var workerThreads, out var asyncThreads);
+                            if (_agentConfig.MaxWorkers > workerThreads ||
+                                _agentConfig.MaxWorkers > asyncThreads) {
+                                var result = ThreadPool.SetMinThreads(_agentConfig.MaxWorkers.Value, _agentConfig.MaxWorkers.Value);
+                                _logger.Information("Thread pool changed to: worker {worker}, async {async} threads {succeeded}",
+                                    _agentConfig.MaxWorkers.Value, _agentConfig.MaxWorkers.Value, result ? "succeeded" : "failed");
+                            }
                         }
                         _availableJobs = availableJobs;
                         _assignedJobs.Clear();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.Azure.IIoT.Exceptions;
 
     /// <summary>
     /// Published nodes
@@ -53,6 +54,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
             _logger.Debug("Reading published nodes file ({elapsed}", sw.Elapsed);
             var items = _serializer.Deserialize<List<PublishedNodesEntryModel>>(
                 publishedNodesFile);
+            if (items == null) {
+                throw new SerializerException("Published nodes files, missformed");
+            }
             _logger.Information(
                 "Read {count} items from published nodes file in {elapsed}",
                 items.Count, sw.Elapsed);
@@ -88,7 +92,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                         },
                         User = item.OpcAuthenticationMode != OpcAuthenticationMode.UsernamePassword ?
                                 null : ToUserNamePasswordCredentialAsync(item).Result,
-                        
+
                     },
                         // Select and batch nodes into published data set sources
                         item => GetNodeModels(item, legacyCliModel.ScaleTestCount.GetValueOrDefault(1)),
@@ -114,7 +118,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                     .Select(node => new PublishedDataSetVariableModel {
                                         // this is the monitored item id, not the nodeId!
                                         // Use the display name if any otherwise the nodeId
-                                        Id = string.IsNullOrEmpty(node.DisplayName) ? 
+                                        Id = string.IsNullOrEmpty(node.DisplayName) ?
                                                 string.IsNullOrEmpty(node.DataSetFieldId) ? node.Id : node.DataSetFieldId : node.DisplayName,
                                         PublishedVariableNodeId = node.Id,
                                         PublishedVariableDisplayName = node.DisplayName,


### PR DESCRIPTION
Changes to published nodes files, currently ending up in unexpected behavior. 

* Handling error while deserialization published nodes json
* Don't set MaxWorker if there are not work items in published nodes json
* Improved logging while reloading published nodes json

