### PR TITLE
Enable CI/CD for main branch

### DIFF
--- a/tools/e2etesting/ReplaceVariablesInAppSettings.ps1
+++ b/tools/e2etesting/ReplaceVariablesInAppSettings.ps1
@@ -70,7 +70,7 @@ if (!$ImageTag) {
 }
 
 if (!$ImageNamespace) {
-   $ImageNamespace="public"
+   $ImageNamespace="main"
 }
 
 if (!$ContainerRegistryServer) {

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -1,7 +1,26 @@
 name: $(Date:yyyyMMdd)$(Rev:rr)
-
 trigger: none
 pr: none
+
+schedules:
+- cron: "0 10 * * *"
+  displayName: Nightly build of main branch.
+  branches:
+    include:
+    - main
+  always: true
+
+# Trigger Orchestrated E2E Pipeline post completion of build pipeline.
+resources:
+  pipelines:
+  - pipeline: Orchestrated-E2E-CD-Pipeline
+    source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
+    trigger:
+      branches:
+        include:
+        - refs/heads/releases/*
+        - refs/heads/master
+        - refs/heads/main
 
 pool:
   name: '$(AgentPool)'

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -3,6 +3,25 @@ name: $(Date:yyyyMMdd)$(Rev:rr)
 trigger: none
 pr: none
 
+schedules:
+- cron: "0 10 * * *"
+  displayName: Nightly build of main branch.
+  branches:
+    include:
+    - main
+  always: true
+
+# Trigger Stand Alone E2E Pipeline post completion of build pipeline.
+resources:
+  pipelines:
+  - pipeline: Standalone-E2E-CD-Pipeline
+    source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
+    trigger:
+      branches:
+        include:
+        - refs/heads/releases/*
+        - refs/heads/master
+        - refs/heads/main
 pool:
   name: '$(AgentPool)'
 

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -17,6 +17,34 @@ steps:
     artifact: 'iai'
     path: $(BasePath)
 
+- task: AzureKeyVault@1
+  displayName: 'Load secrets from Key Vault as variables by default'
+  condition: and(eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
+  inputs:
+    azureSubscription: 'IOT-OPC-WALLS-SP'
+    KeyVaultName: 'developPipelineKV'
+    SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
+    RunAsPreJob: true
+
+- task: PowerShell@2
+  displayName: Versioning
+  name: setVersionInfo
+  inputs:
+    targetType: filePath
+    filePath: $(BasePath)\..\scripts\set-version.ps1
+
+- task: AzureCLI@2
+  displayName: 'Override platform version if necessary'
+  condition: eq(variables['PlatformVersion'], '')
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    azurePowerShellVersion: 'latestVersion'
+    scriptLocation: 'InlineScript'
+    scriptType: 'ps'
+    addSpnToEnvironment: true
+    inlineScript: |
+      Write-Host "##vso[task.setvariable variable=PlatformVersion]$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)"
+
 - task: AzurePowerShell@5
   displayName: "Replace parameters in appSettings.json (for IAI)"
   inputs:

--- a/tools/scripts/set-version.ps1
+++ b/tools/scripts/set-version.ps1
@@ -20,3 +20,4 @@ Write-Host "Setting version build variables:"
 
 Write-Host "##vso[task.setvariable variable=Version_Full;isOutput=true]$($version.Full)"
 Write-Host "##vso[task.setvariable variable=Version_Prefix;isOutput=true]$($version.Prefix)"
+Write-Host "##vso[task.setvariable variable=Version_Prerelease;isOutput=true]$($version.Prerelease)"

--- a/tools/templates/acrbuild.yml
+++ b/tools/templates/acrbuild.yml
@@ -45,3 +45,4 @@ jobs:
       azureSubscription: azureiiot
       scriptLocation: inlineScript
       inlineScript: powershell ./tools/scripts/acr-build.ps1 $(dockerFolder)
+      

--- a/version.json
+++ b/version.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8.0",
-  "versionHeightOffset": 0,
+  "version": "2.8.0-rc.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
This PR does the following
1. Enables Continuous Integration, Continuous Deployment by enabling
   following
   - PR Build Completion Triggers Orchestrated Pipeline E2E test (Aka CD follows CI)
   - Adds Code Coverage to PR Pipeline as required step (Adds PR Gate)
   - Uses Key vault to retrieve secrets like username, password by default if unspecified for CD
   - Uses default branch "main" for pointing to a 'ImageNameSpace' if unspecified for CD
   - Uses default version i.e. last successfully built version from
     last commit on the main branch to run end to end test if
     unspecified (CI build default)
   - PR builds are generated in 'Industrailiotdev' container registry by default and 'main' is the default ImageNameSpace for 
   building (CI/PR gates)
   - Run scheduled nightly builds on both CI Pipeline (PR Pipeline) and CD Pipeline (Orchestrated E2E Pipeline)
   - Run scheduled nightly on Standalone Pipeline 
2. Adds '-RC' (Release Candidate) to version to indicate a release candidate on main branch
3. Generates unique builds for every different run using Git Height i.e. number of commits post the last version bump.

Post this PR the following practices are recommended to be followed 
1. Main represents the release candidate for future releases (both regular and LTS)
2. Main should only contain code targeted to be released in the order in which it is to be committed to avoid cherry-picking.
3. Even though end to end testing is not gated per PR, upon failure of orchestrated pipeline, team should stop further check-ins to investigate the root cause of instability and only then proceed forward.
4. If there is need to build a feature which is not yet planned to be released a 'preview' or 'alpha' branch should be spawned off until it is ready to be released. In such a case, version should appropriately reflect '-alpha' or '-preview' instead of '-rc'. It is advised to enable CI\CD on preview branches as well.
5. Code development should happen in individual developer branches. Recommendation for such a branch name is 'feature\alias\anybranchname' to clearly indicate the code in development.

Co-authored-by: Karapet Kostandyan <kakostan@microsoft.com>