### PR TITLE
Enable CI/CD for release branch

### DIFF
--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -8,7 +8,7 @@ schedules:
   branches:
     include:
     - main
-    - prmathur/release
+    - release
   always: true
 
 # Trigger Orchestrated E2E Pipeline post completion of build pipeline.
@@ -20,7 +20,7 @@ resources:
       branches:
         include:
         - refs/heads/releases/*
-        - refs/heads/prmathur/release/*
+        - refs/heads/release/*
         - refs/heads/master
         - refs/heads/main
 

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -4,10 +4,11 @@ pr: none
 
 schedules:
 - cron: "0 10 * * *"
-  displayName: Nightly build of main branch.
+  displayName: Nightly build of main and release branch.
   branches:
     include:
     - main
+    - prmathur/release
   always: true
 
 # Trigger Orchestrated E2E Pipeline post completion of build pipeline.
@@ -19,6 +20,7 @@ resources:
       branches:
         include:
         - refs/heads/releases/*
+        - refs/heads/prmathur/release/*
         - refs/heads/master
         - refs/heads/main
 

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -5,10 +5,11 @@ pr: none
 
 schedules:
 - cron: "0 10 * * *"
-  displayName: Nightly build of main branch.
+  displayName: Nightly build of main and release branch.
   branches:
     include:
     - main
+    - release
   always: true
 
 # Trigger Stand Alone E2E Pipeline post completion of build pipeline.
@@ -20,6 +21,7 @@ resources:
       branches:
         include:
         - refs/heads/releases/*
+        - refs/heads/release/*
         - refs/heads/master
         - refs/heads/main
 pool:

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -31,7 +31,7 @@ steps:
   condition: eq(variables['BranchName'], 'prmathur/release')
   inputs:
     azureSubscription: 'IOT-OPC-WALLS-SP'
-    KeyVaultName: 'releasePipelineKV'
+    KeyVaultName: 'developPipelineKV'
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 
@@ -53,6 +53,18 @@ steps:
     addSpnToEnvironment: true
     inlineScript: |
       Write-Host "##vso[task.setvariable variable=PlatformVersion]$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)"
+
+- task: AzureCLI@2
+  displayName: 'Override "$(ImageNamespace)" for release branch to "public"'
+  condition: eq(variables['BranchName'], 'prmathur/release')
+  inputs:
+    azureSubscription: '$(AzureSubscription)'
+    azurePowerShellVersion: 'latestVersion'
+    scriptLocation: 'InlineScript'
+    scriptType: 'ps'
+    addSpnToEnvironment: true
+    inlineScript: |
+      Write-Host "##vso[task.setvariable variable=ImageNamespace]public"
 
 - task: AzurePowerShell@5
   displayName: "Replace parameters in appSettings.json (for IAI)"

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -26,6 +26,15 @@ steps:
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 
+- task: AzureKeyVault@1
+  displayName: 'Load secrets from Release Key Vault as variables on Release Branch'
+  condition: and(eq(variables['BranchName'], 'prmathur/release'), eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
+  inputs:
+    azureSubscription: 'IOT-OPC-WALLS-SP'
+    KeyVaultName: 'releasePipelineKV'
+    SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
+    RunAsPreJob: true
+
 - task: PowerShell@2
   displayName: Versioning
   name: setVersionInfo

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -28,7 +28,7 @@ steps:
 
 - task: AzureKeyVault@1
   displayName: 'Load secrets from Release Key Vault as variables on Release Branch'
-  condition: eq(variables['BranchName'], 'prmathur/release')
+  condition: eq(variables['BranchName'], 'release')
   inputs:
     azureSubscription: 'IOT-OPC-WALLS-SP'
     KeyVaultName: 'releaseCICDPipelineKV'
@@ -56,7 +56,7 @@ steps:
 
 - task: AzureCLI@2
   displayName: 'Override "ImageNamespace : $(ImageNamespace)" for release branch to "public"'
-  condition: eq(variables['BranchName'], 'prmathur/release')
+  condition: eq(variables['BranchName'], 'release')
   inputs:
     azureSubscription: '$(AzureSubscription)'
     azurePowerShellVersion: 'latestVersion'

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -28,7 +28,7 @@ steps:
 
 - task: AzureKeyVault@1
   displayName: 'Load secrets from Release Key Vault as variables on Release Branch'
-  condition: and(eq(variables['BranchName'], 'prmathur/release'), eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
+  condition: eq(variables['BranchName'], 'prmathur/release')
   inputs:
     azureSubscription: 'IOT-OPC-WALLS-SP'
     KeyVaultName: 'releasePipelineKV'

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -31,7 +31,7 @@ steps:
   condition: eq(variables['BranchName'], 'prmathur/release')
   inputs:
     azureSubscription: 'IOT-OPC-WALLS-SP'
-    KeyVaultName: 'developPipelineKV'
+    KeyVaultName: 'releaseCICDPipelineKV'
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 
@@ -55,7 +55,7 @@ steps:
       Write-Host "##vso[task.setvariable variable=PlatformVersion]$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)"
 
 - task: AzureCLI@2
-  displayName: 'Override "$(ImageNamespace)" for release branch to "public"'
+  displayName: 'Override "ImageNamespace : $(ImageNamespace)" for release branch to "public"'
   condition: eq(variables['BranchName'], 'prmathur/release')
   inputs:
     azureSubscription: '$(AzureSubscription)'

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -28,7 +28,7 @@ steps:
 
 - task: AzureKeyVault@1
   displayName: 'Load secrets from Release Key Vault as variables on Release Branch'
-  condition: eq(variables['BranchName'], 'release')
+  condition: startsWith(variables['BranchName'], 'release')
   inputs:
     azureSubscription: 'IOT-OPC-WALLS-SP'
     KeyVaultName: 'releaseCICDPipelineKV'
@@ -56,7 +56,7 @@ steps:
 
 - task: AzureCLI@2
   displayName: 'Override "ImageNamespace : $(ImageNamespace)" for release branch to "public"'
-  condition: eq(variables['BranchName'], 'release')
+  condition: startsWith(variables['BranchName'], 'release')
   inputs:
     azureSubscription: '$(AzureSubscription)'
     azurePowerShellVersion: 'latestVersion'

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -6,3 +6,7 @@ variables:
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
   Runtime: 'win-x64'
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
+    BranchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
+    BranchName: $[ replace(variables['System.PullRequest.TargetBranch'], 'refs/heads/', '') ]

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -8,5 +8,3 @@ variables:
   Runtime: 'win-x64'
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
     BranchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
-    BranchName: $[ replace(variables['System.PullRequest.TargetBranch'], 'refs/heads/', '') ]

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8.0-rc.{height}",
+  "version": "2.8.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8.0",
+  "version": "2.8.0-rc.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
This PR does the following 
* Adds a new key vault for fetching secrets for staging releases
* Identifies branch as 'release' and updates the ImageNamespace to "public"
* Enables nightly scheduled runs for 'release' branch