### PR TITLE
IAI: Upgraded Helm chart version to 0.3.2 and platform to 2.7.206.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration {
 
         // Defaults
         public static string _defaultRepoUrl = "https://microsoft.github.io/charts/repo";
-        public static string _defaultChartVersion = "0.3.1";
-        public static string _defaultImageTag = "2.7.199";
+        public static string _defaultChartVersion = "0.3.2";
+        public static string _defaultImageTag = "2.7.206";
 
         /// <summary> Helm repository URL </summary>
         public string RepoUrl { get; set; }

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.Designer.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.Designer.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 2.7.199.
+        ///   Looks up a localized string similar to 2.7.206.
         /// </summary>
         internal static string VALUE_VERSION_IIOT {
             get {

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.resx
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/IIoTDeploymentTags.resx
@@ -142,6 +142,6 @@
     <value>Microsoft.Azure.IIoT.Deployment</value>
   </data>
   <data name="VALUE_VERSION_IIOT" xml:space="preserve">
-    <value>2.7.199</value>
+    <value>2.7.206</value>
   </data>
 </root>

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
@@ -110,9 +110,9 @@
     // Helm repository URL
     "RepoUrl": "https://microsoft.github.io/charts/repo",
     // azure-industrial-iot Helm chart version
-    "ChartVersion": "0.3.1",
+    "ChartVersion": "0.3.2",
     // Azure IIoT components image tag
-    "ImageTag": "2.7.199"
+    "ImageTag": "2.7.206"
   },
 
   // Provides definitions of applications and Service Principals to be used.

--- a/docs/deploy/howto-add-aks-to-ps1.md
+++ b/docs/deploy/howto-add-aks-to-ps1.md
@@ -313,7 +313,7 @@ Note the following values in the YAML file:
 
 ```yaml
 image:
-  tag: 2.7.199
+  tag: 2.7.206
 
 loadConfFromKeyVault: true
 
@@ -353,8 +353,8 @@ deployment:
     hostName: aks-cluster-ip.westeurope.cloudapp.azure.com
 ```
 
-> **NOTE**: Please note that we have used `2.7.199` as the value of `image:tag` configuration parameter
-> above. That will result in `2.7.199` version of microservices and edge modules to be deployed. If you want
+> **NOTE**: Please note that we have used `2.7.206` as the value of `image:tag` configuration parameter
+> above. That will result in `2.7.206` version of microservices and edge modules to be deployed. If you want
 > to deploy a different version of the platform, please specify it as the value of `image:tag` parameter.
 
 #### Passing Azure resource details through YAML file
@@ -395,7 +395,7 @@ Note the following values in the YAML file:
 
 ```yaml
 image:
-  tag: 2.7.199
+  tag: 2.7.206
 
 azure:
   tenantId: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
@@ -487,8 +487,8 @@ deployment:
     hostName: aks-cluster-ip.westeurope.cloudapp.azure.com
 ```
 
-> **NOTE**: Please note that we have used `2.7.199` as the value of `image:tag` configuration parameter
-> above. That will result in `2.7.199` version of microservices and edge modules to be deployed. If you want
+> **NOTE**: Please note that we have used `2.7.206` as the value of `image:tag` configuration parameter
+> above. That will result in `2.7.206` version of microservices and edge modules to be deployed. If you want
 > to deploy a different version of the platform, please specify it as the value of `image:tag` parameter.
 
 #### Installing `azure-industrial-iot` Helm chart
@@ -518,7 +518,7 @@ For that you would first add Helm repository and then install the chart from the
 ```bash
 helm repo add azure-iiot https://azureiiot.blob.core.windows.net/helm
 helm repo update
-helm install aiiot azure-iiot/azure-industrial-iot --namespace aiiot --version 0.3.1 -f aiiot.yaml
+helm install aiiot azure-iiot/azure-industrial-iot --namespace aiiot --version 0.3.2 -f aiiot.yaml
 ```
 
 Please note that the version of the chart in GitHub repo will be ahead of chart versions that we publish

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -30,7 +30,7 @@
 
 `Microsoft.Azure.IIoT.Deployment` is a command line application for deploying Azure Industrial IoT solution.
 It takes care of deploying Azure infrastructure resources and microservices of Azure Industrial IoT solution.
-By default, it deploys `2.7.199` version of Azure Industrial IoT microservices.
+By default, it deploys `2.7.206` version of Azure Industrial IoT microservices.
 
 The main difference compared to the [script based deployment](howto-deploy-all-in-one.md) option is that
 from an infrastructure perspective `Microsoft.Azure.IIoT.Deployment` deploys microservices to an Azure
@@ -461,8 +461,8 @@ Command line argument key-value pairs can be specified with:
 | `ResourceGroup:UseExisting` | If set, should be `true` or `false`.                | Determines whether an existing Resource Group should be used or a new one should be created. |                                           |
 | `ResourceGroup:Region`      | Check bellow for list of supported Azure regions.   | Region where new Resource Group should be created.                                           |                                           |
 | `Helm:RepoUrl`              | Should be URL.                                      | Helm repository URL for `azure-industrial-iot` Helm chart.                                   | `https://microsoft.github.io/charts/repo` |
-| `Helm:ChartVersion`         |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.3.1`                                   |
-| `Helm:ImageTag`             |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.7.199`                                 |
+| `Helm:ChartVersion`         |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.3.2`                                   |
+| `Helm:ImageTag`             |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.7.206`                                 |
 | `ApplicationRegistration`   | Object, see [Special Notes](#special-notes) bellow. | Provides definitions of existing Applications and Service Principals to be used.             |                                           |
 | `SaveEnvFile`               | If set, should be `true` or `false`.                | Defines whether to create .env file after successful deployment or not.                      |                                           |
 | `NoCleanup`                 | If set, should be `true` or `false`.                | Defines whether to perform cleanup if an error occurs during deployment.                     |                                           |
@@ -527,16 +527,16 @@ The following Azure regions are supported by `Microsoft.Azure.IIoT.Deployment` f
     Provides definitions of applications and Service Principals to be used. Those definitions will be used
     instead of creating new application registrations and Service Principals for deployment of Azure
     resources.
-  
+
     This is particularly useful in `ResourceDeployment` mode, where `Microsoft.Azure.IIoT.Deployment` would
     rely on existing Application Registrations and Service Principals.
 
     > **Note**: Execution in `ApplicationRegistration` run mode will output JSON object for this property that should be used on consequent `ResourceDeployment`
     run.
-  
+
     Properties correspond to that of application registration and Service Principal manifests. Definition
     of application properties can be found [here](https://docs.microsoft.com/azure/active-directory/develop/reference-app-manifest).
-  
+
     Application objects should contain the following properties:
 
     ``` json
@@ -606,8 +606,8 @@ Kubernetes Dashboard.
 `azure-industrial-iot` Helm chart will be deployed. For more details about the chart please check its
 [documentation](../../deploy/helm/azure-industrial-iot/README.md).
 
-By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.3.1` version of `azure-industrial-iot` Helm chart
-with `2.7.199` version of Azure Industrial IoT components. Both chart version and components version can be
+By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.3.2` version of `azure-industrial-iot` Helm chart
+with `2.7.206` version of Azure Industrial IoT components. Both chart version and components version can be
 changed using configuration parameters. Please check `Helm:ChartVersion` and `Helm:ImageTag` parameters for
 that.
 


### PR DESCRIPTION
Changes:
* Upgraded Helm chart version to `0.3.2` and platform to `2.7.206`.
* Changed Helm chart and platform versions in documentation.

This will allow us to use `0.3.2` version of the Helm chart in E2E tests for orchestrated mode.