### PR TITLE
Fix null reference exception in OnSubscriptionStateChanged

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
@@ -153,6 +153,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 }
                 TriggerKeepAlive();
             }
+            catch (Exception ex) {
+                _logger.Error(ex, "Failed to register subscription");
+            }
             finally {
                 _lock.Release();
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -129,6 +129,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
 
             /// <inheritdoc/>
             public void OnSubscriptionStateChanged(bool online) {
+                if (_currentlyMonitored == null) {
+                    return;
+                }
                 foreach (var monitoredItem in _currentlyMonitored) {
                     monitoredItem.OnMonitoredItemStateChanged(online);
                 }


### PR DESCRIPTION
When a subscription is registered there is a potential timing issue between when _currentlyMonitored is set and OnSubscriptionStateChanged is called. A null-check fixes this.