### PR TITLE
Use IP address of the test servers instead of fqdn

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestContext.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestContext.cs
@@ -5,10 +5,6 @@
 
 namespace IIoTPlatform_E2E_Tests.Discovery {
     using IIoTPlatform_E2E_Tests.TestExtensions;
-    using RestSharp;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
 
     public class DiscoveryTestContext : IIoTPlatformTestContext {
         /// <summary>
@@ -16,13 +12,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
         /// Used for preparation executed once before any tests of the collection are started.
         /// </summary>
         public DiscoveryTestContext() : base() {
-            GetServersInformation();
         }
-
-        /// <summary>
-        /// Gets or sets the servers info
-        /// </summary>
-        public List<dynamic> ServersInfo;
 
         /// <summary>
         /// Disposes resources.
@@ -36,46 +26,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
             // OutputHelper cannot be used outside of test calls, we get rid of it before a helper method would use it
             OutputHelper = null;
 
-            // Remove servers
-            var applicationIds = ServersInfo.Select(s => s.applicationId?.ToString());
-            RemoveAllApplications(applicationIds.OfType<string>().ToList());
-
             base.Dispose(true);
-        }
-
-        private void GetServersInformation() {
-            // Add servers
-            var simulatedOpcServers = TestHelper.GetSimulatedPublishedNodesConfigurationAsync(this).GetAwaiter().GetResult();
-            var urls = simulatedOpcServers.Values.ToList().Select(s => s.EndpointUrl).ToList();
-            AddTestOpcServers(urls);
-
-            // Get info about servers
-            dynamic result = TestHelper.Discovery.WaitForDiscoveryToBeCompletedAsync(this, requestedEndpointUrls: urls).GetAwaiter().GetResult();
-            ServersInfo = result.items;
-
-            // Remove servers
-            var applicationIds = ServersInfo.Select(s => s.applicationId?.ToString());
-            RemoveAllApplications(applicationIds.OfType<string>().ToList());
-        }
-
-        private void AddTestOpcServers(List<string> endpointUrls) {
-            foreach (var endpointUrl in endpointUrls) {
-                var body = new {
-                    discoveryUrl = endpointUrl
-                };
-                TestHelper.CallRestApi(this, Method.POST, TestConstants.APIRoutes.RegistryApplications, body);
-            }
-        }
-
-        private void RemoveApplication(string applicationId) {
-            var route = $"{TestConstants.APIRoutes.RegistryApplications}/{applicationId}";
-            TestHelper.CallRestApi(this, Method.DELETE, route);        
-        }
-
-        private void RemoveAllApplications(List<string> applicationIds) {
-            foreach (var appId in applicationIds) {
-                RemoveApplication(appId);
-            }
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
@@ -43,9 +43,9 @@ namespace IIoTPlatform_E2E_Tests.TestExtensions {
         public ITestOutputHelper? OutputHelper { get; set; }
 
         /// <summary>
-        /// Gets or sets the discovery url
+        /// Gets or sets the OPC server url
         /// </summary>
-        public string? DiscoveryUrl { get; set; }
+        public string? OpcServerUrl { get; set; }
 
         /// <summary>
         /// IoT Device Configuration

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
@@ -69,8 +69,8 @@ namespace IIoTPlatform_E2E_Tests {
                             await Task.Delay(TestConstants.DefaultDelayMilliseconds);
                         }
                         else {
-                            for (int indexOfOpcApplication = 0; indexOfOpcApplication < numberOfItems; indexOfOpcApplication++) {
-                                var endpoint = ((string)json.items[indexOfOpcApplication].discoveryUrls[0]).TrimEnd('/');
+                            for (int i = 0; i < numberOfItems; i++) {
+                                var endpoint = "opc.tcp://" +((string)json.items[i].hostAddresses[0]).TrimEnd('/');
 
                                 if (requestedEndpointUrls == null || requestedEndpointUrls.Contains(endpoint)) {
                                     foundEndpoints++;
@@ -96,7 +96,7 @@ namespace IIoTPlatform_E2E_Tests {
                 catch (Exception e) {
                     context.OutputHelper?.WriteLine("Error: discovery module didn't find OPC UA server in time");
                     PrettyPrintException(e, context.OutputHelper);
-                    throw;
+                    return null;
                 }
             }
 
@@ -131,7 +131,7 @@ namespace IIoTPlatform_E2E_Tests {
                         }
                         else {
                             for (int indexOfOpcUaEndpoint = 0; indexOfOpcUaEndpoint < numberOfItems; indexOfOpcUaEndpoint++) {
-                                var endpoint = ((string)json.items[indexOfOpcUaEndpoint].registration.endpointUrl).TrimEnd('/');
+                                var endpoint = ((string)json.items[indexOfOpcUaEndpoint].registration.endpoint.url).TrimEnd('/');
 
                                 if (requestedEndpointUrls == null || requestedEndpointUrls.Contains(endpoint)) {
                                     foundEndpoints++;
@@ -178,7 +178,7 @@ namespace IIoTPlatform_E2E_Tests {
 
                 for (var indexOfOpcUaEndpoint = 0; indexOfOpcUaEndpoint < numberOfItems; indexOfOpcUaEndpoint++) {
 
-                    var endpoint = ((string)json.items[indexOfOpcUaEndpoint].registration.endpointUrl).TrimEnd('/');
+                    var endpoint = ((string)json.items[indexOfOpcUaEndpoint].registration.endpoint.url).TrimEnd('/');
                     if (endpoint == requestedEndpointUrl) {
                         return (string)json.items[indexOfOpcUaEndpoint].registration.id;
                     }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Registry.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Registry.cs
@@ -72,7 +72,7 @@ namespace IIoTPlatform_E2E_Tests {
                             for (int indexOfRequestedOpcServer = 0;
                                 indexOfRequestedOpcServer < count;
                                 indexOfRequestedOpcServer++) {
-                                var endpoint = ((string)json.items[indexOfRequestedOpcServer].registration.endpointUrl).TrimEnd('/');
+                                var endpoint = ((string)json.items[indexOfRequestedOpcServer].registration.endpoint.url).TrimEnd('/');
                                 if (requestedEndpointUrls.Contains(endpoint)) {
                                     activationStates.Add((string)json.items[indexOfRequestedOpcServer].activationState);
                                 }
@@ -90,7 +90,7 @@ namespace IIoTPlatform_E2E_Tests {
                 }
                 catch (Exception) {
                     context.OutputHelper?.WriteLine("Error: OPC UA endpoint couldn't be activated");
-                    throw;
+                    return null;
                 }
             }
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -85,6 +85,16 @@ namespace IIoTPlatform_E2E_Tests {
         }
 
         /// <summary>
+        /// Get urls of the simulated test opc servers
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <returns>List of server urls</returns>
+        public static List<string> GetSimulatedOpcServerUrls(
+            IIoTPlatformTestContext context) {
+            return context.OpcPlcConfig.Urls.Split(TestConstants.SimulationUrlsSeparator).Select(ip => $"opc.tcp://{ip}:50000").ToList();
+        }
+
+        /// <summary>
         /// Read PublishedNodes json from OPC-PLC and provide the data to the tests
         /// </summary>
         /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>

--- a/tools/e2etesting/DeployPLCs.ps1
+++ b/tools/e2etesting/DeployPLCs.ps1
@@ -105,7 +105,7 @@ if ($aciNamesToCreate.Length -gt 0) {
 
         $script = {
             Param($Name)
-            $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType) --ph=$($Name).$($using:resourceGroup.Location).azurecontainer.io'"
+            $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
             $aci = New-AzContainerGroup -ResourceGroupName $using:ResourceGroupName -Name $Name -Image $using:PLCImage -OsType Linux -Command $aciCommand -Port @(50000,80) -Cpu $using:CpuCount -MemoryInGB $using:MemoryInGb -IpAddressType Public -DnsNameLabel $Name
         }
 
@@ -147,7 +147,7 @@ $containerInstances = Get-AzContainerGroup -ResourceGroupName $ResourceGroupName
 
 $plcSimNames = ""
 foreach ($ci in $containerInstances) {
-    $plcSimNames += $ci.Fqdn + ";"
+    $plcSimNames += $ci.IpAddress + ";"
 }
 
 Write-Host "Adding/Updating KeyVault-Secret 'plc-simulation-urls' with value '$($plcSimNames)'..."

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -48,25 +48,7 @@ stages:
   dependsOn: deploy
   condition: or(eq(dependencies.deploy.result, 'Succeeded'), eq(dependencies.deploy.result, 'Skipped'))
   jobs:
-  - job: runtestspublisher
-    timeoutInMinutes: 60
-    displayName: 'Execute publisher tests'
-    steps:
-    - template: steps/runtests.yml
-      parameters:
-        ModeName: PublisherMode
-        ModeValue: orchestrated
-  - job: runteststwin
-    dependsOn: runtestspublisher
-    timeoutInMinutes: 60
-    displayName: 'Execute twin tests'
-    steps:
-    - template: steps/runtests.yml
-      parameters:
-        ModeName: TwinMode
-        ModeValue: default
   - job: runtestsdiscovery
-    dependsOn: runteststwin
     timeoutInMinutes: 60
     displayName: 'Execute discovery tests'
     steps:
@@ -74,6 +56,26 @@ stages:
       parameters:
         ModeName: DiscoveryMode
         ModeValue: default
+
+  - job: runteststwin
+    dependsOn: runtestsdiscovery
+    timeoutInMinutes: 60
+    displayName: 'Execute twin tests'
+    steps:
+    - template: steps/runtests.yml
+      parameters:
+        ModeName: TwinMode
+        ModeValue: default
+
+  - job: runtestspublisher
+    dependsOn: runteststwin
+    timeoutInMinutes: 60
+    displayName: 'Execute publisher tests'
+    steps:
+    - template: steps/runtests.yml
+      parameters:
+        ModeName: PublisherMode
+        ModeValue: orchestrated
 
 - stage: cleanup
   displayName: Cleanup resources


### PR DESCRIPTION
Switch to using IP addresses of the test servers so that we can use the same tests for servers that have only private IP (for example for the nested edge validation)