### PR TITLE
do not change OPC UA namespace URI after parsing it. (#738)

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Extensions/NodeIdEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Extensions/NodeIdEx.cs
@@ -285,7 +285,10 @@ namespace Opc.Ua.Extensions {
                 if (string.IsNullOrEmpty(uri.Fragment)) {
                     throw new FormatException($"Bad fragment - should contain identifier.");
                 }
-                nsUri = uri.NoQueryAndFragment().AbsoluteUri;
+
+                var idStart = value.IndexOf('#');
+
+                nsUri = idStart >= 0 ? value.Substring(0, idStart) : uri.NoQueryAndFragment().AbsoluteUri;
                 value = uri.Fragment.TrimStart('#');
             }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Stack/Extensions/NodeIdExTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Stack/Extensions/NodeIdExTests.cs
@@ -99,6 +99,21 @@ namespace Opc.Ua.Extensions {
         }
 
         [Fact]
+        public void DecodeNodeIdFromIntUrl() {
+            var context = new ServiceMessageContext();
+            var uri = "http://contosos.com#i=1";
+            var result = uri.ToExpandedNodeId(context);
+            Assert.Equal("http://contosos.com", result.NamespaceUri);
+        }
+
+        [Fact]
+        public void ParseNodeIdUsingAbsoluteUri() {
+            var value = "http://contosos.com#i=1";
+            Uri.TryCreate(value, UriKind.Absolute, out var uri);
+            Assert.NotEqual("http://contosos.com", uri.NoQueryAndFragment().AbsoluteUri);
+        }
+
+        [Fact]
         public void DecodeNodeIdFromBufferNoUri() {
             var context = new ServiceMessageContext();
             var expected = new byte[] { 0, 34, 23, 255, 6, 34, 65, 0, 0, 2, 0 };


### PR DESCRIPTION
* do not change OPC UA namespace URI after parsing it.

* added to to show uri.NoQueryAndFragment().AbsoluteUri behavior parsing http://contosos.com

* formatting and make tests pass

Co-authored-by: Martin Regen <mregen@microsoft.com>
Co-authored-by: Dovydas Jarukaitis <dovydas.jarukaitis@tinkamaskodas.lt>