### PR TITLE
Added release branch name to git clone command.

### DIFF
--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -2,7 +2,7 @@
 
 [Home](readme.md)
 
-This article explains how to deploy the Azure Industrial IoT Platform and Simulation in Azure using the deployment scripts.  
+This article explains how to deploy the Azure Industrial IoT Platform and Simulation in Azure using the deployment scripts.
 The ARM deployment templates included in the repository deploy the platform and an entire simulation environment consisting of
 
 - Linux and Windows IoT Edge simulation running all required modules
@@ -15,10 +15,10 @@ The ARM deployment templates included in the repository deploy the platform and 
 
 The platform and simulation can also be deployed using the deploy script.
 
-1. If you have not done so yet, clone the GitHub repository.  To clone the repository you need git.  If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it.  Open a new command prompt or terminal and run:
+1. If you have not done so yet, clone the GitHub repository from one of our release branches, `release/2.7.206` for example. To clone the repository you need git. If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it. Open a new command prompt or terminal and run:
 
    ```bash
-   git clone https://github.com/Azure/Industrial-IoT
+   git clone -b <ReleaseBranchName> https://github.com/Azure/Industrial-IoT
    cd Industrial-IoT
    ```
 
@@ -38,16 +38,16 @@ The platform and simulation can also be deployed using the deploy script.
 
    > Additional supported parameters can be found [here](#deployment-script-options).
 
-3. Follow the prompts to assign a name to the resource group of the deployment and a name to the website. The script deploys the Microservices and their Azure platform dependencies into the resource group in your Azure subscription.  The script also registers an Application in your Azure Active Directory (AAD) tenant to support OAUTH based authentication.  
-   Deployment will take several minutes.  An example of what you'd see once the solution is successfully deployed:
+3. Follow the prompts to assign a name to the resource group of the deployment and a name to the website. The script deploys the Microservices and their Azure platform dependencies into the resource group in your Azure subscription. The script also registers an Application in your Azure Active Directory (AAD) tenant to support OAUTH based authentication.
+   Deployment will take several minutes. An example of what you'd see once the solution is successfully deployed:
 
    ![Deployment Result](../media/deployment-succeeded.png)
 
-   The output includes the  URL of the public endpoint.  
+   The output includes the URL of the public endpoint.
 
    In case you run into issues please follow the steps [below](#troubleshooting-deployment-failures).
 
-4. Once the script completes successfully, select whether you want to save the `.env` file.  You need the `.env` environment file if you want to connect to the cloud endpoint using tools such as the [Console](../tutorials/tut-use-cli.md) or for debugging.
+4. Once the script completes successfully, select whether you want to save the `.env` file. You need the `.env` environment file if you want to connect to the cloud endpoint using tools such as the [Console](../tutorials/tut-use-cli.md) or for debugging.
 
 ## Troubleshooting deployment failures
 
@@ -82,17 +82,17 @@ Choose R to run once.
 
 ### Resource group name
 
-Ensure you use a short and simple resource group name.  The name is used also to name resources as such it must comply with resource naming requirements.  
+Ensure you use a short and simple resource group name. The name is used also to name resources as such it must comply with resource naming requirements.
 
 ### Website name already in use
 
-It is possible that the name of the website is already in use.  If you run into this error, you need to use a different application name.
+It is possible that the name of the website is already in use. If you run into this error, you need to use a different application name.
 
 ### Azure Active Directory Registration
 
-The deployment script tries to register 2 Azure Active Directory (AAD) applications representing the client and the platform (service).  Depending on your rights to the selected AAD tenant, this might fail.
+The deployment script tries to register 2 Azure Active Directory (AAD) applications representing the client and the platform (service). Depending on your rights to the selected AAD tenant, this might fail.
 
-An administrator with the relevant rights to the tenant can create the AAD applications for you.  The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying.  The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
+An administrator with the relevant rights to the tenant can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying. The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
 
 ```pwsh
 pwsh
@@ -103,7 +103,7 @@ cd deploy/scripts
 
 ### Missing Script dependencies
 
-On **Windows**, the script uses Powershell, which comes with Windows.  The deploy batch file uses it to install all required modules.
+On **Windows**, the script uses Powershell, which comes with Windows. The deploy batch file uses it to install all required modules.
 
 In case you run into issues, e.g. because you want to use pscore, run following two commands in PowerShell as Administrator. For more info on AzureAD and Az modules, refer [here](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
@@ -140,7 +140,7 @@ To install all necessary requirements on other Linux distributions follow these 
 
 ## Deployment script options
 
-Using the  `deploy/scripts/deploy.ps1`  script you can deploy several configurations including deploying images from a private Azure Container Registry (ACR).
+Using the `deploy/scripts/deploy.ps1` script you can deploy several configurations including deploying images from a private Azure Container Registry (ACR).
 
 To support these scenarios, the `deploy.ps1` takes the following parameters:
 
@@ -165,16 +165,16 @@ To support these scenarios, the `deploy.ps1` takes the following parameters:
     The account name to use if not to use default.
 
  .PARAMETER applicationName
-    The name of the application if not local deployment. 
+    The name of the application if not local deployment.
 
  .PARAMETER aadConfig
-    The aad configuration file or object (use aad-register.ps1 to create).  If not provided, calls aad-register.ps1.
+    The aad configuration file or object (use aad-register.ps1 to create). If not provided, calls aad-register.ps1.
 
  .PARAMETER context
     A previously created az context to be used as authentication.
 
  .PARAMETER aadApplicationName
-    The application name to use when registering aad application.  If not set, uses applicationName
+    The application name to use when registering aad application. If not set, uses applicationName
 
  .PARAMETER acrRegistryName
     An optional name of a Azure container registry to deploy containers from.


### PR DESCRIPTION
Changes:
* Added release branch name to git clone command in deployment instructions. This transfers the changes that we already have in the `master` branch to `release/2.7.206` branch to eliminate deployment issues for customers.
* Removed double whitespaces in text and trailing whitespaces.