### PR TITLE
Added release branch name to git clone command.

### DIFF
--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -112,7 +112,7 @@ The following details of the Azure IoT Hub would be required:
     ```
 
     Here are our recommended names for them:
-  
+
     * `events`: will be used by `eventsProcessor` microservices
     * `telemetry`: will be used by `telemetryProcessor` microservices
     * `tunnel`: will be used by `tunnelProcessor` microservices
@@ -344,7 +344,7 @@ The following details of **ServicesApp** AAD App Registrations will be required:
 * Client secret for **ServicesApp**. Client secret is also referred to as password. Here you can either
   provide client secret that you got when creating AAD App Registration. Or you can create a new client
   secret and use that.
-  
+
   Here are the steps to create new client secret
   [using portal](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#create-a-new-application-secret),
   or you can create a new client secret (password) using the following command:
@@ -388,7 +388,7 @@ The following details of **ClientsApp** AAD App Registrations will be required:
 * Client secret for **ClientsApp**. Client secret is also referred to as password. Here you can either
   provide client secret that you got when creating AAD App Registration. Or you can create a new client
   secret and use that.
-  
+
   Here are the steps to create new client secret
   [using portal](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#create-a-new-application-secret),
   or you can create a new client secret (password) using the following command:
@@ -500,7 +500,7 @@ The following details of the Azure Storage account would be required:
     automatically.
 
     Configuration parameter for this is `azure.adlsg2.container.cdm.name`.
-  
+
   * Root folder within the container. Defaults to `IIoTDataFlow`.
 
     Configuration parameter for this is `azure.adlsg2.container.cdm.rootFolder`.
@@ -1090,7 +1090,7 @@ This configuration makes sure that:
 * processing of forwarded headers is enabled:
   * [`use-forward-headers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers)
   * [`compute-full-forward-for`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#compute-full-forwarded-for)
-  
+
 * authentication response from Azure AAD is delivered to components:
   * [`proxy-buffer-size`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-buffer-size)
 

--- a/docs/architecture-details.md
+++ b/docs/architecture-details.md
@@ -2,7 +2,7 @@
 
 [Home](readme.md)
 
-The following diagram shows a more detailed view of the platform components.  
+The following diagram shows a more detailed view of the platform components.
 
 ![architecture](media/architecture2.svg)
 

--- a/docs/architecture-flow.md
+++ b/docs/architecture-flow.md
@@ -6,7 +6,7 @@ The following diagrams illustrate the OPC Twin architecture and how its componen
 
 ## Discovery and Activation
 
-1. The operator enables network scanning on the [OPC Twin module](modules/twin.md) or sends a one-time discovery using a discovery URL. The discovered endpoints and server application information is sent via telemetry to the onboarding agent for processing.  The [OPC UA onboarding agent](services/onboarding.md) processes these discovery events sent. The discovery events result in application registration and updates in Azure IoT Hub.  
+1. The operator enables network scanning on the [OPC Twin module](modules/twin.md) or sends a one-time discovery using a discovery URL. The discovered endpoints and server application information is sent via telemetry to the onboarding agent for processing.  The [OPC UA onboarding agent](services/onboarding.md) processes these discovery events sent. The discovery events result in application registration and updates in Azure IoT Hub.
 
    ![How OPC Twin works](media/twin1.png)
 
@@ -16,11 +16,11 @@ The following diagrams illustrate the OPC Twin architecture and how its componen
 
 ## Interact with a Server Endpoint
 
-1. Once activated, the operator can use the [OPC Twin Microservice](services/twin.md) REST API to browse or inspect the server information model, read/write object variables and call methods.  The API expects the Azure IoT Hub identity of one of the registered Server endpoints.  
+1. Once activated, the operator can use the [OPC Twin Microservice](services/twin.md) REST API to browse or inspect the server information model, read/write object variables and call methods.  The API expects the Azure IoT Hub identity of one of the registered Server endpoints.
 
    ![How OPC Twin works](media/twin3.png)
 
-1. The [OPC Twin Microservice](services/twin.md) REST interface can also be used to create monitored items and subscriptions inside the [OPC Publisher](publisher.md) module. The OPC Publisher sends variable changes and events in the OPC UA server as telemetry to Azure IoT Hub.  
+1. The [OPC Twin Microservice](services/twin.md) REST interface can also be used to create monitored items and subscriptions inside the [OPC Publisher](publisher.md) module. The OPC Publisher sends variable changes and events in the OPC UA server as telemetry to Azure IoT Hub.
 
    ![How OPC Twin works](media/twin4.png)
 

--- a/docs/deploy/howto-deploy-all-in-one.md
+++ b/docs/deploy/howto-deploy-all-in-one.md
@@ -2,7 +2,7 @@
 
 [Home](readme.md)
 
-This article explains how to deploy the Azure Industrial IoT Platform and Simulation in Azure using the deployment scripts.  
+This article explains how to deploy the Azure Industrial IoT Platform and Simulation in Azure using the deployment scripts.
 The ARM deployment templates included in the repository deploy the platform and an entire simulation environment consisting of
 
 - Linux and Windows IoT Edge simulation running all required modules
@@ -15,10 +15,10 @@ The ARM deployment templates included in the repository deploy the platform and 
 
 The platform and simulation can also be deployed using the deploy script.
 
-1. If you have not done so yet, clone the GitHub repository.  To clone the repository you need git.  If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it.  Open a new command prompt or terminal and run:
+1. If you have not done so yet, clone the GitHub repository from one of our release branches, `release/2.7.206` for example. To clone the repository you need git. If you do not have git installed on your system, follow the instructions for [Linux or Mac](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git), or [Windows](https://gitforwindows.org/) to install it. Open a new command prompt or terminal and run:
 
    ```bash
-   git clone https://github.com/Azure/Industrial-IoT
+   git clone -b <ReleaseBranchName> https://github.com/Azure/Industrial-IoT
    cd Industrial-IoT
    ```
 
@@ -38,16 +38,16 @@ The platform and simulation can also be deployed using the deploy script.
 
    > Additional supported parameters can be found [here](#deployment-script-options).
 
-3. Follow the prompts to assign a name to the resource group of the deployment and a name to the website. The script deploys the Microservices and their Azure platform dependencies into the resource group in your Azure subscription.  The script also registers an Application in your Azure Active Directory (AAD) tenant to support OAUTH based authentication.  
-   Deployment will take several minutes.  An example of what you'd see once the solution is successfully deployed:
+3. Follow the prompts to assign a name to the resource group of the deployment and a name to the website. The script deploys the Microservices and their Azure platform dependencies into the resource group in your Azure subscription. The script also registers an Application in your Azure Active Directory (AAD) tenant to support OAUTH based authentication.
+   Deployment will take several minutes. An example of what you'd see once the solution is successfully deployed:
 
    ![Deployment Result](../media/deployment-succeeded.png)
 
-   The output includes the  URL of the public endpoint.  
+   The output includes the URL of the public endpoint.
 
    In case you run into issues please follow the steps [below](#troubleshooting-deployment-failures).
 
-4. Once the script completes successfully, select whether you want to save the `.env` file.  You need the `.env` environment file if you want to connect to the cloud endpoint using tools such as the [Console](../tutorials/tut-use-cli.md) or for debugging.
+4. Once the script completes successfully, select whether you want to save the `.env` file. You need the `.env` environment file if you want to connect to the cloud endpoint using tools such as the [Console](../tutorials/tut-use-cli.md) or for debugging.
 
 ## Troubleshooting deployment failures
 
@@ -82,17 +82,17 @@ Choose R to run once.
 
 ### Resource group name
 
-Ensure you use a short and simple resource group name.  The name is used also to name resources as such it must comply with resource naming requirements.  
+Ensure you use a short and simple resource group name. The name is used also to name resources as such it must comply with resource naming requirements.
 
 ### Website name already in use
 
-It is possible that the name of the website is already in use.  If you run into this error, you need to use a different application name.
+It is possible that the name of the website is already in use. If you run into this error, you need to use a different application name.
 
 ### Azure Active Directory Registration
 
-The deployment script tries to register 2 Azure Active Directory (AAD) applications representing the client and the platform (service).  Depending on your rights to the selected AAD tenant, this might fail.
+The deployment script tries to register 2 Azure Active Directory (AAD) applications representing the client and the platform (service). Depending on your rights to the selected AAD tenant, this might fail.
 
-An administrator with the relevant rights to the tenant can create the AAD applications for you.  The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying.  The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
+An administrator with the relevant rights to the tenant can create the AAD applications for you. The `deploy/scripts` folder contains the `aad-register.ps1` script to perform the AAD registration separately from deploying. The output of the script is an object containing the relevant information to be used as part of deployment and must be passed to the `deploy.ps1` script in the same folder using the `-aadConfig` argument.
 
 ```pwsh
 pwsh
@@ -103,7 +103,7 @@ cd deploy/scripts
 
 ### Missing Script dependencies
 
-On **Windows**, the script uses Powershell, which comes with Windows.  The deploy batch file uses it to install all required modules.
+On **Windows**, the script uses Powershell, which comes with Windows. The deploy batch file uses it to install all required modules.
 
 In case you run into issues, e.g. because you want to use pscore, run following two commands in PowerShell as Administrator. For more info on AzureAD and Az modules, refer [here](https://docs.microsoft.com/en-us/powershell/azure/install-az-ps).
 
@@ -140,7 +140,7 @@ To install all necessary requirements on other Linux distributions follow these 
 
 ## Deployment script options
 
-Using the  `deploy/scripts/deploy.ps1`  script you can deploy several configurations including deploying images from a private Azure Container Registry (ACR).
+Using the `deploy/scripts/deploy.ps1` script you can deploy several configurations including deploying images from a private Azure Container Registry (ACR).
 
 To support these scenarios, the `deploy.ps1` takes the following parameters:
 
@@ -165,16 +165,16 @@ To support these scenarios, the `deploy.ps1` takes the following parameters:
     The account name to use if not to use default.
 
  .PARAMETER applicationName
-    The name of the application if not local deployment. 
+    The name of the application if not local deployment.
 
  .PARAMETER aadConfig
-    The aad configuration file or object (use aad-register.ps1 to create).  If not provided, calls aad-register.ps1.
+    The aad configuration file or object (use aad-register.ps1 to create). If not provided, calls aad-register.ps1.
 
  .PARAMETER context
     A previously created az context to be used as authentication.
 
  .PARAMETER aadApplicationName
-    The application name to use when registering aad application.  If not set, uses applicationName
+    The application name to use when registering aad application. If not set, uses applicationName
 
  .PARAMETER acrRegistryName
     An optional name of a Azure container registry to deploy containers from.

--- a/docs/deploy/howto-deploy-modules-portal.md
+++ b/docs/deploy/howto-deploy-modules-portal.md
@@ -6,7 +6,7 @@ This article explains how to deploy the Industrial IoT Edge modules to [Azure Io
 
 Before you begin, make sure you followed the [instructions to set up a IoT Edge device](howto-install-iot-edge.md) and have a running IoT Edge Gateway.
 
-To deploy all required modules to the Gateway using the Azure Portal...  
+To deploy all required modules to the Gateway using the Azure Portal...
 
 1. Sign in to the [Azure portal](https://portal.azure.com/) and navigate to the IoT Hub deployed earlier.
 
@@ -34,7 +34,7 @@ To deploy all required modules to the Gateway using the Azure Portal...
 
    Fill out the optional fields if necessary. For more information about container create options, restart policy, and desired status see [EdgeAgent desired properties](https://docs.microsoft.com/azure/iot-edge/module-edgeagent-edgehub#edgeagent-desired-properties). For more information about the module twin see [Define or update desired properties](https://docs.microsoft.com/azure/iot-edge/module-composition#define-or-update-desired-properties).
 
-7. Select **Save** and repeat step **5**.  
+7. Select **Save** and repeat step **5**.
 
 8. In the **IoT Edge Custom Module** dialog use `twin` as name for the module, then specify the container *image URI* as
 
@@ -44,7 +44,7 @@ To deploy all required modules to the Gateway using the Azure Portal...
 
    Leave the *create options* empty.
 
-9. Select **Save** and repeat step **5**.  
+9. Select **Save** and repeat step **5**.
 
 10. In the IoT Edge Custom Module dialog, use `publisher` as name for the module and the container *image URI* as
 


### PR DESCRIPTION
Changes:
* Added release branch name to git clone command in deployment instructions. This transfers the changes that we already have in the `master` branch to `release/2.7.206` branch to eliminate deployment issues for customers.
* Removed double whitespaces in text and trailing whitespaces.