### PR TITLE
Fix build registry typo in ACR scripts

### DIFF
--- a/tools/scripts/acr-build.ps1
+++ b/tools/scripts/acr-build.ps1
@@ -143,7 +143,7 @@ if (![string]::IsNullOrEmpty($Subscription)) {
 
 # Check and set registry
 if ([string]::IsNullOrEmpty($Registry)) {
-    $Registry = $env.BUILD_REGISTRY
+    $Registry = $env:BUILD_REGISTRY
     if ([string]::IsNullOrEmpty($Registry)) {
         if ($releaseBuild) {
             # Make sure we do not override latest in release builds - this is done manually later.

--- a/tools/scripts/acr-prune.ps1
+++ b/tools/scripts/acr-prune.ps1
@@ -21,7 +21,7 @@ Param(
 
 # Check and set registry
 if ([string]::IsNullOrEmpty($Registry)) {
-    $Registry = $env.BUILD_REGISTRY
+    $Registry = $env:BUILD_REGISTRY
     if ([string]::IsNullOrEmpty($Registry)) {
         $Registry = "industrialiotdev"
         Write-Warning "No registry specified - using $($Registry).azurecr.io."


### PR DESCRIPTION
Unable to set BUILD_REGISTRY with environment variable. Syntax should be `$Env:<variable-name>`.