### PR TITLE
Fix filtering of LocalizedText in EncodeableDictionary

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
@@ -61,7 +61,7 @@ namespace Opc.Ua.Encoders {
                 .Where(x => !string.IsNullOrEmpty(x.Key))
                 .Where(x => x.Value != null)
                 .Where(x => x.Value.Value != null)
-                .Where(x => !(x.Value.Value is LocalizedText lt) || (lt.Locale != null && lt.Text != null))
+                .Where(x => !(x.Value.Value is LocalizedText lt) || lt.Locale != null || lt.Text != null)
                 .ToArray();
 
             if (encoder.UseReversibleEncoding) {


### PR DESCRIPTION
Allow LocalizedText without Locale (only Text) to be encoded. For example, generated by OPC-PLC.