### PR TITLE
published nodes with different "groups/assets" for same endpoint causing closing and reopening of sessions

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// <param name="ct"></param>
         /// <returns></returns>
         public Task<JobProcessingInstructionModel> GetAvailableJobAsync(string workerId, JobRequestModel request, CancellationToken ct = default) {
+            _lock.Wait(ct);
             try {
-                _lock.Wait(ct);
                 if (_assignedJobs.TryGetValue(workerId, out var job)) {
                     return Task.FromResult(job);
                 }
@@ -110,9 +110,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// <param name="ct"></param>
         /// <returns></returns>
         public Task<HeartbeatResultModel> SendHeartbeatAsync(HeartbeatModel heartbeat, CancellationToken ct = default) {
+            _lock.Wait(ct);
             try {
-                _lock.Wait(ct);
-
                 HeartbeatResultModel heartbeatResultModel;
                 JobProcessingInstructionModel job = null;
                 if (heartbeat.Job != null) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -91,8 +91,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 return Task.FromResult(job);
             }
             catch(OperationCanceledException) {
-                JobProcessingInstructionModel job = null;
-                return Task.FromResult(job);
+                _logger.Information("Operation GetAvailableJobAsync was canceled");
+                throw;
             }
             catch(Exception e) {
                 _logger.Error(e, "Error while looking for available jobs, for {Worker}", workerId);
@@ -147,6 +147,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     job?.Job?.Id);
 
                 return Task.FromResult(heartbeatResultModel);
+            }
+            catch (OperationCanceledException) {
+                _logger.Information("Operation SendHeartbeatAsync was canceled");
+                throw;
             }
             finally {
                 _lock.Release();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -167,7 +167,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                             }
 
                             foreach (var job in jobs) {
-                                var jobId = $"Standalone_{_identity.DeviceId}_{_identity.ModuleId}";
+                                var jobId = string.IsNullOrEmpty(job.WriterGroup.WriterGroupId)
+                                        ? $"Standalone_{_identity.DeviceId}_{Guid.NewGuid()} "
+                                        : job.WriterGroup.WriterGroupId;
+
                                 job.WriterGroup.DataSetWriters.ForEach(d => {
                                     d.DataSet.ExtensionFields ??= new Dictionary<string, string>();
                                     d.DataSet.ExtensionFields["PublisherId"] = jobId;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             for (var i = 0; i < 10; i++) {
                 tasks.Add(converter.GetAvailableJobAsync(i.ToString(), new JobRequestModel()));
             }
-            
+
             await Task.WhenAll(tasks);
 
             Assert.Equal(2, tasks.Count(t => t.Result != null));
@@ -51,6 +51,31 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 .Select(t => t.Result.Job.JobConfiguration)
                 .Distinct();
             Assert.Equal(2, distinctConfigurations.Count());
+        }
+
+        [Fact]
+        public void Test_PnJson_With_Multiple_Jobs_Expect_DifferentJobIds() {
+            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
+            var identityMock = new Mock<IIdentity>();
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+            var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
+            var publishedNodesJobConverter = new PublishedNodesJobConverter(TraceLogger.Create(), newtonSoftJsonSerializer);
+
+            var legacyCliModel = new LegacyCliModel { PublishedNodesFile = "Engine/pn_assets.json" };
+            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
+
+            var converter = new LegacyJobOrchestrator(publishedNodesJobConverter, legacyCliModelProviderMock.Object, agentConfigProviderMock.Object, jobSerializer, TraceLogger.Create(), identityMock.Object);
+
+            var job1 = converter.GetAvailableJobAsync(1.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.NotNull(job1);
+            var job2 = converter.GetAvailableJobAsync(2.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.NotNull(job2);
+            var job3 = converter.GetAvailableJobAsync(3.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.Null(job3);
+
+            Assert.NotEqual(job1.Job.Id, job2.Job.Id);
         }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_assets.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_assets.json
@@ -1,0 +1,34 @@
+[
+  {
+    "DataSetWriterId": "Leaf0_10000_3085991c-b85c-4311-9bfb-a916da952234",
+    "DataSetWriterGroup": "Leaf0",
+    "DataSetPublishingInterval": 10000,
+    "EndpointUrl": "opc.tcp://opcplc:50000",
+    "UseSecurity": false,
+    "OpcAuthenticationMode": "Anonymous",
+    "OpcAuthenticationUsername": "",
+    "OpcAuthenticationPassword": "",
+    "OpcNodes": [
+      {
+        "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=StepUp",
+        "DataSetFieldId": "nsu=http://microsoft.com/Opc/OpcPlc/;s=StepUp"
+      }
+    ]
+  },
+  {
+    "DataSetWriterId": "Leaf1_10000_2e4fc28f-ffa2-4532-9f22-378d47bbee5d",
+    "DataSetWriterGroup": "Leaf1",
+    "DataSetPublishingInterval": 10000,
+    "EndpointUrl": "opc.tcp://opcplc:50000",
+    "UseSecurity": false,
+    "OpcAuthenticationMode": "Anonymous",
+    "OpcAuthenticationUsername": "",
+    "OpcAuthenticationPassword": "",
+    "OpcNodes": [
+      {
+        "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1",
+        "DataSetFieldId": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+      }
+    ]
+  }
+]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -35,5 +35,8 @@
     <None Update="Engine\publishednodes.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Engine\pn_assets.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Problems:**
* Jobs generated out of published nodes file, all have same id
* GetAvailableJobAsync didn't lock when called from multiple worker
* SendHeartbeatAsync logic with "dirty flag" (_updated) error prone

**Solutions:**
* Use DataGroupId as job id (if available) otherwise include GUID
* Add lock and exception handling to GetAwailableJobAsync
* SendHeartbeatAsync just working on _assignedJobs dictionary

**Tests:**
* added test to verify job ids are unequal