### PR TITLE
Add event timestamp fields

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -1052,8 +1052,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 else if (EventTemplate != null) {
                     var eventFilter = codec.Decode(EventTemplate.EventFilter, true);
 
-                    // TODO: If we got flag?
-
                     // Add SourceTimestamp and ServerTimestamp select clauses.
                     if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == "Time")) {
                         eventFilter.AddSelectClause(ObjectTypeIds.BaseEventType, "Time");

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -1051,7 +1051,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 }
                 else if (EventTemplate != null) {
                     var eventFilter = codec.Decode(EventTemplate.EventFilter, true);
-                    if (EventTemplate.PendingAlarms != null && EventTemplate.PendingAlarms.IsEnabled) {
+
+                    // TODO: If we got flag?
+
+                    // Add SourceTimestamp and ServerTimestamp select clauses.
+                    if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == "Time")) {
+                        eventFilter.AddSelectClause(ObjectTypeIds.BaseEventType, "Time");
+                    }
+                    if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == "ReceiveTime")) {
+                        eventFilter.AddSelectClause(ObjectTypeIds.BaseEventType, "ReceiveTime");
+                    }
+
+                    if (EventTemplate.PendingAlarms?.IsEnabled == true) {
                         if (!eventFilter.SelectClauses
                             .Where(x => x.TypeDefinitionId == ObjectTypeIds.ConditionType && x.AttributeId == Attributes.NodeId)
                             .Any()) {
@@ -1169,7 +1180,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             }
 
             internal string GetFieldDisplayName(int index) {
-                var fieldName = EventTemplate?.EventFilter?.SelectClauses?[index]?.DisplayName;
+                var fieldName = EventTemplate?.EventFilter?.SelectClauses?.ElementAtOrDefault(index)?.DisplayName;
                 if (fieldName == null) {
                     fieldName = Item.GetFieldName(index);
                     if (!string.IsNullOrEmpty(fieldName) && fieldName[0] == '/') {


### PR DESCRIPTION
Added "Time" and "ReceiveTime" as default select clauses (if not already added) so that SourceTimestamp and ServerTimestamp can be set. Corrected a bug in GetFieldDisplayName when trying to access a display name outside the template array.