### PR TITLE
fix published nodes with different "groups/assets" for same endpoint causing closing and reopening of sessions

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -66,6 +66,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             _fileSystemWatcher.Changed += _fileSystemWatcher_Changed;
             _fileSystemWatcher.Created += _fileSystemWatcher_Changed;
             _fileSystemWatcher.Renamed += _fileSystemWatcher_Changed;
+            _fileSystemWatcher.Deleted += _fileSystemWatcher_Changed;
             _fileSystemWatcher.EnableRaisingEvents = true;
         }
 
@@ -259,7 +260,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 catch (IOException ex) {
                     retryCount--;
                     if (retryCount > 0) {
-                        _logger.Information("Error while loading job from file, retrying...");
                         Task.Delay(5000).GetAwaiter().GetResult();
                     }
                     else {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -78,57 +78,100 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// <param name="ct"></param>
         /// <returns></returns>
         public Task<JobProcessingInstructionModel> GetAvailableJobAsync(string workerId, JobRequestModel request, CancellationToken ct = default) {
-            if (_assignedJobs.TryGetValue(workerId, out var job)) {
+            _lock.Wait(ct);
+            try {
+                if (_assignedJobs.TryGetValue(workerId, out var job)) {
+                    return Task.FromResult(job);
+                }
+                if (_availableJobs.Count > 0 && _availableJobs.TryDequeue(out job)) {
+                    _assignedJobs.AddOrUpdate(workerId, job);
+                }
+
                 return Task.FromResult(job);
             }
-            if (_availableJobs.Count > 0 && _availableJobs.TryDequeue(out job)) {
-                _assignedJobs.AddOrUpdate(workerId, job);
-                if (_availableJobs.Count == 0) {
-                    _updated = false;
-                }
+            catch(OperationCanceledException) {
+                _logger.Information("Operation GetAvailableJobAsync was canceled");
+                throw;
             }
-            else {
-                _updated = false;
+            catch(Exception e) {
+                _logger.Error(e, "Error while looking for available jobs, for {Worker}", workerId);
+                throw;
             }
-
-            return Task.FromResult(job);
+            finally {
+                _lock.Release();
+            }
         }
 
         /// <summary>
-        /// Receives the heartbeat from the agent. Lifetime information is not persisted in this implementation. This method is
-        /// only used if the
-        /// publishednodes.json file has changed. Is that the case, the worker is informed to cancel (and restart) processing.
+        /// Receives the heartbeat from the LegacyJobOrchestrator, JobProcess; used to control lifetime of job (cancel, restart, keep).
         /// </summary>
         /// <param name="heartbeat"></param>
         /// <param name="ct"></param>
         /// <returns></returns>
         public Task<HeartbeatResultModel> SendHeartbeatAsync(HeartbeatModel heartbeat, CancellationToken ct = default) {
-            HeartbeatResultModel heartbeatResultModel;
-
-            if (heartbeat.Job != null && (_updated || (!_assignedJobs.Any() && !_availableJobs.Any()))) {
-                if (_availableJobs.Count == 0) {
-                    _updated = false;
+            _lock.Wait(ct);
+            try {
+                HeartbeatResultModel heartbeatResultModel;
+                JobProcessingInstructionModel job = null;
+                if (heartbeat.Job != null) {
+                    if (_assignedJobs.TryGetValue(heartbeat.Worker.WorkerId, out job)
+                        && job.Job.Id == heartbeat.Job.JobId) {
+                        // JobProcess should keep working
+                        heartbeatResultModel = new HeartbeatResultModel {
+                            HeartbeatInstruction = HeartbeatInstruction.Keep,
+                            LastActiveHeartbeat = DateTime.UtcNow,
+                            UpdatedJob = null,
+                        };
+                    }
+                    else {
+                        // JobProcess have to finished current and process new job (if job != null) otherwise complete
+                        heartbeatResultModel = new HeartbeatResultModel {
+                            HeartbeatInstruction = HeartbeatInstruction.CancelProcessing,
+                            LastActiveHeartbeat = DateTime.UtcNow,
+                            UpdatedJob = job,
+                        };
+                    }
                 }
+                else {
+                    // usecase when called from Timer of Worker instead of JobProcess
+                    heartbeatResultModel = new HeartbeatResultModel {
+                        HeartbeatInstruction = HeartbeatInstruction.Keep,
+                        LastActiveHeartbeat = DateTime.UtcNow,
+                        UpdatedJob = null,
+                    };
+                }
+                _logger.Debug("SendHeartbeatAsync updated worker {worker} with {heartbeatInstruction} instruction for job {jobId}.",
+                    heartbeat.Worker.WorkerId,
+                    heartbeatResultModel?.HeartbeatInstruction,
+                    job?.Job?.Id);
 
-                heartbeatResultModel = new HeartbeatResultModel {
-                    HeartbeatInstruction = HeartbeatInstruction.CancelProcessing,
-                    LastActiveHeartbeat = DateTime.UtcNow,
-                    UpdatedJob = _assignedJobs.TryGetValue(heartbeat.Worker.WorkerId, out var job) ? job : null
-                };
+                return Task.FromResult(heartbeatResultModel);
             }
-            else {
-                heartbeatResultModel = new HeartbeatResultModel {
-                    HeartbeatInstruction = HeartbeatInstruction.Keep,
-                    LastActiveHeartbeat = DateTime.UtcNow,
-                    UpdatedJob = null
-                };
+            catch (OperationCanceledException) {
+                _logger.Information("Operation SendHeartbeatAsync was canceled");
+                throw;
             }
-
-            return Task.FromResult(heartbeatResultModel);
+            finally {
+                _lock.Release();
+            }
         }
 
         private void _fileSystemWatcher_Changed(object sender, FileSystemEventArgs e) {
-            RefreshJobFromFile();
+            if (e.ChangeType == WatcherChangeTypes.Deleted) {
+                _logger.Information("Published nodes file deleted, cancelling all publishing jobs");
+                _lock.Wait();
+                try {
+                    _availableJobs.Clear();
+                    _assignedJobs.Clear();
+                    _lastKnownFileHash = string.Empty;
+                }
+                finally {
+                    _lock.Release();
+                }
+            }
+            else {
+                RefreshJobFromFile();
+            }
         }
 
         private static string GetChecksum(string file) {
@@ -167,7 +210,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                             }
 
                             foreach (var job in jobs) {
-                                var jobId = $"Standalone_{_identity.DeviceId}_{_identity.ModuleId}";
+                                var jobId = string.IsNullOrEmpty(job.WriterGroup.WriterGroupId)
+                                        ? $"Standalone_{_identity.DeviceId}_{Guid.NewGuid()}"
+                                        : job.WriterGroup.WriterGroupId;
+
                                 job.WriterGroup.DataSetWriters.ForEach(d => {
                                     d.DataSet.ExtensionFields ??= new Dictionary<string, string>();
                                     d.DataSet.ExtensionFields["PublisherId"] = jobId;
@@ -205,7 +251,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                         _availableJobs = availableJobs;
                         _assignedJobs.Clear();
-                        _updated = true;
                     } else {
                         _logger.Information("File {publishedNodesFile} has changed and content-hash is equal to last one, nothing to do", _legacyCliModel.PublishedNodesFile);
                     }
@@ -226,7 +271,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     _logger.Error(e, "Error while reloading {PublishedNodesFile}", _legacyCliModel.PublishedNodesFile);
                     _availableJobs.Clear();
                     _assignedJobs.Clear();
-                    _updated = true;
                 }
                 finally {
                     _lock.Release();
@@ -245,7 +289,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private ConcurrentQueue<JobProcessingInstructionModel> _availableJobs;
         private readonly ConcurrentDictionary<string, JobProcessingInstructionModel> _assignedJobs;
         private string _lastKnownFileHash;
-        private bool _updated;
         private readonly SemaphoreSlim _lock;
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -351,6 +351,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         PublisherId = message.PublisherId,
                         DataSetClassId = message.Writer?.DataSet?
                             .DataSetMetaData?.DataSetClassId.ToString(),
+                        DataSetWriterGroup = message.WriterGroup.WriterGroupId,
                         MessageId = message.SequenceNumber.ToString()
                     };
                     var notificationQueues = message.Notifications.GroupBy(m => m.NodeId)
@@ -360,8 +361,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                             .Select(q => q.Any() ? q.Dequeue() : null)
                                 .Where(s => s != null)
                                     .ToDictionary(
-                                        s => s.NodeId.ToExpandedNodeId(context.NamespaceUris)
-                                            .AsString(message.ServiceMessageContext),
+                                        s => !string.IsNullOrEmpty(s.Id)
+                                            ? s.Id
+                                            : s.NodeId.ToExpandedNodeId(context.NamespaceUris)
+                                                .AsString(message.ServiceMessageContext),
                                         s => s.Value);
                         var dataSetMessage = new DataSetMessage() {
                             DataSetWriterId = message.Writer.DataSetWriterId,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -121,8 +121,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                         PublishedVariableDisplayName = node.DisplayName,
                                         SamplingInterval = node.OpcSamplingIntervalTimespan ??
                                             legacyCliModel.DefaultSamplingInterval,
-                                        HeartbeatInterval = node.HeartbeatInterval.HasValue ?
-                                            TimeSpan.FromSeconds(node.HeartbeatInterval.Value) :
+                                        HeartbeatInterval = node.HeartbeatIntervalTimespan.HasValue ?
+                                            node.HeartbeatIntervalTimespan.Value :
                                             legacyCliModel.DefaultHeartbeatInterval,
                                         QueueSize = legacyCliModel.DefaultQueueSize,
                                         // TODO: skip first?
@@ -213,7 +213,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                 DisplayName = string.IsNullOrEmpty(node.DisplayName) ?
                                     $"{node.Id}_{i}" : $"{node.DisplayName}_{i}",
                                 ExpandedNodeId = node.ExpandedNodeId,
-                                HeartbeatInterval = node.HeartbeatInterval,
                                 HeartbeatIntervalTimespan = node.HeartbeatIntervalTimespan,
                                 OpcPublishingInterval = node.OpcPublishingInterval,
                                 OpcPublishingIntervalTimespan = node.OpcPublishingIntervalTimespan,
@@ -325,18 +324,16 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
 
             /// <summary> Heartbeat </summary>
             [DataMember(EmitDefaultValue = false)]
-            public int? HeartbeatInterval { get; set; }
+            public int? HeartbeatInterval {
+                get => HeartbeatIntervalTimespan.HasValue ? (int)HeartbeatIntervalTimespan.Value.TotalSeconds : default(int?);
+                set => HeartbeatIntervalTimespan = value.HasValue ? TimeSpan.FromSeconds(value.Value) : default(TimeSpan?);
+            }
 
             /// <summary>
             /// Heartbeat interval as TimeSpan.
             /// </summary>
-            [IgnoreDataMember]
-            public TimeSpan? HeartbeatIntervalTimespan {
-                get => HeartbeatInterval.HasValue ?
-                    TimeSpan.FromSeconds(HeartbeatInterval.Value) : (TimeSpan?)null;
-                set => HeartbeatInterval = value != null ?
-                    (int)value.Value.TotalSeconds : (int?)null;
-            }
+            [DataMember(EmitDefaultValue = false)]
+            public TimeSpan? HeartbeatIntervalTimespan { get; set; }
 
             /// <summary> Skip first value </summary>
             [DataMember(EmitDefaultValue = false)]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -5,6 +5,7 @@
 
 namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
+    using Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models;
     using Microsoft.Azure.IIoT.OpcUa.Publisher;
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
     using Microsoft.Azure.IIoT.OpcUa.Core.Models;
@@ -12,7 +13,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
     using Microsoft.Azure.IIoT.Serializers;
     using Serilog;
     using System;
-    using System.Runtime.Serialization;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
@@ -78,10 +78,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                 return Enumerable.Empty<WriterGroupJobModel>();
             }
             try {
-                return items
+                var result = items
                     // Group by connection
                     .GroupBy(item => new ConnectionModel {
                         OperationTimeout = legacyCliModel.OperationTimeout,
+                        Id = item.DataSetWriterId,
+                        Group = item.DataSetWriterGroup,
                         Endpoint = new EndpointModel {
                             Url = item.EndpointUrl.OriginalString,
                             SecurityMode = item.UseSecurity == false &&
@@ -89,7 +91,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                     SecurityMode.None : SecurityMode.Best
                         },
                         User = item.OpcAuthenticationMode != OpcAuthenticationMode.UsernamePassword ?
-                                null : ToUserNamePasswordCredentialAsync(item).Result
+                                null : ToUserNamePasswordCredentialAsync(item).Result,
+                        
                     },
                         // Select and batch nodes into published data set sources
                         item => GetNodeModels(item, legacyCliModel.ScaleTestCount.GetValueOrDefault(1)),
@@ -101,7 +104,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                         .Flatten()
                         .GroupBy(n => n.OpcPublishingInterval)
                         .SelectMany(n => n
-                            .Distinct((a, b) => a.Id == b.Id && a.DisplayName == b.DisplayName &&
+                            .Distinct((a, b) => a.Id == b.Id && a.DisplayName == b.DisplayName && a.DataSetFieldId == b.DataSetFieldId &&
                                         a.OpcSamplingInterval == b.OpcSamplingInterval)
                             .Batch(1000))
                         .Select(opcNodes => new PublishedDataSetSourceModel {
@@ -114,9 +117,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                 PublishedData = opcNodes
                                     .Select(node => new PublishedDataSetVariableModel {
                                         // this is the monitored item id, not the nodeId!
-                                        // Use the display name if any otherwisw the nodeId
-                                        Id = string.IsNullOrEmpty(node.DisplayName)
-                                            ? node.Id : node.DisplayName,
+                                        // Use the display name if any otherwise the nodeId
+                                        Id = string.IsNullOrEmpty(node.DisplayName) ? 
+                                                string.IsNullOrEmpty(node.DataSetFieldId) ? node.Id : node.DataSetFieldId : node.DisplayName,
                                         PublishedVariableNodeId = node.Id,
                                         PublishedVariableDisplayName = node.DisplayName,
                                         SamplingInterval = node.OpcSamplingIntervalTimespan ??
@@ -141,11 +144,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                         },
                         WriterGroup = new WriterGroupModel {
                             MessageType = legacyCliModel.MessageEncoding,
-                            WriterGroupId = $"{dataSetSourceBatches.First().Connection.Endpoint.Url}_" +
-                                $"{new ConnectionIdentifier(dataSetSourceBatches.First().Connection)}",
+                            WriterGroupId = !string.IsNullOrEmpty(dataSetSourceBatches.First().Connection.Group)
+                                ? $"{dataSetSourceBatches.First().Connection.Group}"
+                                : $"{dataSetSourceBatches.First().Connection.Endpoint.Url}_" +
+                                    $"{new ConnectionIdentifier(dataSetSourceBatches.First().Connection)}",
                             DataSetWriters = dataSetSourceBatches.Select(dataSetSource => new DataSetWriterModel {
-                                DataSetWriterId = $"{dataSetSource.Connection.Endpoint.Url}_" +
-                                    $"{dataSetSource.GetHashSafe()}",
+                                DataSetWriterId = !string.IsNullOrEmpty(dataSetSource.Connection.Id)
+                                    ? $"{dataSetSource.Connection.Id}"
+                                    : $"{dataSetSource.Connection.Endpoint.Url}_" +
+                                        $"{dataSetSource.GetHashSafe()}",
                                 DataSet = new PublishedDataSetModel {
                                     DataSetSource = dataSetSource.Clone(),
                                 },
@@ -182,6 +189,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                             }
                         }
                     }).ToList();
+                return result;
             }
             catch (Exception ex){
                 _logger.Error(ex, "failed to convert the published nodes.");
@@ -204,6 +212,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                         node.Id = node.ExpandedNodeId;
                     }
                     if (scaleTestCount == 1) {
+                        node.OpcPublishingInterval = item.DataSetPublishingInterval.HasValue ? item.DataSetPublishingInterval : node.OpcPublishingInterval;
                         yield return node;
                     }
                     else {
@@ -212,13 +221,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                 Id = node.Id,
                                 DisplayName = string.IsNullOrEmpty(node.DisplayName) ?
                                     $"{node.Id}_{i}" : $"{node.DisplayName}_{i}",
+                                DataSetFieldId = node.DataSetFieldId,
                                 ExpandedNodeId = node.ExpandedNodeId,
                                 HeartbeatIntervalTimespan = node.HeartbeatIntervalTimespan,
-                                OpcPublishingInterval = node.OpcPublishingInterval,
-                                OpcPublishingIntervalTimespan = node.OpcPublishingIntervalTimespan,
+                                OpcPublishingInterval = item.DataSetPublishingInterval.HasValue ? item.DataSetPublishingInterval : node.OpcPublishingInterval,
                                 OpcSamplingInterval = node.OpcSamplingInterval,
-                                OpcSamplingIntervalTimespan = node.OpcSamplingIntervalTimespan,
-                                SkipFirst = node.SkipFirst
+                                SkipFirst = node.SkipFirst,
                             };
                         }
                     }
@@ -272,138 +280,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                 Type = CredentialType.UserName,
                 Value = _serializer.FromObject(new { user, password })
             };
-        }
-
-        /// <summary>
-        /// Describing an entry in the node list
-        /// </summary>
-        [DataContract]
-        public class OpcNodeModel {
-
-            /// <summary> Node Identifier </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string Id { get; set; }
-
-            /// <summary> Also </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string ExpandedNodeId { get; set; }
-
-            /// <summary> Sampling interval </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public int? OpcSamplingInterval { get; set; }
-
-            /// <summary>
-            /// OpcSamplingInterval as TimeSpan.
-            /// </summary>
-            [IgnoreDataMember]
-            public TimeSpan? OpcSamplingIntervalTimespan {
-                get => OpcSamplingInterval.HasValue ?
-                    TimeSpan.FromMilliseconds(OpcSamplingInterval.Value) : (TimeSpan?)null;
-                set => OpcSamplingInterval = value != null ?
-                    (int)value.Value.TotalMilliseconds : (int?)null;
-            }
-
-            /// <summary> Publishing interval </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public int? OpcPublishingInterval { get; set; }
-
-            /// <summary>
-            /// OpcPublishingInterval as TimeSpan.
-            /// </summary>
-            [IgnoreDataMember]
-            public TimeSpan? OpcPublishingIntervalTimespan {
-                get => OpcPublishingInterval.HasValue ?
-                    TimeSpan.FromMilliseconds(OpcPublishingInterval.Value) : (TimeSpan?)null;
-                set => OpcPublishingInterval = value != null ?
-                    (int)value.Value.TotalMilliseconds : (int?)null;
-            }
-
-            /// <summary> Display name </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string DisplayName { get; set; }
-
-            /// <summary> Heartbeat </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public int? HeartbeatInterval {
-                get => HeartbeatIntervalTimespan.HasValue ? (int)HeartbeatIntervalTimespan.Value.TotalSeconds : default(int?);
-                set => HeartbeatIntervalTimespan = value.HasValue ? TimeSpan.FromSeconds(value.Value) : default(TimeSpan?);
-            }
-
-            /// <summary>
-            /// Heartbeat interval as TimeSpan.
-            /// </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public TimeSpan? HeartbeatIntervalTimespan { get; set; }
-
-            /// <summary> Skip first value </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public bool? SkipFirst { get; set; }
-        }
-
-        /// <summary>
-        /// Node id serialized as object
-        /// </summary>
-        [DataContract]
-        public class NodeIdModel {
-            /// <summary> Identifier </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string Identifier { get; set; }
-        }
-
-        /// <summary>
-        /// Contains the nodes which should be
-        /// </summary>
-        [DataContract]
-        public class PublishedNodesEntryModel {
-
-            /// <summary> The endpoint URL of the OPC UA server. </summary>
-            [DataMember(IsRequired = true)]
-            public Uri EndpointUrl { get; set; }
-
-            /// <summary> Secure transport should be used to </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public bool? UseSecurity { get; set; }
-
-            /// <summary> The node to monitor in "ns=" syntax. </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public NodeIdModel NodeId { get; set; }
-
-            /// <summary> authentication mode </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public OpcAuthenticationMode OpcAuthenticationMode { get; set; }
-
-            /// <summary> encrypted username </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string EncryptedAuthUsername { get; set; }
-
-            /// <summary> encrypted password </summary>
-            [DataMember]
-            public string EncryptedAuthPassword { get; set; }
-
-            /// <summary> plain username </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public string OpcAuthenticationUsername { get; set; }
-
-            /// <summary> plain password </summary>
-            [DataMember]
-            public string OpcAuthenticationPassword { get; set; }
-
-            /// <summary> Nodes defined in the collection. </summary>
-            [DataMember(EmitDefaultValue = false)]
-            public List<OpcNodeModel> OpcNodes { get; set; }
-        }
-
-        /// <summary>
-        /// Enum that defines the authentication method
-        /// </summary>
-        [DataContract]
-        public enum OpcAuthenticationMode {
-            /// <summary> Anonymous authentication </summary>
-            [EnumMember]
-            Anonymous,
-            /// <summary> Username/Password authentication </summary>
-            [EnumMember]
-            UsernamePassword
         }
 
         private readonly IEngineConfiguration _config;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             for (var i = 0; i < 10; i++) {
                 tasks.Add(converter.GetAvailableJobAsync(i.ToString(), new JobRequestModel()));
             }
-            
+
             await Task.WhenAll(tasks);
 
             Assert.Equal(2, tasks.Count(t => t.Result != null));
@@ -51,6 +51,31 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 .Select(t => t.Result.Job.JobConfiguration)
                 .Distinct();
             Assert.Equal(2, distinctConfigurations.Count());
+        }
+
+        [Fact]
+        public void Test_PnJson_With_Multiple_Jobs_Expect_DifferentJobIds() {
+            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
+            var identityMock = new Mock<IIdentity>();
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+            var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
+            var publishedNodesJobConverter = new PublishedNodesJobConverter(TraceLogger.Create(), newtonSoftJsonSerializer);
+
+            var legacyCliModel = new LegacyCliModel { PublishedNodesFile = "Engine/pn_assets.json" };
+            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
+
+            var converter = new LegacyJobOrchestrator(publishedNodesJobConverter, legacyCliModelProviderMock.Object, agentConfigProviderMock.Object, jobSerializer, TraceLogger.Create(), identityMock.Object);
+
+            var job1 = converter.GetAvailableJobAsync(1.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.NotNull(job1);
+            var job2 = converter.GetAvailableJobAsync(2.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.NotNull(job2);
+            var job3 = converter.GetAvailableJobAsync(3.ToString(), new JobRequestModel()).GetAwaiter().GetResult();
+            Assert.Null(job3);
+
+            Assert.NotEqual(job1.Job.Id, job2.Job.Id);
         }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/LegacyJobOrchestratorTests.cs
@@ -1,0 +1,56 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Agent.Framework;
+    using Agent.Framework.Models;
+    using Diagnostics;
+    using Models;
+    using Module;
+    using Moq;
+    using Publisher.Engine;
+    using Serializers.NewtonSoft;
+    using Xunit;
+    using static Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Agent.PublisherJobsConfiguration;
+
+    /// <summary>
+    /// Tests the LegacyJobOrchestrator class
+    /// </summary>
+    public class LegacyJobOrchestratorTests {
+
+        [Fact]
+        public async Task GetAvailableJobAsyncMulithreading() {
+            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
+            var identityMock = new Mock<IIdentity>();
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+            var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
+            var publishedNodesJobConverter = new PublishedNodesJobConverter(TraceLogger.Create(), newtonSoftJsonSerializer);
+
+            var legacyCliModel = new LegacyCliModel { PublishedNodesFile = "Engine/publishednodes.json"};
+            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
+
+            var converter = new LegacyJobOrchestrator(publishedNodesJobConverter, legacyCliModelProviderMock.Object, agentConfigProviderMock.Object, jobSerializer, TraceLogger.Create(), identityMock.Object);
+
+            var tasks = new List<Task<JobProcessingInstructionModel>>();
+            for (var i = 0; i < 10; i++) {
+                tasks.Add(converter.GetAvailableJobAsync(i.ToString(), new JobRequestModel()));
+            }
+            
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(2, tasks.Count(t => t.Result != null));
+            var distinctConfigurations = tasks
+                .Where(t => t.Result != null)
+                .Select(t => t.Result.Job.JobConfiguration)
+                .Distinct();
+            Assert.Equal(2, distinctConfigurations.Count());
+        }
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_assets.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_assets.json
@@ -1,0 +1,34 @@
+[
+  {
+    "DataSetWriterId": "Leaf0_10000_3085991c-b85c-4311-9bfb-a916da952234",
+    "DataSetWriterGroup": "Leaf0",
+    "DataSetPublishingInterval": 10000,
+    "EndpointUrl": "opc.tcp://opcplc:50000",
+    "UseSecurity": false,
+    "OpcAuthenticationMode": "Anonymous",
+    "OpcAuthenticationUsername": "",
+    "OpcAuthenticationPassword": "",
+    "OpcNodes": [
+      {
+        "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=StepUp",
+        "DataSetFieldId": "nsu=http://microsoft.com/Opc/OpcPlc/;s=StepUp"
+      }
+    ]
+  },
+  {
+    "DataSetWriterId": "Leaf1_10000_2e4fc28f-ffa2-4532-9f22-378d47bbee5d",
+    "DataSetWriterGroup": "Leaf1",
+    "DataSetPublishingInterval": 10000,
+    "EndpointUrl": "opc.tcp://opcplc:50000",
+    "UseSecurity": false,
+    "OpcAuthenticationMode": "Anonymous",
+    "OpcAuthenticationUsername": "",
+    "OpcAuthenticationPassword": "",
+    "OpcNodes": [
+      {
+        "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1",
+        "DataSetFieldId": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+      }
+    ]
+  }
+]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/publishednodes.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/publishednodes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "EndpointUrl": "opc.tcp://server1:49580",
+    "OpcNodes": [
+      {
+        "Id": "ns=2;s=Node-Server1",
+        "DisplayName": "Node-Server1"
+      }
+    ]
+  },
+  {
+    "EndpointUrl": "opc.tcp://server2:49580",
+    "OpcNodes": [
+      {
+        "Id": "ns=2;s=Node-Server2",
+        "DisplayName": "Node-Server2"
+      }
+    ]
+  }
+]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -28,4 +28,15 @@
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Utils\" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Engine\publishednodes.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Engine\pn_assets.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.Debug\src\Microsoft.Azure.IIoT.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\..\..\..\modules\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher\src\Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.csproj" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.OpcUa.Testing\src\Microsoft.Azure.IIoT.OpcUa.Testing.csproj" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -43,6 +43,482 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
         }
 
         [Fact]
+        public void PnPlcPubSubDataSetWriterIdTest() {
+            var pn = @"
+[
+    {
+        ""DataSetWriterId"": ""testid"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""HeartbeatInterval"": 2
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testid", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetWriterGroupTest() {
+            var pn = @"
+[
+    {
+        ""DataSetWriterGroup"": ""testgroup"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""HeartbeatInterval"": 2
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testgroup", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Group);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetFieldId1Test() {
+            var pn = @"
+[
+    {
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DataSetFieldId"": ""testfieldid1""
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testfieldid1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetFieldId2Test() {
+            var pn = @"
+[
+    {
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DataSetFieldId"": ""testfieldid1""
+            },
+            {
+                ""Id"": ""i=2259"",
+                ""DataSetFieldId"": ""testfieldid2""
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(2, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Count);
+            Assert.Equal("testfieldid1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.First().Id);
+            Assert.Equal("testfieldid2", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Last().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubFullTest() {
+            var pn = @"
+[
+    {
+        ""DataSetWriterGroup"": ""testgroup"",
+        ""DataSetWriterId"": ""testwriterid"",
+        ""DataSetPublishingInterval"": 1000,
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DataSetFieldId"": ""testfieldid1"",
+                ""OpcPublishingInterval"": 2000
+            },
+            {
+                ""Id"": ""i=2259"",
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromSeconds(5) } );
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(2, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Count);
+            Assert.Equal("testfieldid1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.First().Id);
+            Assert.Equal("i=2259", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Last().Id);
+            Assert.Equal("testgroup", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Group);
+            Assert.Equal("testwriterid", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Id);
+            Assert.Equal(1000, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetPublishingInterval1Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(1000, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetPublishingInterval2Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""OpcPublishingInterval"": 2000
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(1000, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetPublishingInterval3Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258""
+            },
+            {
+                ""Id"": ""i=2259""
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(1000, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDataSetPublishingInterval4Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""OpcPublishingInterval"": 2000
+            },
+            {
+                ""Id"": ""i=2259"",
+                ""OpcPublishingInterval"": 3000
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal(1000, jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDisplayName1Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DisplayName"": ""testdisplayname1""
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testdisplayname1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDisplayName2Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("i=2258", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDisplayName3Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DisplayName"": ""testdisplayname1"",
+                ""DataSetFieldId"": ""testdatasetfieldid1"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testdisplayname1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubDisplayName4Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DataSetFieldId"": ""testdatasetfieldid1"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testdatasetfieldid1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().Id);
+        }
+
+        [Fact]
+        public void PnPlcPubSubPublishedNodeDisplayName1Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DisplayName"": ""testdisplayname1""
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testdisplayname1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().PublishedVariableDisplayName);
+        }
+
+        [Fact]
+        public void PnPlcPubSubPublishedNodeDisplayName2Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Null(jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().PublishedVariableDisplayName);
+        }
+
+        [Fact]
+        public void PnPlcPubSubPublishedNodeDisplayName3Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DisplayName"": ""testdisplayname1"",
+                ""DataSetFieldId"": ""testdatasetfieldid1"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Equal("testdisplayname1", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().PublishedVariableDisplayName);
+        }
+
+        [Fact]
+        public void PnPlcPubSubPublishedNodeDisplayName4Test() {
+            var pn = @"
+[
+    {
+        ""DataSetPublishingInterval"": ""1000"",
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""DataSetFieldId"": ""testdatasetfieldid1"",
+            },
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Null(jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.PublishedVariables.PublishedData.Single().PublishedVariableDisplayName);
+        }
+
+        [Fact]
         public void PnPlcHeartbeatInterval2Test() {
 
             var pn = @"
@@ -74,6 +550,40 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
                 .WriterGroup.DataSetWriters.Single()
                 .DataSet.DataSetSource.PublishedVariables.PublishedData.Single()
                 .HeartbeatInterval.Value.TotalSeconds);
+        }
+
+        [Fact]
+        public void PnPlcHeartbeatIntervalTimespanTest() {
+
+            var pn = @"
+[
+    {
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258"",
+                ""HeartbeatIntervalTimespan"": ""00:00:01.500""
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel());
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.All(jobs, j => Assert.Equal(MessagingMode.Samples, j.MessagingMode));
+            Assert.All(jobs, j => Assert.Null(j.ConnectionString));
+            Assert.Single(jobs
+                .Single().WriterGroup.DataSetWriters);
+            Assert.Equal("opc.tcp://localhost:50000", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Endpoint.Url);
+            Assert.Equal(1500, jobs.Single()
+                .WriterGroup.DataSetWriters.Single()
+                .DataSet.DataSetSource.PublishedVariables.PublishedData.Single()
+                .HeartbeatInterval.Value.TotalMilliseconds);
         }
 
         [Fact]
@@ -163,6 +673,39 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
             Assert.Equal("opc.tcp://localhost:50000", jobs
                 .Single().WriterGroup.DataSetWriters
                 .Single().DataSet.DataSetSource.Connection.Endpoint.Url);
+            Assert.Equal(2000, jobs.Single().WriterGroup.DataSetWriters.Single()
+                .DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
+        }
+
+        [Fact]
+        public void PnPlcPublishingIntervalCliTest() {
+
+            var pn = @"
+[
+    {
+        ""EndpointUrl"": ""opc.tcp://localhost:50000"",
+        ""OpcNodes"": [
+            {
+                ""Id"": ""i=2258""
+            }
+        ]
+    }
+]
+";
+            var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
+            var jobs = converter.Read(new StringReader(pn), new LegacyCliModel() { DefaultPublishingInterval = TimeSpan.FromSeconds(10) });
+
+            Assert.NotEmpty(jobs);
+            Assert.Single(jobs);
+            Assert.Single(jobs
+                .Single().WriterGroup.DataSetWriters);
+            Assert.All(jobs, j => Assert.Equal(MessagingMode.Samples, j.MessagingMode));
+            Assert.All(jobs, j => Assert.Null(j.ConnectionString));
+            Assert.Equal("opc.tcp://localhost:50000", jobs
+                .Single().WriterGroup.DataSetWriters
+                .Single().DataSet.DataSetSource.Connection.Endpoint.Url);
+            Assert.Equal(10000, jobs.Single().WriterGroup.DataSetWriters.Single()
+                .DataSet.DataSetSource.SubscriptionSettings.PublishingInterval.Value.TotalMilliseconds);
         }
 
         [Fact]
@@ -193,6 +736,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
             Assert.Equal("opc.tcp://localhost:50000", jobs
                 .Single().WriterGroup.DataSetWriters
                 .Single().DataSet.DataSetSource.Connection.Endpoint.Url);
+            Assert.Equal(2000, jobs.Single()
+             .WriterGroup.DataSetWriters.Single()
+             .DataSet.DataSetSource.PublishedVariables.PublishedData.Single()
+             .SamplingInterval.Value.TotalMilliseconds);
         }
 
         [Fact]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/NetworkMessage.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/NetworkMessage.cs
@@ -33,6 +33,11 @@ namespace Opc.Ua.PubSub {
         public string DataSetClassId { get; set; }
 
         /// <summary>
+        /// Dataset writerGroup
+        /// </summary>
+        public string DataSetWriterGroup { get; set; }
+
+        /// <summary>
         /// Message type
         /// </summary>
         public string MessageType { get; set; } = "ua-data";
@@ -106,6 +111,7 @@ namespace Opc.Ua.PubSub {
             if (!Utils.IsEqual(wrapper.MessageContentMask, MessageContentMask) ||
                 !Utils.IsEqual(wrapper.MessageId, MessageId) ||
                 !Utils.IsEqual(wrapper.DataSetClassId, DataSetClassId) ||
+                !Utils.IsEqual(wrapper.DataSetWriterGroup, DataSetWriterGroup) ||
                 !Utils.IsEqual(wrapper.BinaryEncodingId, BinaryEncodingId) ||
                 !Utils.IsEqual(wrapper.MessageType, MessageType) ||
                 !Utils.IsEqual(wrapper.PublisherId, PublisherId) ||
@@ -165,6 +171,8 @@ namespace Opc.Ua.PubSub {
             if(DataSetClassId != null){
                 MessageContentMask |= (uint)JsonNetworkMessageContentMask.DataSetClassId;
             }
+            DataSetWriterGroup = decoder.ReadString(nameof(DataSetWriterGroup));
+
             var messagesArray = decoder.ReadEncodeableArray("Messages", typeof(DataSetMessage));
             Messages = new List<DataSetMessage>();
             foreach (var value in messagesArray) {
@@ -207,8 +215,12 @@ namespace Opc.Ua.PubSub {
                 if ((MessageContentMask & (uint)JsonNetworkMessageContentMask.PublisherId) != 0) {
                     encoder.WriteString(nameof(PublisherId), PublisherId);
                 }
-                if ((MessageContentMask & (uint)JsonNetworkMessageContentMask.DataSetClassId) != 0) {
+                if ((MessageContentMask & (uint)JsonNetworkMessageContentMask.DataSetClassId) != 0 &&
+                    !string.IsNullOrEmpty(DataSetClassId)) {
                     encoder.WriteString(nameof(DataSetClassId), DataSetClassId);
+                }
+                if (!string.IsNullOrEmpty(DataSetWriterGroup)) {
+                    encoder.WriteString(nameof(DataSetWriterGroup), DataSetWriterGroup);
                 }
                 if (Messages != null && Messages.Count > 0) {
                     if ((MessageContentMask & (uint)JsonNetworkMessageContentMask.SingleDataSetMessage) != 0) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Extensions/ConnectionModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Extensions/ConnectionModelEx.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Core.Models {
             if (model == null || that == null) {
                 return false;
             }
+            if (that.Id != model.Id) {
+                return false;
+            }
+            if (that.Group != model.Group) {
+                return false;
+            }
             if (!that.Endpoint.IsSameAs(model.Endpoint)) {
                 return false;
             }
@@ -63,6 +69,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Core.Models {
                 return null;
             }
             return new ConnectionModel {
+                Id = model.Id,
+                Group = model.Group,
                 Endpoint = model.Endpoint.Clone(),
                 User = model.User.Clone(),
                 Diagnostics = model.Diagnostics.Clone()

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Models/ConnectionModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Models/ConnectionModel.cs
@@ -12,6 +12,16 @@ namespace Microsoft.Azure.IIoT.OpcUa.Core.Models {
     public class ConnectionModel {
 
         /// <summary>
+        /// Connection Identifier - DataSetWriterId
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Group Id of the data set associated to the connection that the stram belongs to - DataSetWriterGroup
+        /// </summary>
+        public string Group { get; set; }
+
+        /// <summary>
         /// Endpoint
         /// </summary>
         public EndpointModel Endpoint { get; set; }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/NodeIdModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/NodeIdModel.cs
@@ -1,0 +1,19 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Node id serialized as object
+    /// </summary>
+    [DataContract]
+    public class NodeIdModel {
+
+        /// <summary> Identifier </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string Identifier { get; set; }
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcAuthenticationMode.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcAuthenticationMode.cs
@@ -1,0 +1,21 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Enum that defines the authentication method
+    /// </summary>
+    [DataContract]
+    public enum OpcAuthenticationMode {
+        /// <summary> Anonymous authentication </summary>
+        [EnumMember]
+        Anonymous,
+        /// <summary> Username/Password authentication </summary>
+        [EnumMember]
+        UsernamePassword
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcNodeModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcNodeModel.cs
@@ -1,0 +1,79 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Describing an entry in the node list
+    /// </summary>
+    [DataContract]
+    public class OpcNodeModel {
+
+        /// <summary> Node Identifier </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string Id { get; set; }
+
+        /// <summary> Expanded Node identifier </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string ExpandedNodeId { get; set; }
+
+        /// <summary> Sampling interval </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public int? OpcSamplingInterval { get; set; }
+
+        /// <summary>
+        /// OpcSamplingInterval as TimeSpan.
+        /// </summary>
+        [IgnoreDataMember]
+        public TimeSpan? OpcSamplingIntervalTimespan {
+            get => OpcSamplingInterval.HasValue ?
+                TimeSpan.FromMilliseconds(OpcSamplingInterval.Value) : (TimeSpan?)null;
+            set => OpcSamplingInterval = value != null ?
+                (int)value.Value.TotalMilliseconds : (int?)null;
+        }
+
+        /// <summary> Publishing interval </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public int? OpcPublishingInterval { get; set; }
+
+        /// <summary>
+        /// OpcPublishingInterval as TimeSpan.
+        /// </summary>
+        [IgnoreDataMember]
+        public TimeSpan? OpcPublishingIntervalTimespan {
+            get => OpcPublishingInterval.HasValue ?
+                TimeSpan.FromMilliseconds(OpcPublishingInterval.Value) : (TimeSpan?)null;
+            set => OpcPublishingInterval = value != null ?
+                (int)value.Value.TotalMilliseconds : (int?)null;
+        }
+
+        /// <summary> DataSetFieldId </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string DataSetFieldId { get; set; }
+
+        /// <summary> Display name </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string DisplayName { get; set; }
+
+        /// <summary> Heartbeat </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public int? HeartbeatInterval {
+            get => HeartbeatIntervalTimespan.HasValue ? (int)HeartbeatIntervalTimespan.Value.TotalSeconds : default(int?);
+            set => HeartbeatIntervalTimespan = value.HasValue ? TimeSpan.FromSeconds(value.Value) : default(TimeSpan?);
+        }
+
+        /// <summary>
+        /// Heartbeat interval as TimeSpan.
+        /// </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public TimeSpan? HeartbeatIntervalTimespan { get; set; }
+
+        /// <summary> Skip first value </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public bool? SkipFirst { get; set; }
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedItemModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedItemModel.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// Alias identifier to be used in telemetry stream if provided
+        /// </summary>
+        public string AliasId { get; set; }
+
+        /// <summary>
         /// Publishing interval to use
         /// </summary>
         public TimeSpan? PublishingInterval { get; set; }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedNodesEntryModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedNodesEntryModel.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Contains the nodes which should be
+    /// </summary>
+    [DataContract]
+    public class PublishedNodesEntryModel {
+
+        /// <summary> Id Identifier of the DataFlow - DataSetWriterId. </summary>
+        [DataMember(IsRequired = false)]
+        public string DataSetWriterId { get; set; }
+
+        /// <summary> The Group the stream belongs to - DataSetWriterGroup. </summary>
+        [DataMember(IsRequired = false)]
+        public string DataSetWriterGroup { get; set; }
+
+        /// <summary> The Publishing interval for a dataset writer </summary>
+        [DataMember(IsRequired = false)]
+        public int? DataSetPublishingInterval { get; set; }
+
+        /// <summary> The endpoint URL of the OPC UA server. </summary>
+        [DataMember(IsRequired = true)]
+        public Uri EndpointUrl { get; set; }
+
+        /// <summary> Secure transport should be used to </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public bool? UseSecurity { get; set; }
+
+        /// <summary> The node to monitor in "ns=" syntax. </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public NodeIdModel NodeId { get; set; }
+
+        /// <summary> authentication mode </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public OpcAuthenticationMode OpcAuthenticationMode { get; set; }
+
+        /// <summary> encrypted username </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string EncryptedAuthUsername { get; set; }
+
+        /// <summary> encrypted password </summary>
+        [DataMember]
+        public string EncryptedAuthPassword { get; set; }
+
+        /// <summary> plain username </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public string OpcAuthenticationUsername { get; set; }
+
+        /// <summary> plain password </summary>
+        [DataMember]
+        public string OpcAuthenticationPassword { get; set; }
+
+        /// <summary> Nodes defined in the collection. </summary>
+        [DataMember(EmitDefaultValue = false)]
+        public List<OpcNodeModel> OpcNodes { get; set; }
+    }
+}

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -38,7 +38,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 this[item.Key] = item.Value;
             }
             Config = ToAgentConfigModel();
-            LegacyCliModel = ToLegacyCliModel();
         }
 
         // TODO: Figure out which are actually supported in the new publisher implementation
@@ -190,7 +189,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             options.Parse(args);
 
             Config = ToAgentConfigModel();
-            LegacyCliModel = ToLegacyCliModel();
         }
 
         /// <summary>
@@ -240,7 +238,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// The model of the CLI arguments.
         /// </summary>
-        public LegacyCliModel LegacyCliModel { get; }
+        public LegacyCliModel LegacyCliModel {
+            get {
+                if (_legacyCliModel == null) {
+                    _legacyCliModel = ToLegacyCliModel();
+                }
+
+                return _legacyCliModel;
+            }
+        }
 
         /// <summary>
         /// Gets the additiona loggerConfiguration that represents the command line arguments.
@@ -316,5 +322,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             var converter = TypeDescriptor.GetConverter(typeof(T));
             return (T)converter.ConvertFrom(this[key]);
         }
+
+        private LegacyCliModel _legacyCliModel = null;
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -194,9 +194,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// check if we're running in standalone mode - default publishednodes.json file accessible
         /// </summary>
-        public bool RunInLegacyMode => System.IO.File.Exists(
-            GetValueOrDefault(LegacyCliConfigKeys.PublisherNodeConfigurationFilename,
-                LegacyCliConfigKeys.DefaultPublishedNodesFilename));
+        public bool RunInLegacyMode => TryGetValue(LegacyCliConfigKeys.PublisherNodeConfigurationFilename, out _) ||
+             System.IO.File.Exists(LegacyCliConfigKeys.DefaultPublishedNodesFilename);
 
         /// <summary>
         /// The AgentConfigModel instance that is based on specified legacy command line arguments.


### PR DESCRIPTION
main fix is  [published nodes with different "groups/assets" for same endpoint causing closing and reopening of sessions](https://github.com/Azure/Industrial-IoT/pull/1017), but it needs some previous fixes.

Merging in a number of commits with bug fixes

3c96d7a[](https://github.com/Azure/Industrial-IoT/commit/3c96d7afd1cc05d90f7e9689630a9b7c5b6b3724)

3d9d503[](https://github.com/Azure/Industrial-IoT/commit/3d9d503d665c1171323f4cdff52505fb5cd71c81)

72bede2[](https://github.com/Azure/Industrial-IoT/commit/72bede29649073e53c7d38ab7d44c0ea6a1eff16)

aad90ac[](https://github.com/Azure/Industrial-IoT/commit/aad90ac0be31a8ba0b2f416874c85d237e1e1a27)

5639f97[](https://github.com/Azure/Industrial-IoT/commit/5639f97e258a09f19a24ae9fd6cbd4028aa149a8)