### PR TITLE
Refactoring: Use the helper method for REST calls

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/A_PublishSingleNodeOrchestratedTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/A_PublishSingleNodeOrchestratedTestTheory.cs
@@ -63,30 +63,16 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             TestHelper.WaitForServicesAsync(_context, cts.Token).GetAwaiter().GetResult();
             _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(_context.DeviceConfig.DeviceId, cts.Token).GetAwaiter().GetResult();
 
-            var accessToken = TestHelper.GetTokenAsync(_context, cts.Token).GetAwaiter().GetResult();
             var endpointUrl = TestHelper.GetSimulatedOpcServerUrls(_context).First();
             _context.OpcServerUrl = endpointUrl;
-
-            var client = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) {Timeout = TestConstants.DefaultTimeoutInMilliseconds};
-
-            var request = new RestRequest(Method.POST);
-            request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = TestConstants.APIRoutes.RegistryApplications;
 
             var body = new {
                 discoveryUrl = endpointUrl
             };
 
-            request.AddJsonBody(JsonConvert.SerializeObject(body));
-
-            var response = client.ExecuteAsync(request, cts.Token).GetAwaiter().GetResult();
-            Assert.NotNull(response);
-
-            if (!response.IsSuccessful) {
-                _output.WriteLine($"StatusCode: {response.StatusCode}");
-                _output.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                Assert.True(response.IsSuccessful, "POST /registry/v2/application failed!");
-            }
+            var route = TestConstants.APIRoutes.RegistryApplications;
+            var response = TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            Assert.True(response.IsSuccessful);
         }
 
         [Fact, PriorityOrder(4)]
@@ -100,39 +86,25 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
         public void Test_GetEndpoints_Expect_OneWithMultipleAuthentication() {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var json = TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(_context, cts.Token, new List<string> { _context.OpcServerUrl }).GetAwaiter().GetResult();
+            Assert.NotNull(json);
+            
+            var result = json.items[0].registration;
+            var endpointId = (string)result.id;
+            Assert.NotEmpty(endpointId);
 
-            var numberOfItems = (int)json.items.Count;
-            bool found = false;
-            for (int indexOfOpcUaEndpoint = 0; indexOfOpcUaEndpoint < numberOfItems; indexOfOpcUaEndpoint++) {
+            // Authentication Checks
+            Assert.Equal("SignAndEncrypt", result.endpoint.securityMode);
+            Assert.Equal("None", result.authenticationMethods[0].credentialType);
+            Assert.Equal("UserName", result.authenticationMethods[1].credentialType);
+            Assert.Equal("X509Certificate", result.authenticationMethods[2].credentialType);
 
-                var endpoint = ((string)json.items[indexOfOpcUaEndpoint].registration.endpoint.url).TrimEnd('/');
-                if (endpoint == _context.OpcServerUrl) {
-                    found = true;
-
-                    //Authentication Checks
-                    var id = (string)json.items[indexOfOpcUaEndpoint].registration.id;
-                    Assert.NotEmpty(id);
-                    var securityMode = (string)json.items[indexOfOpcUaEndpoint].registration.endpoint.securityMode;
-                    Assert.Equal("SignAndEncrypt", securityMode);
-                    var authenticationModeNone = (string)json.items[indexOfOpcUaEndpoint].registration.authenticationMethods[0].credentialType;
-                    Assert.Equal("None", authenticationModeNone);
-                    var authenticationModeUserName = (string)json.items[indexOfOpcUaEndpoint].registration.authenticationMethods[1].credentialType;
-                    Assert.Equal("UserName", authenticationModeUserName);
-                    var authenticationModeCertificate = (string)json.items[indexOfOpcUaEndpoint].registration.authenticationMethods[2].credentialType;
-                    Assert.Equal("X509Certificate", authenticationModeCertificate);
-
-                    //store id of endpoint for further interaction
-                    _context.OpcUaEndpointId = id;
-                    break;
-                }
-            }
-            Assert.True(found, "OPC UA Endpoint not found");
+            // Store id of endpoint for further interaction
+            _context.OpcUaEndpointId = endpointId;
         }
 
         [Fact, PriorityOrder(6)]
         public void Test_ActivateEndpoint_Expect_Success() {
-
-            // used if running test cases separately (during development)
+            // Used if running test cases separately (during development)
             if (string.IsNullOrWhiteSpace(_context.OpcUaEndpointId)) {
                 Test_GetEndpoints_Expect_OneWithMultipleAuthentication();
                 Assert.False(string.IsNullOrWhiteSpace(_context.OpcUaEndpointId));
@@ -157,16 +129,9 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             }
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            var accessToken = TestHelper.GetTokenAsync(_context, cts.Token).GetAwaiter().GetResult();
             var simulatedOpcServer = TestHelper.GetSimulatedPublishedNodesConfigurationAsync(_context, cts.Token).GetAwaiter().GetResult();
-            var client = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds
-            };
 
-            var request = new RestRequest(Method.POST);
-            request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = string.Format(TestConstants.APIRoutes.PublisherStartFormat, _context.OpcUaEndpointId);
-
+            var route = string.Format(TestConstants.APIRoutes.PublisherStartFormat, _context.OpcUaEndpointId);
             var body = new {
                 item = new {
                     nodeId = simulatedOpcServer.Values.First().OpcNodes.First().Id,
@@ -175,76 +140,50 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
                 }
             };
 
-            request.AddJsonBody(JsonConvert.SerializeObject(body));
-
-            var response = client.ExecuteAsync(request, cts.Token).GetAwaiter().GetResult();
-            Assert.NotNull(response);
-
-            if (!response.IsSuccessful) {
-                _output.WriteLine($"StatusCode: {response.StatusCode}");
-                _output.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                Assert.True(response.IsSuccessful, "POST /publisher/v2/publish/{endpointId}/start failed!");
-            }
-
+            var response = TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
             Assert.Equal("{}",response.Content);
         }
 
         [Fact, PriorityOrder(9)]
         public void Test_GetListOfJobs_Expect_OneJobWithPublishingOneNode() {
-
-            // used if running test cases separately (during development)
+            // Used if running test cases separately (during development)
             if (string.IsNullOrWhiteSpace(_context.OpcUaEndpointId)) {
                 Test_GetEndpoints_Expect_OneWithMultipleAuthentication();
                 Assert.False(string.IsNullOrWhiteSpace(_context.OpcUaEndpointId));
             }
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            var accessToken = TestHelper.GetTokenAsync(_context, cts.Token).GetAwaiter().GetResult();
-            var simulatedOpcServer = TestHelper.GetSimulatedPublishedNodesConfigurationAsync(_context, cts.Token).GetAwaiter().GetResult();
-            var client = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds
-            };
-
-            var request = new RestRequest(Method.GET);
-            request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = TestConstants.APIRoutes.PublisherJobs;
-
-            var response = client.ExecuteAsync(request, cts.Token).GetAwaiter().GetResult();
-            Assert.NotNull(response);
-
-            if (!response.IsSuccessful) {
-                _output.WriteLine($"StatusCode: {response.StatusCode}");
-                _output.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                Assert.True(response.IsSuccessful, "GET /publisher/v2/jobs failed!");
-            }
-
+            var simulatedOpcServer = TestHelper.GetSimulatedPublishedNodesConfigurationAsync(_context, cts.Token).GetAwaiter().GetResult();            
+            var route = TestConstants.APIRoutes.PublisherJobs;
+            var response = TestHelper.CallRestApi(_context, Method.GET, route, ct: cts.Token);
             dynamic json = JsonConvert.DeserializeObject(response.Content);
 
-            var count = (int)json.jobs.Count;
-            Assert.NotEqual(0, count);
-            Assert.NotNull(json.jobs[0].jobConfiguration);
-            Assert.NotNull(json.jobs[0].jobConfiguration.writerGroup);
-            Assert.NotNull(json.jobs[0].jobConfiguration.writerGroup.dataSetWriters);
-            count = (int)json.jobs[0].jobConfiguration.writerGroup.dataSetWriters.Count;
-            Assert.Equal(1, count);
-            Assert.NotNull(json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet);
-            Assert.NotNull(json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet.dataSetSource);
-            Assert.NotNull(json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet.dataSetSource.publishedVariables.publishedData);
-            count = (int)json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet.dataSetSource.publishedVariables.publishedData.Count;
-            Assert.Equal(1, count);
-            Assert.NotEmpty((string)json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet.dataSetSource.publishedVariables.publishedData[0].publishedVariableNodeId);
-            var publishedNodeId = (string)json.jobs[0].jobConfiguration.writerGroup.dataSetWriters[0].dataSet.dataSetSource.publishedVariables.publishedData[0].publishedVariableNodeId;
+            Assert.NotEqual(0, json.jobs.Count);
+
+            var jobConfiguration = json.jobs[0].jobConfiguration;
+            Assert.NotNull(jobConfiguration);
+            Assert.NotNull(jobConfiguration.writerGroup);
+            Assert.NotNull(jobConfiguration.writerGroup.dataSetWriters);
+            Assert.Equal(1, (int)jobConfiguration.writerGroup.dataSetWriters.Count);
+
+            var dataSet = jobConfiguration.writerGroup.dataSetWriters[0].dataSet;
+            Assert.NotNull(dataSet);
+            Assert.NotNull(dataSet.dataSetSource);
+            Assert.NotNull(dataSet.dataSetSource.publishedVariables.publishedData);
+            Assert.Equal(1, (int)dataSet.dataSetSource.publishedVariables.publishedData.Count);
+            Assert.NotEmpty((string)dataSet.dataSetSource.publishedVariables.publishedData[0].publishedVariableNodeId);
+            var publishedNodeId = (string)dataSet.dataSetSource.publishedVariables.publishedData[0].publishedVariableNodeId;
             Assert.Equal(simulatedOpcServer.Values.First().OpcNodes.First().Id, publishedNodeId);
         }
 
         [Fact, PriorityOrder(10)]
         public void Test_VerifyDataAvailableAtIoTHub() {
-
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
-            //use test event processor to verify data send to IoT Hub (expected* set to zero as data gap analysis is not part of this test case)
+            // Use test event processor to verify data send to IoT Hub (expected* set to zero as data gap analysis is not part of this test case)
             TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).GetAwaiter().GetResult();
-            // wait some time to generate events to process
+
+            // Wait some time to generate events to process
             Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).GetAwaiter().GetResult();
             var json = TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).GetAwaiter().GetResult();
             Assert.True((int)json.totalValueChangesCount > 0, "No messages received at IoT Hub");
@@ -254,41 +193,28 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
 
         [Fact, PriorityOrder(11)]
         public void RemoveJob_Expect_Success() {
-
-            // used if running test cases separately (during development)
+            // Used if running test cases separately (during development)
             if (string.IsNullOrWhiteSpace(_context.OpcUaEndpointId)) {
                 Test_GetEndpoints_Expect_OneWithMultipleAuthentication();
                 Assert.False(string.IsNullOrWhiteSpace(_context.OpcUaEndpointId));
             }
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            var accessToken = TestHelper.GetTokenAsync(_context, cts.Token).GetAwaiter().GetResult();
-
-            var client = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds
-            };
-
-            var request = new RestRequest(Method.DELETE);
-            request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = string.Format(TestConstants.APIRoutes.PublisherJobsFormat, _context.OpcUaEndpointId);
-
-            var response = client.ExecuteAsync(request, cts.Token).GetAwaiter().GetResult();
-            Assert.NotNull(response);
-
-            if (!response.IsSuccessful) {
-                _output.WriteLine($"StatusCode: {response.StatusCode}");
-                _output.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                Assert.True(response.IsSuccessful, "DELETE /publisher/v2/jobs/{jobId} failed!");
-            }
+            var route = string.Format(TestConstants.APIRoutes.PublisherJobsFormat, _context.OpcUaEndpointId);
+            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
         }
 
         [Fact, PriorityOrder(12)]
         public void Test_VerifyNoDataIncomingAtIoTHub() {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).GetAwaiter().GetResult(); //wait till the publishing has stopped
-            //use test event processor to verify data send to IoT Hub (expected* set to zero as data gap analysis is not part of this test case)
+
+            // Wait untill the publishing has stopped
+            Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).GetAwaiter().GetResult(); 
+
+            // Use test event processor to verify data send to IoT Hub (expected* set to zero as data gap analysis is not part of this test case)
             TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).GetAwaiter().GetResult();
-            // wait some time to generate events to process
+
+            // Wait some time to generate events to process
             Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).GetAwaiter().GetResult();
             var json = TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).GetAwaiter().GetResult();
             Assert.True((int)json.totalValueChangesCount == 0, "Messages received at IoT Hub");
@@ -297,22 +223,8 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
         [Fact, PriorityOrder(13)]
         public void Test_RemoveAllApplications() {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-
-            var accessToken = TestHelper.GetTokenAsync(_context, cts.Token).GetAwaiter().GetResult();
-            var client = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
-
-            var request = new RestRequest(Method.DELETE);
-            request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = TestConstants.APIRoutes.RegistryApplications;
-
-            var response = client.ExecuteAsync(request, cts.Token).GetAwaiter().GetResult();
-            Assert.NotNull(response);
-
-            if (!response.IsSuccessful) {
-                _output.WriteLine($"StatusCode: {response.StatusCode}");
-                _output.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                Assert.True(response.IsSuccessful, "DELETE /registry/v2/application failed!");
-            }
+            var route = TestConstants.APIRoutes.RegistryApplications;
+            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
@@ -43,24 +43,9 @@ namespace IIoTPlatform_E2E_Tests {
                     bool shouldExit = false;
                     do {
                         foundEndpoints = 0;
-                        var accessToken = await TestHelper.GetTokenAsync(context, ct);
-                        var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                            Timeout = TestConstants.DefaultTimeoutInMilliseconds
-                        };
 
-                        var request = new RestRequest(Method.GET);
-                        request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                        request.Resource = TestConstants.APIRoutes.RegistryApplications;
-
-                        var response = await client.ExecuteAsync(request, ct);
-                        Assert.NotNull(response);
-                        Assert.True(response.IsSuccessful, "GET /registry/v2/application failed!");
-
-                        if (!response.IsSuccessful) {
-                            context.OutputHelper?.WriteLine($"StatusCode: {response.StatusCode}");
-                            context.OutputHelper?.WriteLine($"ErrorMessage: {response.ErrorMessage}");
-                        }
-
+                        var route = TestConstants.APIRoutes.RegistryApplications;
+                        var response = CallRestApi(context, Method.GET, route, ct);
                         Assert.NotEmpty(response.Content);
                         json = JsonConvert.DeserializeObject<ExpandoObject>(response.Content, new ExpandoObjectConverter());
                         Assert.NotNull(json);


### PR DESCRIPTION
This is the first step of the E2E refactoring, to remove the duplicated code. Later I would like to get away from using this many static helper methods and replace them with something simpler and more understandable.