### PR TITLE
Reporting errors via return codes when a node that is not present in any jobs is unpublished.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Adapter/PublisherServicesApiAdapter.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Adapter/PublisherServicesApiAdapter.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher {
     using Microsoft.Azure.IIoT.OpcUa.Publisher;
     using System;
     using System.Threading.Tasks;
+    using System.Threading;
 
     /// <summary>
     /// Implements node and publish services as adapter on top of api.
@@ -25,33 +26,45 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher {
 
         /// <inheritdoc/>
         public async Task<PublishStartResultModel> NodePublishStartAsync(
-            string endpoint, PublishStartRequestModel request) {
+            string endpoint,
+            PublishStartRequestModel request,
+            CancellationToken ct = default
+        ) {
             var result = await _client.NodePublishStartAsync(endpoint,
-                request.ToApiModel());
+                request.ToApiModel(), ct);
             return result.ToServiceModel();
         }
 
         /// <inheritdoc/>
         public async Task<PublishStopResultModel> NodePublishStopAsync(
-            string endpoint, PublishStopRequestModel request) {
+            string endpoint,
+            PublishStopRequestModel request,
+            CancellationToken ct = default
+        ) {
             var result = await _client.NodePublishStopAsync(endpoint,
-                request.ToApiModel());
+                request.ToApiModel(), ct);
             return result.ToServiceModel();
         }
 
         /// <inheritdoc/>
         public async Task<PublishBulkResultModel> NodePublishBulkAsync(
-            string endpoint, PublishBulkRequestModel request) {
+            string endpoint,
+            PublishBulkRequestModel request,
+            CancellationToken ct = default
+        ) {
             var result = await _client.NodePublishBulkAsync(endpoint,
-                request.ToApiModel());
+                request.ToApiModel(), ct);
             return result.ToServiceModel();
         }
 
         /// <inheritdoc/>
         public async Task<PublishedItemListResultModel> NodePublishListAsync(
-            string endpoint, PublishedItemListRequestModel request) {
+            string endpoint,
+            PublishedItemListRequestModel request,
+            CancellationToken ct = default
+        ) {
             var result = await _client.NodePublishListAsync(endpoint,
-                request.ToApiModel());
+                request.ToApiModel(), ct);
             return result.ToServiceModel();
         }
 

--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
     using Microsoft.Azure.IIoT.Agent.Framework.Models;
     using Microsoft.Azure.IIoT.Auth.Models;
     using System.Linq;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Api model extensions
@@ -2015,18 +2016,20 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// </summary>
         /// <param name="model"></param>
         public static PublishBulkResponseApiModel ToApiModel(
-            this PublishBulkResultModel model) {
+            this PublishBulkResultModel model
+        ) {
             if (model == null) {
                 return null;
             }
-            return new PublishBulkResponseApiModel {
+
+            var apiModel = new PublishBulkResponseApiModel {
                 NodesToAdd = model.NodesToAdd?
-                    .Select(n => n.ToApiModel())
-                    .ToList(),
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToApiModel()),
                 NodesToRemove = model.NodesToRemove?
-                    .Select(n => n.ToApiModel())
-                    .ToList()
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToApiModel())
             };
+
+            return apiModel;
         }
 
         /// <summary>
@@ -2034,18 +2037,20 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// </summary>
         /// <param name="model"></param>
         public static PublishBulkResultModel ToServiceModel(
-            this PublishBulkResponseApiModel model) {
+            this PublishBulkResponseApiModel model
+        ) {
             if (model == null) {
                 return null;
             }
-            return new PublishBulkResultModel {
+
+            var serviceModel = new PublishBulkResultModel {
                 NodesToAdd = model.NodesToAdd?
-                    .Select(n => n.ToServiceModel())
-                    .ToList(),
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToServiceModel()),
                 NodesToRemove = model.NodesToRemove?
-                    .Select(n => n.ToServiceModel())
-                    .ToList()
+                    .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ToServiceModel())
             };
+
+            return serviceModel;
         }
 
         /// <summary>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishBulkResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishBulkResponseApiModel.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// </summary>
         [DataMember(Name = "nodesToAdd", Order = 0,
             EmitDefaultValue = false)]
-        public List<ServiceResultApiModel> NodesToAdd { get; set; }
+        public Dictionary<string, ServiceResultApiModel> NodesToAdd { get; set; }
 
         /// <summary>
         /// Node to remove
         /// </summary>
         [DataMember(Name = "nodesToRemove", Order = 1,
             EmitDefaultValue = false)]
-        public List<ServiceResultApiModel> NodesToRemove { get; set; }
+        public Dictionary<string, ServiceResultApiModel> NodesToRemove { get; set; }
     }
 }

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishBulkResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishBulkResponseApiModel.cs
@@ -18,13 +18,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// </summary>
         [DataMember(Name = "nodesToAdd", Order = 0,
             EmitDefaultValue = false)]
-        public Dictionary<string, ServiceResultApiModel> NodesToAdd { get; set; }
+        public IDictionary<string, ServiceResultApiModel> NodesToAdd { get; set; }
 
         /// <summary>
         /// Node to remove
         /// </summary>
         [DataMember(Name = "nodesToRemove", Order = 1,
             EmitDefaultValue = false)]
-        public Dictionary<string, ServiceResultApiModel> NodesToRemove { get; set; }
+        public IDictionary<string, ServiceResultApiModel> NodesToRemove { get; set; }
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IJobService.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/IJobService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework {
         /// <param name="jobId"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task RestartJobAsync(string jobId, CancellationToken ct = default);
+        Task<JobInfoModel> RestartJobAsync(string jobId, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes a job
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.IIoT.Agent.Framework {
         /// <param name="jobId"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task DeleteJobAsync(string jobId, CancellationToken ct = default);
+        Task<JobInfoModel> DeleteJobAsync(string jobId, CancellationToken ct = default);
 
         /// <summary>
         /// Get job or throws if not found.
@@ -63,7 +63,6 @@ namespace Microsoft.Azure.IIoT.Agent.Framework {
         /// <param name="jobId"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
-        Task<JobInfoModel> GetJobAsync(string jobId,
-            CancellationToken ct = default);
+        Task<JobInfoModel> GetJobAsync(string jobId, CancellationToken ct = default);
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Storage/Database/Services/JobDatabase.cs
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/src/Storage/Database/Services/JobDatabase.cs
@@ -23,7 +23,17 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Storage.Database {
         /// </summary>
         /// <param name="databaseServer"></param>
         /// <param name="databaseJobRepositoryConfig"></param>
-        public JobDatabase(IDatabaseServer databaseServer, IJobDatabaseConfig databaseJobRepositoryConfig) {
+        public JobDatabase(
+            IDatabaseServer databaseServer,
+            IJobDatabaseConfig databaseJobRepositoryConfig
+        ) {
+            if (databaseServer == null) {
+                throw new ArgumentNullException(nameof(databaseServer));
+            }
+            if (databaseJobRepositoryConfig == null) {
+                throw new ArgumentNullException(nameof(databaseJobRepositoryConfig));
+            }
+
             var dbs = databaseServer.OpenAsync(databaseJobRepositoryConfig.DatabaseName).Result;
             var cont = dbs.OpenContainerAsync(databaseJobRepositoryConfig.ContainerName).Result;
             _documents = cont.AsDocuments();
@@ -156,10 +166,9 @@ namespace Microsoft.Azure.IIoT.Agent.Framework.Storage.Database {
                 throw new ArgumentNullException(nameof(jobId));
             }
             while (true) {
-                var document = await _documents.FindAsync<JobDocument>(
-                    jobId);
+                var document = await _documents.FindAsync<JobDocument>(jobId);
                 if (document == null) {
-                    return null;
+                    throw new ResourceNotFoundException("Job not found");
                 }
                 var job = document.Value.ToFrameworkModel();
                 if (!await predicate(job)) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Services {
 
             var jobChanged = false;
             var jobId = GetDefaultId(endpointId);
-            var result = await _jobs.NewOrUpdateJobAsync(jobId, job => {
+            await _jobs.NewOrUpdateJobAsync(jobId, job => {
                 // remove from job
                 var publishJob = AsJob(job);
                 var connection = new ConnectionModel {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -152,12 +152,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Services {
                 }
                 return Task.FromResult(jobChanged);
             }, ct);
-            return new PublishBulkResultModel {
+
+            var bulkResult = new PublishBulkResultModel {
                 NodesToAdd = request.NodesToAdd?
-                    .Select(_ => new ServiceResultModel()).ToList(),
+                    .ToDictionary(node => node.NodeId, node => new ServiceResultModel()),
                 NodesToRemove = request.NodesToRemove?
-                    .Select(_ => new ServiceResultModel()).ToList(),
+                    .ToDictionary(node => node, node => new ServiceResultModel())
             };
+
+            return bulkResult;
         }
 
         /// <inheritdoc/>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/IPublishServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/IPublishServices.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
             PublishStartRequestModel request);
 
         /// <summary>
-        /// Start publishing node values
+        /// Stop publishing node values
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="request"></param>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/IPublishServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/IPublishServices.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -17,35 +18,39 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher {
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="request"></param>
+        /// <param name="ct"> Cancellation token </param>
         /// <returns></returns>
         Task<PublishStartResultModel> NodePublishStartAsync(T endpoint,
-            PublishStartRequestModel request);
+            PublishStartRequestModel request, CancellationToken ct = default);
 
         /// <summary>
         /// Stop publishing node values
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="request"></param>
+        /// <param name="ct"> Cancellation token </param>
         /// <returns></returns>
         Task<PublishStopResultModel> NodePublishStopAsync(T endpoint,
-            PublishStopRequestModel request);
+            PublishStopRequestModel request, CancellationToken ct = default);
 
         /// <summary>
         /// Configure nodes to publish and unpublish in bulk
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="request"></param>
+        /// <param name="ct"> Cancellation token </param>
         /// <returns></returns>
         Task<PublishBulkResultModel> NodePublishBulkAsync(T endpoint,
-            PublishBulkRequestModel request);
+            PublishBulkRequestModel request, CancellationToken ct = default);
 
         /// <summary>
         /// Get all published nodes for endpoint.
         /// </summary>
         /// <param name="endpoint"></param>
         /// <param name="request"></param>
+        /// <param name="ct"> Cancellation token </param>
         /// <returns></returns>
-        Task<PublishedItemListResultModel> NodePublishListAsync(
-            T endpoint, PublishedItemListRequestModel request);
+        Task<PublishedItemListResultModel> NodePublishListAsync(T endpoint,
+            PublishedItemListRequestModel request, CancellationToken ct = default);
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishBulkResultModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishBulkResultModel.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         /// <summary>
         /// Node to add
         /// </summary>
-        public List<ServiceResultModel> NodesToAdd { get; set; }
+        public Dictionary<string, ServiceResultModel> NodesToAdd { get; set; }
 
         /// <summary>
         /// Node to remove
         /// </summary>
-        public List<ServiceResultModel> NodesToRemove { get; set; }
+        public Dictionary<string, ServiceResultModel> NodesToRemove { get; set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishBulkResultModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishBulkResultModel.cs
@@ -15,11 +15,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         /// <summary>
         /// Node to add
         /// </summary>
-        public Dictionary<string, ServiceResultModel> NodesToAdd { get; set; }
+        public IDictionary<string, ServiceResultModel> NodesToAdd { get; set; }
 
         /// <summary>
         /// Node to remove
         /// </summary>
-        public Dictionary<string, ServiceResultModel> NodesToRemove { get; set; }
+        public IDictionary<string, ServiceResultModel> NodesToRemove { get; set; }
     }
 }

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Controllers/PublishController.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Controllers/PublishController.cs
@@ -90,13 +90,15 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Controllers {
         /// <returns>The unpublish response</returns>
         [HttpPost("{endpointId}/stop")]
         public async Task<PublishStopResponseApiModel> StopPublishingValuesAsync(
-            string endpointId, [FromBody] [Required] PublishStopRequestApiModel request) {
+            string endpointId, [FromBody] [Required] PublishStopRequestApiModel request
+        ) {
             if (request == null) {
                 throw new ArgumentNullException(nameof(request));
             }
-            var result = await _publisher.NodePublishStopAsync(
-                endpointId, request.ToServiceModel());
-            return result.ToApiModel();
+            var stopRequestModel = request.ToServiceModel();
+            var stopResultModel = await _publisher.NodePublishStopAsync(endpointId, stopRequestModel);
+            var result = stopResultModel.ToApiModel();
+            return result;
         }
 
         /// <summary>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Controllers/PublishController.cs
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Controllers/PublishController.cs
@@ -72,9 +72,10 @@ namespace Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Controllers {
             if (request == null) {
                 throw new ArgumentNullException(nameof(request));
             }
-            var result = await _publisher.NodePublishBulkAsync(
-                endpointId, request.ToServiceModel());
-            return result.ToApiModel();
+            var requestModel = request.ToServiceModel();
+            var resultModel = await _publisher.NodePublishBulkAsync(endpointId, requestModel);
+            var result = resultModel.ToApiModel();
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
Azure DevOps PBI: [[REST API] unpublishing an unknown node, doesn't indicate an error](https://msazure.visualstudio.com/One/_workitems/edit/9056770)

Changes:
* `PublisherJobService.NodePublishStopAsync()` method has been modified to throw an exception when a node that is not present in any jobs is unpublished.
* `PublisherJobService.NodePublishBulkAsync()` method has been modified to report `404/NotFound` status code for unpublish node requests for nodes that are not present in any jobs.
* `PublishController` controller class has been modified to report `404/NotFound` status codes when appropriate.
* `DefaultJobService.DeleteJobAsync()` method has been modified to throw an exception when it is called with an unknown `jobId`.
* Added `CancellationToken` to `IPublishServices` interface.
