### PR TITLE
Fix FetchOpcNodeDisplayName flag for events

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -291,6 +291,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 }
 
                 var unresolvedMonitoredItems = _subscription.MonitoredItems
+                    .OfType<DataMonitoredItemModel>()
                     .Where(mi => string.IsNullOrEmpty(mi.DisplayName));
                 if (!unresolvedMonitoredItems.Any()) {
                     return;


### PR DESCRIPTION
When the flag _FetchOpcNodeDisplayName_ (--fd) is set, it has an undesirable impact on the published events. Fixed by filtering the monitored items when the subscription wrapper is asked to resolve display names.

The flag is intended for OpcNodes and not OpcEvents: "... flag whether to fetch the display names of the nodes." (from LegacyCliConfigKeys).