### PR TITLE
Encode EncodeableDictionary as dictionary

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Extensions/MonitoredItemNotificationModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Extensions/MonitoredItemNotificationModelEx.cs
@@ -182,13 +182,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Models {
                     BrowseNames.ReceiveTime, monitoredItem),
                 StatusCode = eventFields.GetEventValue<StatusCode>(
                     BrowseNames.StatusCode, monitoredItem),
-                Value = new EncodeableDictionary {
-                    Fields = new KeyValuePairCollection(eventFields.EventFields
-                        .Select((value, i) => new Opc.Ua.KeyValuePair {
-                            Key = SubscriptionServices.GetFieldDisplayName(monitoredItem, i),
-                            Value = value
-                        }))
-                }
+                Value = new EncodeableDictionary(eventFields.EventFields
+                    .Select((value, i) => new KeyDataValuePair {
+                        Key = SubscriptionServices.GetFieldDisplayName(monitoredItem, i),
+                        Value = new DataValue(value)
+                    }))
             };
         }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
@@ -29,17 +29,17 @@ namespace Opc.Ua.Encoders {
             nameof(EncodeableDictionary) + "_Encoding_DefaultJson";
 
         /// <summary>
-        /// Initializes the collection with default values.
+        /// Initializes the dictionary with default values.
         /// </summary>
         public EncodeableDictionary() { }
 
         /// <summary>
-        /// Initializes the collection with an initial capacity.
+        /// Initializes the dictionary with an initial capacity.
         /// </summary>
         public EncodeableDictionary(int capacity) : base(capacity) { }
 
         /// <summary>
-        /// Initializes the collection with another collection.
+        /// Initializes the dictionary with another collection.
         /// </summary>
         public EncodeableDictionary(IEnumerable<KeyDataValuePair> collection) : base(collection) { }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
@@ -5,16 +5,12 @@
 
 namespace Opc.Ua.Encoders {
     using Opc.Ua;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Encodeable dictionary carrying field names and values
     /// </summary>
-    public class EncodeableDictionary : IEncodeable {
-
-        /// <summary>
-        /// Event fields
-        /// </summary>
-        public KeyValuePairCollection Fields { get; set; }
+    public class EncodeableDictionary : List<KeyDataValuePair>, IEncodeable {
 
         /// <inheritdoc/>
         public ExpandedNodeId TypeId =>
@@ -33,22 +29,30 @@ namespace Opc.Ua.Encoders {
             nameof(EncodeableDictionary) + "_Encoding_DefaultJson";
 
         /// <summary>
-        /// Create
+        /// Initializes the collection with default values.
         /// </summary>
-        public EncodeableDictionary() {
-            Fields = new KeyValuePairCollection();
-        }
+        public EncodeableDictionary() { }
+
+        /// <summary>
+        /// Initializes the collection with an initial capacity.
+        /// </summary>
+        public EncodeableDictionary(int capacity) : base(capacity) { }
+
+        /// <summary>
+        /// Initializes the collection with another collection.
+        /// </summary>
+        public EncodeableDictionary(IEnumerable<KeyDataValuePair> collection) : base(collection) { }
 
         /// <inheritdoc/>
         public virtual void Encode(IEncoder encoder) {
-            //  todo: check if "EventFields" is appropriate
-            encoder.WriteEncodeableArray("EventFields", Fields.ToArray(), typeof(KeyValuePair));
+            foreach (var entry in this) {
+                encoder.WriteDataValue(entry.Key, entry.Value);
+            }
         }
 
         /// <inheritdoc/>
         public virtual void Decode(IDecoder decoder) {
-            Fields = (KeyValuePairCollection)decoder.ReadEncodeableArray(
-                "EventFields", typeof(KeyValuePair));
+            // No operation. Cannot decode without known keys.
         }
 
         /// <inheritdoc/>
@@ -56,10 +60,10 @@ namespace Opc.Ua.Encoders {
             if (this == encodeable) {
                 return true;
             }
-            if (!(encodeable is EncodeableDictionary eventFieldList)) {
+            if (!(encodeable is EncodeableDictionary encodableDictionary)) {
                 return false;
             }
-            if (!Utils.IsEqual(Fields, eventFieldList.Fields)) {
+            if (!Utils.IsEqual(this, encodableDictionary)) {
                 return false;
             }
             return true;


### PR DESCRIPTION
The EncodeableDictionary is only used for encoding event values. It was encoded as an array on a property called EventFields. There are already classes to encode arrays, but it also is not reflective of how the encoder should encode a dictionary. 

The following change makes the encoder produce key-value pairs. One caveat is that decoding is challenging when the keys are not known. However, this is not required for events as far as I understand.