### PR TITLE
IAI: Changed logic of latest Kubernetes version selection.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -806,16 +806,15 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
             var kubernetesVersions = await _azureResourceManager
                 .ListKubernetesVersionsAsync(_resourceGroup.Region, cancellationToken);
             var kubernetesVersion = AksMgmtClient.SelectLatestPatchVersion(
-                AksMgmtClient.KUBERNETES_VERSION_MAJ_MIN, kubernetesVersions.ToList());
-            if (kubernetesVersion is null) {
-                // We will fall back to AksMgmtClient.KUBERNETES_VERSION_FALLBACK if it is available in the region.
-                if (kubernetesVersions.Contains(AksMgmtClient.KUBERNETES_VERSION_FALLBACK)) {
-                    kubernetesVersion = AksMgmtClient.KUBERNETES_VERSION_FALLBACK;
-                }
-                else {
-                    throw new Exception($"Fallback Kubernetes version is not suported in the region: {AksMgmtClient.KUBERNETES_VERSION_FALLBACK}");
-                }
-            }
+                AksMgmtClient.KUBERNETES_VERSION_MAJ_MIN,
+                kubernetesVersions.ToList()
+            );
+
+            // Take higher version between the received latest and KUBERNETES_VERSION_FALLBACK.
+            kubernetesVersion = AksMgmtClient.SelectLatestPatchVersion(
+                AksMgmtClient.KUBERNETES_VERSION_MAJ_MIN,
+                new List<string> { kubernetesVersion, AksMgmtClient.KUBERNETES_VERSION_FALLBACK }
+            );
 
             Log.Information($"Kubernetes version {kubernetesVersion} will be used in AKS.");
 

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION_FALLBACK = "1.18.14";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.18.17";
         public const string KUBERNETES_VERSION_MAJ_MIN = "1.18";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;


### PR DESCRIPTION
Changes:
* Changed logic of latest Kubernetes version selection.
* Upgraded default AKS version to `1.18.17`.

The main change here is that now we select higher version between latest returned patch version from SDK and `AksMgmtClient.KUBERNETES_VERSION_FALLBACK`. This is required as the call that we perform through SDK no longer returns latest version that is available. At the moment there is a discrepancy between returned versions through SDK and Azure CLI. I've filed a bug for this in the GitHub repository of C# SDK. Please check it for more context on this fix. When the returned list in SDK is fixed, the changed logic should still choose the correct version.

Bug in C# SDK: [[BUG] Discrepancy in available Kubernetes versions (AKS) returned from Azure CLI and C# SDK #1242](https://github.com/Azure/azure-libraries-for-net/issues/1242)