### PR TITLE
Helm: Added details about 0.3.2 version of the chart.

### DIFF
--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -110,7 +110,7 @@ The following details of the Azure IoT Hub would be required:
     ```
 
     Here are our recommended names for them:
-  
+
     * `events`: will be used by `eventsProcessor` microservices
     * `telemetry`: will be used by `telemetryProcessor` microservices
     * `onboarding`: will be used by `onboarding` microservices
@@ -318,7 +318,7 @@ The following details of **ServicesApp** AAD App Registrations will be required:
 * Client secret for **ServicesApp**. Client secret is also referred to as password. Here you can either
   provide client secret that you got when creating AAD App Registration. Or you can create a new client
   secret and use that.
-  
+
   Here are the steps to create new client secret
   [using portal](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#create-a-new-application-secret),
   or you can create a new client secret (password) using the following command:
@@ -362,7 +362,7 @@ The following details of **ClientsApp** AAD App Registrations will be required:
 * Client secret for **ClientsApp**. Client secret is also referred to as password. Here you can either
   provide client secret that you got when creating AAD App Registration. Or you can create a new client
   secret and use that.
-  
+
   Here are the steps to create new client secret
   [using portal](https://docs.microsoft.com/azure/active-directory/develop/howto-create-service-principal-portal#create-a-new-application-secret),
   or you can create a new client secret (password) using the following command:
@@ -498,7 +498,7 @@ The following details of the Azure Storage account would be required:
     automatically.
 
     Configuration parameter for this is `azure.adlsg2.container.cdm.name`.
-  
+
   * Root folder within the container. Defaults to `IIoTDataFlow`.
 
     Configuration parameter for this is `azure.adlsg2.container.cdm.rootFolder`.
@@ -1071,7 +1071,7 @@ This configuration makes sure that:
 * processing of forwarded headers is enabled:
   * [`use-forward-headers`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#use-forwarded-headers)
   * [`compute-full-forward-for`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#compute-full-forwarded-for)
-  
+
 * authentication response from Azure AAD is delivered to components:
   * [`proxy-buffer-size`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-buffer-size)
 

--- a/docs/deploy/howto-add-aks-to-ps1.md
+++ b/docs/deploy/howto-add-aks-to-ps1.md
@@ -505,7 +505,7 @@ For installing the chart, please use `aiiot.yaml` that you created above and run
 helm install aiiot --namespace aiiot .\deploy\helm\azure-industrial-iot\ -f aiiot.yaml
 ```
 
-`aiiot.yaml` that we created above is for `0.4.0` or `0.3.1` versions of the Helm chart. Please modify it
+`aiiot.yaml` that we created above is for `0.4.0` or `0.3.2` versions of the Helm chart. Please modify it
 accordingly if you want to install a different version of the chart. Please check documentation of each
 version for a list of applicable values for that specific version. Documentation links of different versions
 of the chart can be found in [Deploying Azure Industrial IoT Platform Microservices Using Helm](howto-deploy-helm.md).

--- a/docs/deploy/howto-deploy-helm.md
+++ b/docs/deploy/howto-deploy-helm.md
@@ -9,7 +9,9 @@ of our microservices:
   Platform microservices.
 - `0.2.0` version of `azure-industrial-iot` Helm chart to deploy `2.6` version of Azure Industrial IoT
   Platform microservices.
-- `0.3.1` version of `azure-industrial-iot` Helm chart to deploy `2.7` version of Azure Industrial IoT
+- `0.3.1` version of `azure-industrial-iot` Helm chart to deploy `2.7` version (up until `2.7.199`) of Azure
+  Industrial IoT Platform microservices.
+- `0.3.2` version of `azure-industrial-iot` Helm chart to deploy `2.7.206` version of Azure Industrial IoT
   Platform microservices.
 - `0.4.0` version of `azure-industrial-iot` Helm chart to deploy `2.8` version of Azure Industrial IoT
   Platform microservices.
@@ -23,6 +25,7 @@ Kubernetes cluster:
 - For `0.1.0` version of the Chart: [Azure Industrial IoT Helm Chart v0.1.0](https://github.com/Azure/Industrial-IoT/blob/helm/0.1.0/deploy/helm/azure-industrial-iot/README.md)
 - For `0.2.0` version of the Chart: [Azure Industrial IoT Helm Chart v0.2.0](https://github.com/Azure/Industrial-IoT/blob/helm/0.2.0/deploy/helm/azure-industrial-iot/README.md)
 - For `0.3.1` version of the Chart: [Azure Industrial IoT Helm Chart v0.3.1](https://github.com/Azure/Industrial-IoT/blob/helm_0.3.1/deploy/helm/azure-industrial-iot/README.md)
+- For `0.3.2` version of the Chart: [Azure Industrial IoT Helm Chart v0.3.2](https://github.com/Azure/Industrial-IoT/blob/helm_0.3.2/deploy/helm/azure-industrial-iot/README.md)
 
 For latest (`0.4.0`) documentation and chart sources please check [deploy/helm/azure-industrial-iot/](../../deploy/helm/azure-industrial-iot/)
 directory.


### PR DESCRIPTION
Updated the following documentation pages to include details about `0.3.2` version of `azure-industrial-iot` Helm chart:
* `docs/deploy/howto-add-aks-to-ps1.md`
* `docs/deploy/howto-deploy-helm.md`

Removed some trailing whitespaces.