### PR TITLE
Enabling nightly builds for Standalone E2E pipeline.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubEdgeBaseDeployment.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubEdgeBaseDeployment.cs
@@ -32,8 +32,8 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
 
         /// <inheritdoc />
         protected override IDictionary<string, IDictionary<string, object>> CreateDeploymentModules() {
-            var server = string.IsNullOrEmpty(_context.ContainerRegistryConfig.ContainerRegistryServer) ?
-                TestConstants.MicrosoftContainerRegistry : _context.ContainerRegistryConfig.ContainerRegistryServer;
+            // We should always consume edgeAgent and edgeHub from mcr.microsoft.com.
+            var server = TestConstants.MicrosoftContainerRegistry;
             var version = _context.IoTEdgeConfig.EdgeVersion;
 
             return JsonConvert.DeserializeObject<IDictionary<string, IDictionary<string, object>>>(@"

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -47,7 +47,7 @@ stages:
   displayName: "Deploy Components"
   dependsOn: build
   condition: eq(dependencies.build.result, 'Succeeded')
-  jobs:  
+  jobs:
   - job: deployplatform
     displayName: 'Deploy Platform'
     steps:
@@ -64,7 +64,7 @@ stages:
 
   - job: deploytestresources
     condition: and(eq(dependencies.deployplatform.result, 'Succeeded'), or(eq(dependencies.deploynestedtestresources.result, 'Succeeded'), eq(dependencies.deploynestedtestresources.result, 'Skipped')))
-    dependsOn: 
+    dependsOn:
       - deployplatform
       - deploynestedtestresources
     displayName: 'Deploy Test Resources'

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -42,7 +42,7 @@ stages:
   displayName: "Deploy Components"
   dependsOn: build
   condition: and(not(canceled()), eq(dependencies.build.result, 'Succeeded'))
-  jobs:  
+  jobs:
   - job: deploystandalone
     displayName: 'Deploy Standalone Resources'
     steps:

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -55,6 +55,35 @@ steps:
     KeyVaultName: '$(KeyVaultName)'
     SecretsFilter: 'PCS-SERVICE-URL,PCS-AUTH-TENANT,PCS-AUTH-CLIENT-APPID,PCS-AUTH-CLIENT-SECRET'
 
+- task: AzureKeyVault@1
+  displayName: 'Load secrets from Key Vault as variables by default'
+  condition: and(eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
+  inputs:
+    azureSubscription: 'IOT-OPC-WALLS-SP'
+    KeyVaultName: 'developPipelineKV'
+    SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
+    RunAsPreJob: true
+
+- task: PowerShell@2
+  displayName: Versioning
+  name: setVersionInfo
+  condition: eq(variables['PlatformVersion'], '')
+  inputs:
+    targetType: filePath
+    filePath: $(BasePath)\..\scripts\set-version.ps1
+
+- task: AzureCLI@2
+  displayName: 'Override platform version if necessary'
+  condition: eq(variables['PlatformVersion'], '')
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    azurePowerShellVersion: 'latestVersion'
+    scriptLocation: 'InlineScript'
+    scriptType: 'ps'
+    addSpnToEnvironment: true
+    inlineScript: |
+      Write-Host "##vso[task.setvariable variable=PlatformVersion]$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)"
+
 - task: DotNetCoreCLI@2
   displayName: 'Executing xUnit tests (with ${{ parameters.ModeName }}=${{ parameters.ModeValue }})'
   timeoutInMinutes: 90


### PR DESCRIPTION
Changes:
* Added loading of container registry details from Key Vault for standalone pipeline.
* We should always consume `edgeAgent` and `edgeHub` from `mcr.microsoft.com`.