### PR TITLE
Add early check to deploy.ps1 for global website name conflict. 

### DIFF
--- a/deploy/scripts/deploy.ps1
+++ b/deploy/scripts/deploy.ps1
@@ -698,6 +698,9 @@ Function New-Deployment() {
                 $script:applicationName = $script:resourceGroupName
             }
         }
+        if (Test-AzureName -Website $script:applicationName -eq $true) {
+            throw "Conflict: Website with given name $script:applicationName already exists."
+        }
         if (($script:type -eq "all") -or ($script:type -eq "app")) {
             $templateParameters.Add("siteName", $script:applicationName)
         }


### PR DESCRIPTION
This PR is an offer to address feature request/issue #1051 by doing Azure Website global name check on the application name and `throws` if there is a conflict. 