### PR TITLE
Add E2E tests

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Config/IOpcPlcConfig.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Config/IOpcPlcConfig.cs
@@ -11,5 +11,30 @@ namespace IIoTPlatform_E2E_Tests.Config {
         /// Semicolon separated URLs to load published_nodes.json from OPC-PLCs
         /// </summary>
         string Urls { get; }
+
+        /// <summary>
+        /// TenantId for SP
+        /// </summary>
+        string TenantId { get; }
+
+        /// <summary>
+        /// SP Id
+        /// </summary>
+        string ServicePrincipalId { get; }
+
+        /// <summary>
+        /// Resource Group
+        /// </summary>
+        string ResourceGroupName { get; }
+
+        /// <summary>
+        /// Region
+        /// </summary>
+        string Region { get; }
+
+        /// <summary>
+        /// Subscription Id
+        /// </summary>
+        string SubscriptionId { get; }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -14,7 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.4.0" />
+    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.6.2" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.4.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.9" />
@@ -23,6 +28,7 @@
     <PackageReference Include="RestSharp" Version="106.11.7" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.0-beta1" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -35,6 +41,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="opc-plc-files\sc001.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Properties\launchSettings.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Properties/launchSettings.json
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Properties/launchSettings.json
@@ -1,9 +1,0 @@
-{
-  "profiles": {
-    "IIoTPlatform-E2E-Tests": {
-      "commandName": "Project",
-      "environmentVariables": {
-      }
-    }
-  }
-}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventNamespaceTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventNamespaceTestTheory.cs
@@ -1,0 +1,139 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Newtonsoft.Json.Linq;
+    using TestExtensions;
+    using TestModels;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// The test theory using different (ordered) test cases to go thru all required steps of publishing OPC UA node
+    /// </summary>
+    public class C_EventNamespaceTestTheory : DynamicAciTestBase {
+        public C_EventNamespaceTestTheory(IIoTStandaloneTestContext context, ITestOutputHelper output)
+            : base(context, output) {
+        }
+
+        [Fact, PriorityOrder(10)]
+        public Task Test_DeployAci() {
+            return TestHelper.CreateSimulationContainerAsync(_context, new List<string> { "/bin/sh", "-c", "./opcplc --autoaccept -ses --pn=50000" }, _timeoutToken);
+        }
+
+        [Fact, PriorityOrder(11)]
+        public async Task Test_VerifyIntegerNamespace_Expect_SimpleEvents_InHub() {
+            // Arrange
+            var pnJson = SimpleEvents(
+                "ns=0;i=2041",
+                "0:Message",
+                "ns=5;i=2",
+                "5:CycleId",
+                "ns=5;i=2");
+
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemCycleStatusEventTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var payloads = await messages.FirstAsync(_timeoutToken);
+
+            // Assert
+            VerifyPayloads(payloads.Messages);
+        }
+
+        [Fact, PriorityOrder(12)]
+        public async Task Test_VerifyStringNamespace_Expect_SimpleEvents_InHub() {
+            // Arrange
+            var pnJson = SimpleEvents(
+                "i=2041",
+                "Message",
+                "nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2",
+                "http://microsoft.com/Opc/OpcPlc/SimpleEvents#CycleId",
+                "nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2");
+
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemCycleStatusEventTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var payloads = await messages.FirstAsync(_timeoutToken);
+
+            // Assert
+            VerifyPayloads(payloads.Messages);
+        }
+
+        [Fact, PriorityOrder(13)]
+        public async Task Test_VerifyIntegerNamespace_Expect_FilteredSimpleEvents_InHub() {
+            // Arrange
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter("ns=5;i=2"));
+
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemCycleStatusEventTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var payloads = await messages.FirstAsync(_timeoutToken);
+
+            // Assert
+            VerifyPayloads(payloads.Messages);
+        }
+
+        [Fact, PriorityOrder(14)]
+        public async Task Test_VerifyStringNamespace_Expect_FilteredSimpleEvents_InHub() {
+            // Arrange
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter("nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2"));
+
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemCycleStatusEventTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var payloads = await messages.FirstAsync(_timeoutToken);
+
+            // Assert
+            VerifyPayloads(payloads.Messages);
+        }
+
+        private static void VerifyPayloads(PubSubMessages<SystemCycleStatusEventTypePayload> payloads) {
+            foreach (var payload in payloads.Select(x => x.Value.Value)) {
+                payload.Message.Should().Match("The system cycle '*' has started.");
+                payload.CycleId.Should().MatchRegex("^\\d+$");
+            }
+        }
+
+        private string SimpleEvents(string messageTypeDefinitionId, string messageBrowsePath, string cycleIdDefinitionId, string cycleIdBrowsePath, string filterTypeDefinitionId) {
+            return _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                new JArray(
+                            new JObject(
+                              new JProperty("Id", "ns=0;i=2253"),
+                              new JProperty("DisplayName", "SimpleEvents"),
+                              new JProperty("SelectClauses", new JArray(
+                                    new JObject(
+                                      new JProperty("TypeDefinitionId", messageTypeDefinitionId),
+                                      new JProperty("BrowsePath", new JArray(
+                                          new JValue(messageBrowsePath)))),
+                                    new JObject(
+                                      new JProperty("TypeDefinitionId", cycleIdDefinitionId),
+                                      new JProperty("BrowsePath", new JArray(
+                                          new JValue(cycleIdBrowsePath)))))),
+                              new JProperty("WhereClause", new JObject(
+                                  new JProperty("Elements", new JArray(
+                                        new JObject(
+                                          new JProperty("FilterOperator", new JValue("OfType")),
+                                          new JProperty("FilterOperands", new JArray(
+                                                new JObject(
+                                                  new JProperty("Value", filterTypeDefinitionId))))))))))));
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventsStressTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventsStressTestTheory.cs
@@ -1,0 +1,110 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using FluentAssertions;
+    using TestExtensions;
+    using TestModels;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static System.TimeSpan;
+
+    /// <summary>
+    /// The test theory submitting a high load of event messages
+    /// </summary>
+    public class C_EventsStressTestTheory : DynamicAciTestBase {
+        public C_EventsStressTestTheory(IIoTStandaloneTestContext context, ITestOutputHelper output)
+            : base(context, output) {
+        }
+
+        [Fact, PriorityOrder(10)]
+        public async void TestACI_VerifyEnd2EndThroughputAndLatency() {
+
+            // Settings
+            const int eventIntervalPerInstanceMs = 400;
+            const int eventInstances = 40;
+            const int instances = 10;
+            const int nSeconds = 20;
+            const int nSecondSkipFirst = 10;
+            const int nSecondSkipLast = 6;
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context,
+                new List<string> {"/bin/sh", "-c", $"./opcplc --autoaccept --ei={eventInstances} --er={eventIntervalPerInstanceMs} --pn=50000"},
+                _timeoutToken,
+                numInstances: instances);
+
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemEventTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter("i=2041")); // OPC-UA BaseEventType
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+
+            const int nSecondsTotal = nSeconds + nSecondSkipFirst + nSecondSkipLast;
+            var fullData = await messages
+                .ConsumeDuring(_context, FromSeconds(nSecondsTotal))
+
+                // Get time of event attached Server node
+                .Select(e => (e.EnqueuedTime, e.Messages["i=2253"].SourceTimestamp))
+                .ToListAsync(_timeoutToken);
+            
+            // Assert throughput
+
+            // Trim first few and last seconds of data, since Publisher polls PLCs
+            // at different times
+            var intervalStart = fullData.Select(d => d.SourceTimestamp).Min() + FromSeconds(nSecondSkipFirst);
+            var intervalEnd = fullData.Select(d => d.SourceTimestamp).Max() - FromSeconds(nSecondSkipLast);
+            var intervalDuration = intervalEnd - intervalStart;
+            var eventData = fullData.Where(d => d.SourceTimestamp > intervalStart && d.SourceTimestamp < intervalEnd).ToList();
+            
+            // Bin events by 1-second interval to compute event rate histogram
+            var eventRatesBySecond = eventData
+                .GroupBy(s => s.SourceTimestamp.Truncate(FromSeconds(1)))
+                .Select(g => g.Count())
+                .ToList();
+
+            _output.WriteLine($"Event rates per second, by second: {string.Join(',', eventRatesBySecond)} e/s");
+
+            var eventRate = eventData.Count / intervalDuration.TotalSeconds;
+            intervalDuration.Should().BeGreaterThan(FromSeconds(nSeconds));
+
+            const int expectedEventsPerSecond = instances * eventInstances * 1000 / eventIntervalPerInstanceMs;
+            eventData.Count().Should().BeGreaterThan(nSeconds * expectedEventsPerSecond,
+                "Publisher should produce data continuously");
+            eventRate.Should().BeApproximately(
+                expectedEventsPerSecond,
+                expectedEventsPerSecond / 10d,
+                "Publisher should match PLC event rate");
+            
+            var (average, stDev) = DescriptiveStats(eventRatesBySecond);
+
+            average.Should().BeApproximately(
+                expectedEventsPerSecond,
+                expectedEventsPerSecond / 10d,
+                "Publisher should match PLC event rate");
+
+            stDev.Should().BeLessThan(expectedEventsPerSecond / 3d, "Publisher should sustain PLC event rate");
+            
+            // Assert latency
+            var end2EndLatency = eventData
+                .Select(v => v.EnqueuedTime - v.SourceTimestamp)
+                .ToList();
+            end2EndLatency.Min().Should().BePositive();
+            end2EndLatency.Average(v => v.TotalMilliseconds).Should().BeLessThan(8000);
+        }
+
+        private static (double average, double stDev) DescriptiveStats(IReadOnlyCollection<int> population) {
+            var average = population.Average();
+            var stDev = Math.Sqrt(population.Sum(v => (v - average) * (v - average)) / population.Count);
+            return (average, stDev);
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PendingAlarmTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PendingAlarmTestTheory.cs
@@ -1,0 +1,84 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using Azure.Messaging.EventHubs.Consumer;
+    using FluentAssertions;
+    using IIoTPlatform_E2E_Tests.TestExtensions;
+    using IIoTPlatform_E2E_Tests.TestModels;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// The test theory using different (ordered) test cases to go thru all required steps of publishing OPC UA node
+    /// </summary>
+    public class C_PendingAlarmTestTheory : DynamicAciTestBase {
+        public C_PendingAlarmTestTheory(IIoTStandaloneTestContext context, ITestOutputHelper output)
+        : base(context, output) {
+        }
+
+        [Fact, PriorityOrder(10)]
+        public async void Test_VerifyDataAvailableAtIoTHub_Expect_PendingAlarmsView() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --alm --pn=50000"},
+                _timeoutToken);
+
+            var messages = _consumer.ReadPendingAlarmMessagesFromWriterIdAsync<ConditionTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+            TestConstants.PublishedNodesConfigurations.PendingAlarmsForAlarmsView(false));
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            // take any message
+            var ev = await messages
+                .FirstAsync(_timeoutToken);
+
+            // Assert
+            ValidatePendingAlarmsView(ev, false);
+        }
+
+        [Fact, PriorityOrder(11)]
+        public async void Test_VerifyDataAvailableAtIoTHub_Expect_PendingAlarmsView_WithCompression() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --alm --pn=50000"},
+                _timeoutToken);
+
+            var messages = _consumer.ReadPendingAlarmMessagesFromWriterIdAsync<ConditionTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+            TestConstants.PublishedNodesConfigurations.PendingAlarmsForAlarmsView(true));
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            // take any message
+            var ev = await messages
+                .FirstAsync(_timeoutToken);
+
+            // Assert
+            ValidatePendingAlarmsView(ev, true);
+        }
+
+        private static void ValidatePendingAlarmsView(PendingAlarmEventData<ConditionTypePayload> eventData, bool expectCompressedPayload) {
+            Assert.Equal(expectCompressedPayload, eventData.IsPayloadCompressed);
+            foreach (var pendingMessage in eventData.Messages.PendingMessages) {
+                pendingMessage.ConditionId.Should().StartWith("http://microsoft.com/Opc/OpcPlc/AlarmsInstance#");
+                eventData.Messages.PendingMessages.Where(x => x.ConditionId == pendingMessage.ConditionId).ToList().Should().HaveCount(1);
+                pendingMessage.Retain.Should().BeTrue();
+            }
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishSingleNodeStandaloneEventsTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishSingleNodeStandaloneEventsTestTheory.cs
@@ -1,0 +1,188 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using TestExtensions;
+    using TestModels;
+    using Xunit;
+    using Xunit.Abstractions;
+    using static System.TimeSpan;
+
+    /// <summary>
+    /// The test theory using different (ordered) test cases to go thru all required steps of publishing OPC UA node
+    /// </summary>
+    public class C_PublishSingleNodeStandaloneEventsTestTheory : DynamicAciTestBase {
+        private static readonly TimeSpan Precision = FromMilliseconds(500);
+
+        public C_PublishSingleNodeStandaloneEventsTestTheory(IIoTStandaloneTestContext context, ITestOutputHelper output)
+            : base(context, output) {
+        }
+
+        [Fact, PriorityOrder(10)]
+        public async Task Test_VerifyDataAvailableAtIoTHub_Expect_AllEvents_ToBeSame() {
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<SystemCycleStatusEventTypePayload>(_writerId, _timeoutToken);
+
+            var plcUrl = _context.OpcPlcConfig.Urls.Split(";")[0];
+            var pnJson = TestConstants.PublishedNodesConfigurations.SimpleEvents(plcUrl, 50000, _writerId);
+
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+
+            // Read one payload from IoT Hub
+            var firstMessage = await messages
+                .FirstAsync(_timeoutToken);
+
+            var payload = firstMessage.Messages["SimpleEvents"];
+            var data = payload.Value;
+            Assert.NotEmpty(data.EventId);
+            Assert.StartsWith("The system cycle '", data.Message);
+            Assert.EndsWith("' has started.", data.Message);
+            Assert.NotEmpty(data.CycleId);
+            Assert.StartsWith("Step ", data.CurrentStep.Name);
+            Assert.NotEqual(0, data.CurrentStep.Duration);
+        }
+
+        [Fact, PriorityOrder(11)]
+        public async void TestACI_VerifyDataAvailableAtIoTHub_Expect_NumberOfEvents_GreaterThan_Zero() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --dalm=files/sc001.json --pn=50000"},
+                _timeoutToken,
+                "opc-plc-files/sc001.json");
+
+            var messages = _consumer.ReadMessagesFromWriterIdAsync<ConditionTypePayload>(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter());
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+
+            const int nMessages = 6; 
+            var payloads = await messages
+                .Select(e => e.Messages["i=2253"].Value)
+                .Skip(nMessages) // First batch of alarms are from a ConditionRefresh, therefore not in order
+                .SkipWhile(c => !c.Message.Contains("LAST EVENT IN LOOP"))
+                .Skip(1)
+                .Take(nMessages)
+                .ToListAsync(_timeoutToken);
+
+            // Assert
+
+            var i = -1;
+            var doorOpen = new ConditionTypePayload {
+                ConditionName = "VendingMachine1_DoorOpen",
+                EnabledState = "Enabled",
+                EnabledStateEffectiveDisplayName = "Active | Unacknowledged",
+                EnabledStateId = true,
+                EventType = "i=10751",
+                LastSeverity = 500,
+                Message = "Door Open",
+                Retain = true,
+                Severity = 900,
+                SourceName = "VendingMachine1",
+                SourceNode = "http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine1",
+            };
+            VerifyPayload(payloads, ++i, null, doorOpen);
+
+            VerifyPayload(payloads,
+                ++i,
+                FromSeconds(5),
+                new ConditionTypePayload {
+                    ConditionName = "VendingMachine2_LightOff",
+                    EnabledState = "Enabled",
+                    EnabledStateEffectiveDisplayName = "Active | Unacknowledged",
+                    EnabledStateId = true,
+                    EventType = "i=10637",
+                    LastSeverity = 500,
+                    Message = "Light Off in machine",
+                    Retain = true,
+                    Severity = 500,
+                    SourceName = "VendingMachine2",
+                    SourceNode = "http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine2",
+                });
+
+            VerifyPayload(payloads,
+                ++i,
+                Zero,
+                new ConditionTypePayload {
+                    ConditionName = "VendingMachine1_AD_Lamp_Off",
+                    EnabledState = "Enabled",
+                    EnabledStateEffectiveDisplayName = "Enabled",
+                    EnabledStateId = true,
+                    EventType = "i=2782",
+                    LastSeverity = 500,
+                    Message = "AD Lamp Off",
+                    Retain = true,
+                    Severity = 500,
+                    SourceName = "VendingMachine1",
+                    SourceNode = "http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine1",
+                });
+
+            VerifyPayload(payloads,
+                ++i,
+                FromSeconds(5),
+                new ConditionTypePayload {
+                    ConditionName = "VendingMachine1_DoorOpen",
+                    EnabledState = "Enabled",
+                    EnabledStateEffectiveDisplayName = "Inactive | Unacknowledged",
+                    EnabledStateId = true,
+                    EventType = "i=10751",
+                    LastSeverity = 900,
+                    Message = "Door Closed",
+                    Retain = false,
+                    Severity = 500,
+                    SourceName = "VendingMachine1",
+                    SourceNode = "http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine1",
+                });
+
+            VerifyPayload(payloads,
+                ++i,
+                FromSeconds(4),
+                new ConditionTypePayload {
+                    ConditionName = "VendingMachine1_TemperatureHigh",
+                    EnabledState = "Enabled",
+                    EnabledStateEffectiveDisplayName = "Active | Unacknowledged",
+                    EnabledStateId = true,
+                    EventType = "i=2955",
+                    LastSeverity = 900,
+                    Message = "Temperature is HIGH (LAST EVENT IN LOOP)",
+                    Retain = true,
+                    Severity = 900,
+                    SourceName = "VendingMachine1",
+                    SourceNode = "http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine1",
+                });
+
+            VerifyPayload(payloads, ++i, Zero, doorOpen); // cycling back to first message
+        }
+
+        private static void VerifyPayload(IReadOnlyList<ConditionTypePayload> payloads, int i, TimeSpan? expectedDelay, ConditionTypePayload expectedPayload) {
+            var p = payloads[i];
+            p.Should().BeEquivalentTo(expectedPayload,
+                opt => opt // ignore non-constant properties
+                    .Excluding(c => c.EventId)
+                    .Excluding(c => c.ConditionId)
+                    .Excluding(m => m.RuntimeType == typeof(DateTime) || m.RuntimeType == typeof(DateTime?)));
+
+            p.ConditionId.Should().StartWith("http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#i=");
+
+            p.CommentSourceTimestamp.Should().BeCloseTo(p.ReceiveTime.Value, Precision);
+            p.EnabledStateEffectiveTransitionTime.Should().BeCloseTo(p.ReceiveTime.Value, Precision);
+            p.EnabledStateTransitionTime.Should().BeCloseTo(p.ReceiveTime.Value, Precision);
+            p.LastSeveritySourceTimestamp.Should().BeCloseTo(p.ReceiveTime.Value, Precision);
+
+            if (expectedDelay != null) {
+                (p.EnabledStateEffectiveTransitionTime - payloads[i - 1].EnabledStateEffectiveTransitionTime)
+                    .Should().BeCloseTo(expectedDelay.Value, Precision);
+            }
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_WhereClauseTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_WhereClauseTestTheory.cs
@@ -1,0 +1,134 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using IIoTPlatform_E2E_Tests.TestExtensions;
+    using Newtonsoft.Json.Linq;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// The test theory using different (ordered) test cases to go thru all required steps of publishing OPC UA node
+    /// </summary>
+    public class C_WhereClauseTestTheory : DynamicAciTestBase {
+        public C_WhereClauseTestTheory(IIoTStandaloneTestContext context, ITestOutputHelper output)
+            : base(context, output) {
+        }
+
+        [Fact, PriorityOrder(10)]
+        public async void Test_VerifyDataAvailableAtIoTHub_Expect_FieldsToMatchSimpleFilter() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --ses --pn=50000"},
+                _timeoutToken);
+
+            var messages = _consumer.ReadMessagesFromWriterIdAsync(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter("i=2041")); // OPC-UA BaseEventType
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+
+            // take any message
+            var ev = await messages
+                .FirstAsync(_timeoutToken);
+
+            // Assert
+            ValidateBaseEventTypeFields(ev.messages);
+        }
+
+        [Fact, PriorityOrder(11)]
+        public async void Test_VerifyDataAvailableAtIoTHub_Expect_FieldsToMatchEventFilter() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --ses --pn=50000"},
+                _timeoutToken);
+
+            var messages = _consumer.ReadMessagesFromWriterIdAsync(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = _context.PublishedNodesJson(
+                50000,
+                _writerId,
+                TestConstants.PublishedNodesConfigurations.SimpleEventFilter("i=2041")); // OPC-UA BaseEventType
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            // take any message
+            var ev = await messages
+                .FirstAsync(_timeoutToken);
+
+            // Assert
+            ValidateBaseEventTypeFields(ev.messages);
+        }
+
+        [Fact, PriorityOrder(12)]
+        public async void Test_VerifyDataAvailableAtIoTHub_Expect_FieldsToSimpleEvents() {
+
+            // Arrange
+            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
+                {"/bin/sh", "-c", "./opcplc --autoaccept --ses --pn=50000"},
+                _timeoutToken);
+
+            var messages = _consumer.ReadMessagesFromWriterIdAsync(_writerId, _timeoutToken);
+
+            // Act
+            var pnJson = TestConstants.PublishedNodesConfigurations.SimpleEvents(_context.PlcAciDynamicUrls[0],
+                50000,
+                _writerId);
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
+            // take any message
+            var ev = await messages
+                .FirstAsync(_timeoutToken);
+
+            // Assert
+            ValidateSimpleEventFields(ev.messages);
+        }
+
+        private void ValidateBaseEventTypeFields(JToken ev) {
+            // navigate to the event fields (nested several layers)
+            var fields = ev.Children()
+                .First()
+                    .Children()
+                        .First()
+                            .Children()
+                                .First()
+                                    .Children()
+                                        .First();
+            Assert.NotNull(fields);
+            Assert.Equal(8, fields.Count());
+            Assert.True(fields.Where(x => x.Path.EndsWith("EventId")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("EventType")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("Message")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("ReceiveTime")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("Severity")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("SourceNode")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("SourceName")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("Time")).Any());
+        }
+
+        private void ValidateSimpleEventFields(JToken ev) {
+            // navigate to the event fields (nested several layers)
+            var fields = ev.Children()
+                .First()
+                    .Children()
+                        .First()
+                            .Children()
+                                .First()
+                                    .Children()
+                                        .First();
+            Assert.NotNull(fields);
+            Assert.Equal(4, fields.Count());
+            Assert.True(fields.Where(x => x.Path.EndsWith("EventId")).Any());
+            Assert.True(fields.Where(x => x.Path.EndsWith("Message")).Any());
+            Assert.True(fields.Where(x => x.Path.Contains("http://microsoft.com/Opc/OpcPlc/SimpleEvents#CycleId")).Any());
+            Assert.True(fields.Where(x => x.Path.Contains("http://microsoft.com/Opc/OpcPlc/SimpleEvents#CurrentStep")).Any());
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DynamicAciTestBase.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DynamicAciTestBase.cs
@@ -1,0 +1,76 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+    using Azure.Messaging.EventHubs.Consumer;
+    using IIoTPlatform_E2E_Tests.TestExtensions;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using TestModels;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Base class for standalone tests using dynamic ACI
+    /// </summary>
+    [TestCaseOrderer(TestCaseOrderer.FullName, TestConstants.TestAssemblyName)]
+    [Collection("IIoT Standalone Test Collection")]
+    [Trait(TestConstants.TraitConstants.PublisherModeTraitName, TestConstants.TraitConstants.PublisherModeStandaloneTraitValue)]
+    public abstract class DynamicAciTestBase : IDisposable {
+        protected readonly ITestOutputHelper _output;
+        protected readonly IIoTStandaloneTestContext _context;
+        protected readonly CancellationToken _timeoutToken;
+        protected readonly EventHubConsumerClient _consumer;
+        protected readonly string _writerId;
+        private readonly CancellationTokenSource _timeoutTokenSource;
+
+        protected DynamicAciTestBase(IIoTStandaloneTestContext context, ITestOutputHelper output) {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _context.OutputHelper = _output;
+            _timeoutTokenSource = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
+            _timeoutToken = _timeoutTokenSource.Token;
+            _consumer = _context.GetEventHubConsumerClient();
+            _writerId = Guid.NewGuid().ToString();
+        }
+
+        public void Dispose() {
+            _consumer?.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+            _timeoutTokenSource?.Dispose();
+        }
+
+        [Fact, PriorityOrder(1)]
+        public async Task Test_CreateEdgeBaseDeployment_Expect_Success() {
+            var result = await _context.IoTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(_timeoutToken);
+            _output.WriteLine("Created/Updated new EdgeBase deployment");
+            Assert.True(result);
+        }
+
+        [Fact, PriorityOrder(2)]
+        public async Task Test_CreatePublisherLayeredDeployment_Expect_Success() {
+            var result = await _context.IoTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(_timeoutToken);
+            _output.WriteLine("Created/Updated layered deployment for publisher module");
+            Assert.True(result);
+        }
+
+        [Fact, PriorityOrder(3)]
+        public async Task Test_WaitForModuleDeployed() {
+            // We will wait for module to be deployed.
+            await _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(_context.DeviceConfig.DeviceId,
+                _timeoutToken, new[] { "publisher_standalone" });
+        }
+        
+        [Fact, PriorityOrder(998)]
+        public async Task Test_StopPublishingAllNodes_Expect_Success() {
+            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(new PublishedNodesEntryModel[0], _context, _timeoutToken);
+        }
+
+        [Fact, PriorityOrder(999)]
+        public void Test_DeleteAci() {
+            TestHelper.DeleteSimulationContainer(_context);
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 namespace IIoTPlatform_E2E_Tests {
+    using Newtonsoft.Json.Linq;
     using System;
 
     /// <summary>
@@ -55,6 +56,11 @@ namespace IIoTPlatform_E2E_Tests {
         /// Default Microsoft Container Registry
         /// </summary>
         public static readonly string MicrosoftContainerRegistry = "mcr.microsoft.com";
+
+        /// <summary>
+        /// IoT Hub Event Hubs endpoint consumer group for tests
+        /// </summary>
+        public const string TestConsumerGroupName = "TestConsumer";
 
         /// <summary>
         /// Contains constants for all routes to Industrial IoT Platform
@@ -155,6 +161,26 @@ namespace IIoTPlatform_E2E_Tests {
             /// of provided (simulated) OPC UA Nodes
             /// </summary>
             public const string PublishedNodesFile = "pn.json";
+
+            /// <summary>
+            /// The share that is created in the pipeline
+            /// </summary>
+            public const string FileShareName = "acishare";
+
+            /// <summary>
+            /// Where to mount the file share in ACI
+            /// </summary>
+            public const string AciMountPath = "/app/files";
+
+            /// <summary>
+            /// This is the first part of the Azure Storage name that is created in pipeline
+            /// </summary>
+            public const string AzureStorageNameWithoutSuffix = "e2etestingstorage";
+
+            /// <summary>
+            /// Name of Tag in Resource Group
+            /// </summary>
+            public const string TestingResourcesSuffixName = "TestingResourcesSuffix";
         }
 
         /// <summary>
@@ -285,6 +311,36 @@ namespace IIoTPlatform_E2E_Tests {
             /// Images tag
             /// </summary>
             public const string PCS_IMAGES_TAG = "PCS_IMAGES_TAG";
+
+            /// <summary>
+            /// SP Key
+            /// </summary>
+            public const string SP_KEY = "SP_KEY";
+
+            /// <summary>
+            /// SP Id
+            /// </summary>
+            public const string SP_ID = "SP_ID";
+
+            /// <summary>
+            /// Tenant Id
+            /// </summary>
+            public const string SP_TENANT_ID = "SP_TENANT_ID";
+
+            /// <summary>
+            /// Tenant Id
+            /// </summary>
+            public const string RESOURCE_GROUP_NAME = "RESOURCE_GROUP_NAME";
+
+            /// <summary>
+            /// Tenant Id
+            /// </summary>
+            public const string REGION = "REGION";
+
+            /// <summary>
+            /// Subscription Id
+            /// </summary>
+            public const string SUBSCRIPTION_ID = "SUBSCRIPTION_ID";
         }
 
         /// <summary>
@@ -346,6 +402,84 @@ namespace IIoTPlatform_E2E_Tests {
             /// </summary>
             public const string Disconnected = "Disconnected";
 
+        }
+
+        internal static class PublishedNodesConfigurations {
+            public static string SimpleEvents(string host, uint port, string writerId) {
+                return @$"
+                [
+                    {{
+                        ""EndpointUrl"": ""opc.tcp://{host}:{port}"",
+                        ""UseSecurity"": false,
+                        ""DataSetWriterId"":""{writerId}"",
+                        ""OpcEvents"": [
+                            {{
+                                ""Id"": ""ns=0;i=2253"",
+                                ""DisplayName"": ""SimpleEvents"",
+                                ""SelectClauses"": [
+                                    {{
+                                        ""TypeDefinitionId"": ""i=2041"",
+                                        ""BrowsePath"": [
+                                            ""EventId""
+                                        ]
+                                    }},
+                                    {{
+                                        ""TypeDefinitionId"": ""i=2041"",
+                                        ""BrowsePath"": [
+                                            ""Message""
+                                        ]
+                                    }},
+                                    {{
+                                        ""TypeDefinitionId"": ""nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2"",
+                                        ""BrowsePath"": [
+                                            ""http://microsoft.com/Opc/OpcPlc/SimpleEvents#CycleId""
+                                        ]
+                                    }},
+                                    {{
+                                        ""TypeDefinitionId"": ""nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2"",
+                                        ""BrowsePath"": [
+                                            ""http://microsoft.com/Opc/OpcPlc/SimpleEvents#CurrentStep""
+                                        ]
+                                    }}
+                                ],
+                                ""WhereClause"": {{
+                                    ""Elements"": [
+                                        {{
+                                            ""FilterOperator"": ""OfType"",
+                                            ""FilterOperands"": [
+                                                {{
+                                                    ""Value"": ""nsu=http://microsoft.com/Opc/OpcPlc/SimpleEvents;i=2""
+                                                }}
+                                            ]
+                                        }}
+                                    ]
+                                }}
+                            }}
+                        ]
+                    }}
+                ]";
+            }
+
+            public static JArray SimpleEventFilter(
+                string typeDefinitionId = "i=2782") {
+                return new JArray(
+                    new JObject(
+                        new JProperty("Id", "i=2253"),
+                        new JProperty("TypeDefinitionId", typeDefinitionId)));
+            }
+
+            public static JArray PendingAlarmsForAlarmsView(bool compressedPayload) {
+                return new JArray(
+                    new JObject(
+                        new JProperty("Id", "i=2253"),
+                        new JProperty("TypeDefinitionId", "i=2915"),
+                        new JProperty("PendingAlarms", new JObject(
+                            new JProperty("IsEnabled", "true"),
+                            new JProperty("UpdateInterval", 10),
+                            new JProperty("SnapshotInterval", 20),
+                            new JProperty("CompressedPayload", compressedPayload)
+                        ))));
+            }
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
@@ -7,6 +7,7 @@
 namespace IIoTPlatform_E2E_Tests.TestExtensions {
     using Config;
     using Extensions;
+    using Microsoft.Azure.Management.Fluent;
     using Microsoft.Extensions.Configuration;
     using System;
     using Xunit.Abstractions;
@@ -96,6 +97,36 @@ namespace IIoTPlatform_E2E_Tests.TestExtensions {
         /// Helper to work with Azure.Devices.RegistryManager
         /// </summary>
         public RegistryHelper RegistryHelper { get; }
+
+        /// <summary>
+        /// Azure Context for managament api
+        /// </summary>
+        public IAzure? AzureContext { get; set; }
+
+        /// <summary>
+        /// Urls for the dynamic ACI containers
+        /// </summary>
+        public string[] PlcAciDynamicUrls { get; set; }
+
+        /// <summary>
+        /// Azure Storage Name
+        /// </summary>
+        public string AzureStorageName { get; set; }
+
+        /// <summary>
+        /// Azure Storage Key
+        /// </summary>
+        public string AzureStorageKey { get; set; }
+
+        /// <summary>
+        /// Image that are used for PLC ACI
+        /// </summary>
+        public string PLCImage { get; set; }
+
+        /// <summary>
+        /// Testing suffix for this environment
+        /// </summary>
+        public string TestingSuffix { get; set; }
 
         /// <inheritdoc />
         public void Dispose() {
@@ -194,6 +225,20 @@ namespace IIoTPlatform_E2E_Tests.TestExtensions {
 
         string IOpcPlcConfig.Urls => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.PLC_SIMULATION_URLS,
             () => throw new Exception("Semicolon separated list of URLs of OPC-PLCs is not provided."));
+
+        string IOpcPlcConfig.TenantId => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.SP_TENANT_ID,
+            () => throw new Exception("Tenant Id is not provided."));
+
+        string IOpcPlcConfig.ServicePrincipalId => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.SP_ID,
+            () => throw new Exception("Service Principal Id is not provided."));
+
+        string IOpcPlcConfig.ResourceGroupName => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.RESOURCE_GROUP_NAME,
+            () => throw new Exception("Resource Group Name is not provided."));
+
+        string IOpcPlcConfig.Region => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.REGION,
+            () => throw new Exception("Region is not provided."));
+
+        string IOpcPlcConfig.SubscriptionId => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.SUBSCRIPTION_ID, () => string.Empty);
 
         string ITestEventProcessorConfig.TestEventProcessorBaseUrl => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.TESTEVENTPROCESSOR_BASEURL,
             () => throw new Exception("Test Event Processor BaseUrl is not provided."));

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -650,6 +650,13 @@ namespace IIoTPlatform_E2E_Tests {
             }
         }
 
+        /// <summary>
+        /// Serialize a published nodes json file.
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="port">Port of OPC UA server</param>
+        /// <param name="writerId">DataSetWriterId to set</param>
+        /// <param name="opcEvents">OPC UA events</param>
         public static string PublishedNodesJson(this IIoTStandaloneTestContext context, uint port, string writerId, JArray opcEvents) {
             return JsonConvert.SerializeObject(
                 new JArray(
@@ -661,6 +668,14 @@ namespace IIoTPlatform_E2E_Tests {
                 ), Formatting.Indented);
         }
 
+        /// <summary>
+        /// Create an ACI
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="commandLine">Command line for container</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <param name="fileToUpload">File to upload to the container</param>
+        /// <param name="numInstances">Number of instances</param>
         public static async Task CreateSimulationContainerAsync(IIoTPlatformTestContext context, List<string> commandLine, CancellationToken cancellationToken, string fileToUpload = null, int numInstances = 1) {
             var azure = await GetAzureContextAsync(context, cancellationToken);
 
@@ -682,6 +697,12 @@ namespace IIoTPlatform_E2E_Tests {
                             context.AzureStorageKey)));
         }
 
+        /// <summary>
+        /// Upload a file to a storage account
+        /// </summary>
+        /// <param name="storageAccountName">Name of storage account</param>
+        /// <param name="storageAccountKey">Key for storage account</param>
+        /// <param name="fileName">File name</param>
         private async static Task UploadFileToStorageAccountAsync(string storageAccountName, string storageAccountKey, string fileName) {
             var cloudStorageAccount = new CloudStorageAccount(new StorageCredentials(storageAccountName, storageAccountKey), true);
             var cloudFileClient = cloudStorageAccount.CreateCloudFileClient();
@@ -703,6 +724,18 @@ namespace IIoTPlatform_E2E_Tests {
             await cf.UploadFromFileAsync(fileName);
         }
 
+        /// <summary>
+        /// Create a container group
+        /// </summary>
+        /// <param name="azure">Azure context</param>
+        /// <param name="resourceGroupName">Resource group name</param>
+        /// <param name="containerGroupName">Container group name</param>
+        /// <param name="containerImage">Container image</param>
+        /// <param name="executable">Starting command line</param>
+        /// <param name="commandLine">Additional command line options</param>
+        /// <param name="fileShareName">File share name</param>
+        /// <param name="storageAccountName">Storage account name</param>
+        /// <param name="storageAccountKey">Storage account key</param>
         private static async Task<string> CreateContainerGroupAsync(IAzure azure,
                                       string resourceGroupName,
                                       string containerGroupName,
@@ -740,10 +773,19 @@ namespace IIoTPlatform_E2E_Tests {
             return containerGroup.Fqdn;
         }
 
+
+        /// <summary>
+        /// Delete an ACI
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
         public static void DeleteSimulationContainer(IIoTPlatformTestContext context) {
             DeleteSimulationContainerAsync(context).GetAwaiter().GetResult();
         }
 
+        /// <summary>
+        /// Delete an ACI
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
         public static async Task DeleteSimulationContainerAsync(IIoTPlatformTestContext context) {
             await Task.WhenAll(
             context.PlcAciDynamicUrls
@@ -752,6 +794,11 @@ namespace IIoTPlatform_E2E_Tests {
             );
         }
 
+        /// <summary>
+        /// Get an azure context
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         private async static Task<IAzure> GetAzureContextAsync(IIoTPlatformTestContext context, CancellationToken cancellationToken) {
             if (context.AzureContext != null) {
                 return context.AzureContext;
@@ -813,6 +860,10 @@ namespace IIoTPlatform_E2E_Tests {
             return kSerializer.Deserialize<T>(reader);
         }
 
+        /// <summary>
+        /// Get an Event Hub consumer
+        /// </summary>
+        /// <param name="config">Configuration for IoT Hub</param>
         public static EventHubConsumerClient GetEventHubConsumerClient(this IIoTHubConfig config) {
             return new EventHubConsumerClient(
                 TestConstants.TestConsumerGroupName,
@@ -1028,6 +1079,11 @@ namespace IIoTPlatform_E2E_Tests {
             return source.ConsumeDuring(context, m => m.PublisherId, duration);
         }
 
+        /// <summary>
+        /// Truncate a date time
+        /// </summary>
+        /// <param name="dateTime">Date time top truncate</param>
+        /// <param name="timeSpan">Time span</param>
         public static DateTime Truncate(this DateTime dateTime, TimeSpan timeSpan) {
             if (timeSpan == TimeSpan.Zero) {
                 return dateTime;

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -18,12 +18,28 @@ namespace IIoTPlatform_E2E_Tests {
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using Azure.Messaging.EventHubs.Consumer;
+    using IIoTPlatform_E2E_Tests.Config;
     using Newtonsoft.Json.Converters;
     using TestExtensions;
     using TestModels;
     using Xunit;
     using Xunit.Abstractions;
     using System.Text.RegularExpressions;
+    using Newtonsoft.Json.Linq;
+    using Microsoft.Azure.Management.ResourceManager.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+    using Microsoft.Azure.Management.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.WindowsAzure.Storage.Auth;
+    using Azure.Identity;
+    using Azure.Core;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Rest;
+    using System.Diagnostics;
+    using System.Runtime.CompilerServices;
+    using System.IO.Compression;
 
     internal static partial class TestHelper {
 
@@ -67,7 +83,7 @@ namespace IIoTPlatform_E2E_Tests {
             Assert.True(!string.IsNullOrWhiteSpace(clientSecret), "clientSecret is null");
             Assert.True(!string.IsNullOrWhiteSpace(applicationName), "applicationName is null");
 
-            var client = new RestClient($"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token") {
+            var client = new RestSharp.RestClient($"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token") {
                 Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                 Authenticator = new HttpBasicAuthenticator(clientId, clientSecret)
             };
@@ -197,23 +213,37 @@ namespace IIoTPlatform_E2E_Tests {
                 }
             }
 
-            var restClient = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+            var restClient = new RestSharp.RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
             var response = restClient.ExecuteAsync(request, ct).GetAwaiter().GetResult();
             return response;
         }
 
         /// <summary>
-        /// transfer the content of published_nodes.json file into the OPC Publisher edge module
+        /// Transfer the content of published_nodes.json file into the OPC Publisher edge module
         /// </summary>
         /// <param name="entries">Entries for published_nodes.json</param>
         /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
         /// <param name="ct">Cancellation token</param>
-        public static async Task SwitchToStandaloneModeAndPublishNodesAsync(
+        public static Task SwitchToStandaloneModeAndPublishNodesAsync(
             IEnumerable<PublishedNodesEntryModel> entries,
             IIoTPlatformTestContext context,
             CancellationToken ct = default
         ) {
             var json = JsonConvert.SerializeObject(entries, Formatting.Indented);
+            return SwitchToStandaloneModeAndPublishNodesAsync(json, context, ct);
+        }
+
+        /// <summary>
+        /// Transfer the content of published_nodes.json file into the OPC Publisher edge module
+        /// </summary>
+        /// <param name="json">String for published_nodes.json</param>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="ct">Cancellation token</param>
+        public static async Task SwitchToStandaloneModeAndPublishNodesAsync(
+            string json,
+            IIoTPlatformTestContext context,
+            CancellationToken ct = default
+        ) {
             context.OutputHelper?.WriteLine("Write published_nodes.json to IoT Edge");
             context.OutputHelper?.WriteLine(json);
             CreateFolderOnEdgeVM(TestConstants.PublishedNodesFolder, context);
@@ -231,10 +261,10 @@ namespace IIoTPlatform_E2E_Tests {
                         // Move file to the target folder with sudo permissions 
                         command = $"ssh -oStrictHostKeyChecking=no {edge} 'sudo mv {TestConstants.PublishedNodesFilename} {TestConstants.PublishedNodesFullName}'";
                         sshCient.RunCommand(command);
-                    }                 
-                }             
+                    }
+                }
             }
-            
+
             await SwitchToStandaloneModeAsync(context, ct);
         }
 
@@ -407,7 +437,7 @@ namespace IIoTPlatform_E2E_Tests {
         ) {
             var runtimeUrl = context.TestEventProcessorConfig.TestEventProcessorBaseUrl.TrimEnd('/') + "/Runtime";
 
-            var client = new RestClient(runtimeUrl) {
+            var client = new RestSharp.RestClient(runtimeUrl) {
                 Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                 Authenticator = new HttpBasicAuthenticator(context.TestEventProcessorConfig.TestEventProcessorUsername,
                     context.TestEventProcessorConfig.TestEventProcessorPassword)
@@ -447,7 +477,7 @@ namespace IIoTPlatform_E2E_Tests {
             // TODO Merge with Start-Method to avoid code duplication
             var runtimeUrl = context.TestEventProcessorConfig.TestEventProcessorBaseUrl.TrimEnd('/') + "/Runtime";
 
-            var client = new RestClient(runtimeUrl) {
+            var client = new RestSharp.RestClient(runtimeUrl) {
                 Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                 Authenticator = new HttpBasicAuthenticator(context.TestEventProcessorConfig.TestEventProcessorUsername,
                     context.TestEventProcessorConfig.TestEventProcessorPassword)
@@ -463,6 +493,36 @@ namespace IIoTPlatform_E2E_Tests {
             var response = await client.ExecuteAsync(request, ct);
 
             dynamic json = JsonConvert.DeserializeObject(response.Content);
+            Assert.NotNull(json);
+            Assert.NotEmpty(json);
+
+            return json;
+        }
+
+        /// <summary>
+        /// Get Json from testeventprocessor after last test run
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns>Json object</returns>
+        public static async Task<dynamic> GetJsonAsync(
+            IIoTPlatformTestContext context,
+            CancellationToken ct = default
+        ) {
+            var runtimeUrl = context.TestEventProcessorConfig.TestEventProcessorBaseUrl.TrimEnd('/') + "/Runtime/Messages";
+
+            var client = new RestSharp.RestClient(runtimeUrl) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                Authenticator = new HttpBasicAuthenticator(context.TestEventProcessorConfig.TestEventProcessorUsername,
+                    context.TestEventProcessorConfig.TestEventProcessorPassword)
+            };
+
+            var request = new RestRequest(Method.GET);
+
+            var response = await client.ExecuteAsync(request, ct);
+
+            dynamic json = JsonConvert.DeserializeObject(response.Content);
+
             Assert.NotNull(json);
             Assert.NotEmpty(json);
 
@@ -489,7 +549,7 @@ namespace IIoTPlatform_E2E_Tests {
             };
 
             try {
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
+                var client = new RestSharp.RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
                     Timeout = TestConstants.DefaultTimeoutInMilliseconds
                 };
 
@@ -555,7 +615,7 @@ namespace IIoTPlatform_E2E_Tests {
         /// <param name="ct">Cancellation token</param>
         private static async Task<dynamic> GetEndpointInternalAsync(IIoTPlatformTestContext context, CancellationToken ct) {
             var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-            var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+            var client = new RestSharp.RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
 
             var request = new RestRequest(Method.GET);
             request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
@@ -589,5 +649,397 @@ namespace IIoTPlatform_E2E_Tests {
                 exception = exception.InnerException;
             }
         }
+
+        public static string PublishedNodesJson(this IIoTStandaloneTestContext context, uint port, string writerId, JArray opcEvents) {
+            return JsonConvert.SerializeObject(
+                new JArray(
+                    context.PlcAciDynamicUrls.Select(host => new JObject(
+                        new JProperty("EndpointUrl", $"opc.tcp://{host}:{port}"),
+                        new JProperty("UseSecurity", false),
+                        new JProperty("DataSetWriterId", writerId),
+                        new JProperty("OpcEvents", opcEvents)))
+                ), Formatting.Indented);
+        }
+
+        public static async Task CreateSimulationContainerAsync(IIoTPlatformTestContext context, List<string> commandLine, CancellationToken cancellationToken, string fileToUpload = null, int numInstances = 1) {
+            var azure = await GetAzureContextAsync(context, cancellationToken);
+
+            if (fileToUpload != null) {
+                await UploadFileToStorageAccountAsync(context.AzureStorageName, context.AzureStorageKey, fileToUpload);
+            }
+
+            context.PlcAciDynamicUrls = await Task.WhenAll(
+                Enumerable.Range(0, numInstances)
+                    .Select(i =>
+                        CreateContainerGroupAsync(azure,
+                            context.OpcPlcConfig.ResourceGroupName,
+                            $"e2etesting-simulation-aci-{i}-{context.TestingSuffix}-dynamic",
+                            context.PLCImage,
+                            commandLine[0],
+                            commandLine.GetRange(1, commandLine.Count - 1).ToArray(),
+                            TestConstants.OpcSimulation.FileShareName,
+                            context.AzureStorageName,
+                            context.AzureStorageKey)));
+        }
+
+        private async static Task UploadFileToStorageAccountAsync(string storageAccountName, string storageAccountKey, string fileName) {
+            var cloudStorageAccount = new CloudStorageAccount(new StorageCredentials(storageAccountName, storageAccountKey), true);
+            var cloudFileClient = cloudStorageAccount.CreateCloudFileClient();
+            var share = cloudFileClient.GetShareReference(TestConstants.OpcSimulation.FileShareName);
+            var directory = share.GetRootDirectoryReference();
+
+            Assert.False(fileName.Contains('\\'), "\\ can't be used for file path");
+
+            // if fileName contains '/' we will extract the filename
+            string onlyFileName;
+            if (fileName.Contains('/')) {
+                onlyFileName = fileName.Substring(fileName.LastIndexOf('/') + 1);
+            }
+            else {
+                onlyFileName = fileName;
+            }
+
+            var cf = directory.GetFileReference(onlyFileName);
+            await cf.UploadFromFileAsync(fileName);
+        }
+
+        private static async Task<string> CreateContainerGroupAsync(IAzure azure,
+                                      string resourceGroupName,
+                                      string containerGroupName,
+                                      string containerImage,
+                                      string executable,
+                                      string[] commandLine,
+                                      string fileShareName,
+                                      string storageAccountName,
+                                      string storageAccountKey) {
+
+            IResourceGroup resGroup = azure.ResourceGroups.GetByName(resourceGroupName);
+            Region azureRegion = resGroup.Region;
+
+            var containerGroup = await azure.ContainerGroups.Define(containerGroupName)
+                .WithRegion(azureRegion)
+                .WithExistingResourceGroup(resourceGroupName)
+                .WithLinux()
+                .WithPublicImageRegistryOnly()
+                .DefineVolume("share")
+                    .WithExistingReadWriteAzureFileShare(fileShareName)
+                    .WithStorageAccountName(storageAccountName)
+                    .WithStorageAccountKey(storageAccountKey)
+                    .Attach()
+                .DefineContainerInstance(containerGroupName)
+                    .WithImage(containerImage)
+                    .WithExternalTcpPort(50000)
+                    .WithCpuCoreCount(0.5)
+                    .WithMemorySizeInGB(0.5)
+                    .WithVolumeMountSetting("share", "/app/files")
+                    .WithStartingCommandLine(executable, commandLine)
+                    .Attach()
+                .WithDnsPrefix(containerGroupName)
+                .CreateAsync();
+
+            return containerGroup.Fqdn;
+        }
+
+        public static void DeleteSimulationContainer(IIoTPlatformTestContext context) {
+            DeleteSimulationContainerAsync(context).GetAwaiter().GetResult();
+        }
+
+        public static async Task DeleteSimulationContainerAsync(IIoTPlatformTestContext context) {
+            await Task.WhenAll(
+            context.PlcAciDynamicUrls
+                .Select(url => url.Split(".")[0])
+                .Select(n => context.AzureContext.ContainerGroups.DeleteByResourceGroupAsync(context.OpcPlcConfig.ResourceGroupName, n))
+            );
+        }
+
+        private async static Task<IAzure> GetAzureContextAsync(IIoTPlatformTestContext context, CancellationToken cancellationToken) {
+            if (context.AzureContext != null) {
+                return context.AzureContext;
+            }
+
+            var defaultAzureCredential = new DefaultAzureCredential();
+            var accessToken = await defaultAzureCredential.GetTokenAsync(new TokenRequestContext(new[] { "https://management.azure.com//.default" }), cancellationToken);
+            var tokenCredentials = new TokenCredentials(accessToken.Token);
+
+            IAzure azure;
+
+            if (string.IsNullOrEmpty(context.OpcPlcConfig.SubscriptionId)) {
+                azure = Azure
+                    .Configure()
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                    .Authenticate(new AzureCredentials(tokenCredentials,
+                                                        tokenCredentials, context.OpcPlcConfig.TenantId,
+                                                        AzureEnvironment.AzureGlobalCloud))
+                    .WithDefaultSubscription();
+            }
+            else {
+                azure = Azure
+                    .Configure()
+                    .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                    .Authenticate(new AzureCredentials(tokenCredentials,
+                                                        tokenCredentials, context.OpcPlcConfig.TenantId,
+                                                        AzureEnvironment.AzureGlobalCloud))
+                    .WithSubscription(context.OpcPlcConfig.SubscriptionId);
+            }
+
+            context.AzureContext = azure;
+
+            var testingSuffix = azure.ResourceGroups.GetByName(context.OpcPlcConfig.ResourceGroupName).Tags[TestConstants.OpcSimulation.TestingResourcesSuffixName];
+            context.TestingSuffix = testingSuffix;
+            context.AzureStorageName = TestConstants.OpcSimulation.AzureStorageNameWithoutSuffix + testingSuffix;
+
+            var storageAccount = azure.StorageAccounts.GetByResourceGroup(context.OpcPlcConfig.ResourceGroupName, context.AzureStorageName);
+            context.AzureStorageKey = storageAccount.GetKeys()[0].Value;
+
+            var firstAciIpAddress = context.OpcPlcConfig.Urls.Split(";")[0];
+            var containerGroups = azure.ContainerGroups.ListByResourceGroup(context.OpcPlcConfig.ResourceGroupName).ToList();
+            var containerGroup = azure.ContainerGroups.ListByResourceGroup(context.OpcPlcConfig.ResourceGroupName)
+                .First(g => g.IPAddress == firstAciIpAddress);
+            context.PLCImage = containerGroup.Containers.First().Value.Image;
+
+            return azure;
+        }
+
+        /// <summary>
+        /// Deserializes the JSON structure contained by the specified <see cref="PartitionEvent"/>
+        /// into an instance of the specified type.
+        /// </summary>
+        /// <param name="partitionEvent">The <see cref="PartitionEvent"/> containing the object.</param>
+        /// <typeparam name="T">The type of the object to deserialize.</typeparam>
+        /// <returns>The instance of <typeparamref name="T"/> being deserialized.</returns>
+        public static T DeserializeJson<T>(this PartitionEvent partitionEvent) {
+            using var sr = new StreamReader(partitionEvent.Data.BodyAsStream);
+            using var reader = new JsonTextReader(sr);
+            return kSerializer.Deserialize<T>(reader);
+        }
+
+        public static EventHubConsumerClient GetEventHubConsumerClient(this IIoTHubConfig config) {
+            return new EventHubConsumerClient(
+                TestConstants.TestConsumerGroupName,
+                config.IoTHubEventHubConnectionString);
+        }
+
+        /// <summary>
+        ///   Reads events from all partitions of the IoT Hub Event Hubs endpoint as an asynchronous enumerable, allowing events to be iterated as they
+        ///   become available on the partition, waiting as necessary should there be no events available.
+        ///
+        ///   Reading begins at the end of each partition seeing only new events as they are published.
+        ///
+        ///   Breaks up the batched messages contained in the event, and returns only messages for the provided
+        ///   DataSetWriterId.
+        ///
+        ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
+        ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.
+        /// </summary>
+        /// <param name="consumer">The Event Hubs consumer.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> to be used for iterating over messages.</returns>
+        public static IAsyncEnumerable<EventData<T>> ReadMessagesFromWriterIdAsync<T>(this EventHubConsumerClient consumer, string dataSetWriterId, [EnumeratorCancellation] CancellationToken cancellationToken) where T : BaseEventTypePayload
+            => ReadMessagesFromWriterIdAsync(consumer, dataSetWriterId, cancellationToken)
+                .Select(x =>
+                    new EventData<T> {
+                        EnqueuedTime = x.enqueuedTime,
+                        PublisherId = x.publisherId,
+                        Messages = x.messages.ToObject<PubSubMessages<T>>()
+                    });
+
+        /// <summary>
+        ///   Reads events from all partitions of the IoT Hub Event Hubs endpoint as an asynchronous enumerable, allowing events to be iterated as they
+        ///   become available on the partition, waiting as necessary should there be no events available.
+        ///
+        ///   Reading begins at the end of each partition seeing only new events as they are published.
+        ///
+        ///   Breaks up the batched messages contained in the event, and returns only messages for the provided
+        ///   DataSetWriterId.
+        ///
+        ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
+        ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.
+        /// </summary>
+        /// <param name="consumer">The Event Hubs consumer.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> to be used for iterating over messages.</returns>
+        public static IAsyncEnumerable<PendingAlarmEventData<T>> ReadPendingAlarmMessagesFromWriterIdAsync<T>(this EventHubConsumerClient consumer, string dataSetWriterId, [EnumeratorCancellation] CancellationToken cancellationToken) where T : BaseEventTypePayload {
+            return ReadMessagesFromWriterIdAsync(consumer, dataSetWriterId, cancellationToken)
+                .Select(x =>
+                    new PendingAlarmEventData<T> {
+                        IsPayloadCompressed = x.isPayloadCompressed,
+                        Messages = x.messages.ToObject<PendingAlarmMessages<T>>()
+                    }
+                );
+        }
+
+        /// <summary>
+        ///   Reads events from all partitions of the IoT Hub Event Hubs endpoint as an asynchronous enumerable, allowing events to be iterated as they
+        ///   become available on the partition, waiting as necessary should there be no events available.
+        ///
+        ///   Reading begins at the end of each partition seeing only new events as they are published.
+        ///
+        ///   Breaks up the batched messages contained in the event, and returns only messages for the provided
+        ///   DataSetWriterId.
+        ///
+        ///   This enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available on the partition, requiring
+        ///   cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.
+        /// </summary>
+        /// <param name="consumer">The Event Hubs consumer.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        /// <returns>An <see cref="IAsyncEnumerable{JObject}"/> to be used for iterating over messages.</returns>
+        public static async IAsyncEnumerable<(DateTime enqueuedTime, string publisherId, JObject messages, bool isPayloadCompressed)> ReadMessagesFromWriterIdAsync(this EventHubConsumerClient consumer, string dataSetWriterId, [EnumeratorCancellation] CancellationToken cancellationToken) {
+            var events = consumer.ReadEventsAsync(false, cancellationToken: cancellationToken);
+            await foreach (var partitionEvent in events.WithCancellation(cancellationToken)) {
+                var enqueuedTime = (DateTime)partitionEvent.Data.SystemProperties[MessageSystemPropertyNames.EnqueuedTime];
+                JArray batchedMessages = null;
+                bool isPayloadCompressed = (string)partitionEvent.Data.Properties["$$ContentEncoding"] == "gzip";
+                if (isPayloadCompressed) {
+                    var compressedPayload = Convert.FromBase64String(partitionEvent.Data.EventBody.ToString());
+                    using (var input = new MemoryStream(compressedPayload)) {
+                        using (var gs = new GZipStream(input, CompressionMode.Decompress)) {
+                            using (var textReader = new StreamReader(gs)) {
+                                batchedMessages = JsonConvert.DeserializeObject<JArray>(await textReader.ReadToEndAsync());
+                            }
+                        }
+                    }
+                }
+                else {
+                    batchedMessages = partitionEvent.DeserializeJson<JArray>();
+                }
+
+                // Expect all messages to be the same
+                var messageIds = new HashSet<string>();
+                foreach (dynamic message in batchedMessages) {
+                    Assert.NotNull(message.MessageId.Value);
+                    Assert.True(messageIds.Add(message.MessageId.Value));
+                    var publisherId = (string)message.PublisherId.Value;
+                    Assert.NotNull(publisherId);
+                    Assert.Equal("ua-data", message.MessageType.Value);
+                    var innerMessages = (JArray)message.Messages;
+                    Assert.True(innerMessages.Any(), "Json doesn't contain any messages");
+
+                    foreach (dynamic innerMessage in innerMessages) {
+                        var messageWriterId = (string)innerMessage.DataSetWriterId.Value;
+                        if (messageWriterId != dataSetWriterId) {
+                            continue;
+                        }
+                        Assert.Equal(1, innerMessage.MetaDataVersion.MajorVersion.Value);
+                        Assert.Equal(0, innerMessage.MetaDataVersion.MinorVersion.Value);
+
+                        yield return (enqueuedTime, publisherId, (JObject)innerMessage.Payload, isPayloadCompressed);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns elements from an async-enumerable sequence for a given time duration.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <param name="source">A sequence to return elements from.</param>
+        /// <param name="duration">A time duration during which to return data.</param>
+        /// <returns>An async-enumerable sequence that contains the elements from the input sequence for the given time period, starting when the first element is retrieved.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        private static IAsyncEnumerable<TSource> TakeDuring<TSource>(this IAsyncEnumerable<TSource> source, TimeSpan duration) {
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+
+            // ReSharper disable once ConvertClosureToMethodGroup
+            var sw = new Lazy<Stopwatch>(() => Stopwatch.StartNew());
+            return source.TakeWhile(_ => sw.Value.Elapsed < duration);
+        }
+
+        /// <summary>
+        /// Bypasses elements in an async-enumerable sequence as long as a number of distinct items has not been seen, and then returns the remaining elements.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <typeparam name="TValue">The type of the elements to be compared for distinct values.</typeparam>
+        /// <param name="source">An async-enumerable sequence to return elements from.</param>
+        /// <param name="valueFunc">A function to generate the value to test for uniqueness, for each element.</param>
+        /// <param name="distinctCountToReach">Number of distinct values for valueFunc output to observe until elements should be passed.</param>
+        /// <param name="before">An optional action to execute when the first element is observed.</param>
+        /// <param name="after">An optional action to execute when the last bypassed element is observed.</param>
+        /// <returns>An async-enumerable sequence that contains the elements from the input sequence starting at the first element in the linear series at which the number of distinct values has been observed.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> or <paramref name="valueFunc"/> is null.</exception>
+        private static IAsyncEnumerable<TSource> SkipUntilDistinctCountReached<TSource, TValue>(
+            this IAsyncEnumerable<TSource> source,
+            Func<TSource, TValue> valueFunc,
+            int distinctCountToReach,
+            Action before = default,
+            Action after = default
+        ) {
+            _ = source ?? throw new ArgumentNullException(nameof(source));
+            _ = valueFunc ?? throw new ArgumentNullException(nameof(valueFunc));
+
+            var seenValues = new HashSet<TValue>();
+            return source.SkipWhile(m => {
+                if (seenValues.Count == 0) {
+                    before?.Invoke();
+                }
+
+                seenValues.Add(valueFunc(m));
+                if (seenValues.Count < distinctCountToReach) {
+                    return true;
+                }
+
+                after?.Invoke();
+                return false;
+            });
+        }
+
+        /// <summary>
+        /// Returns elements from an async-enumerable sequence for a given time duration,
+        /// starting when one message has been published from every publishing source (PLC simulator).
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>
+        /// <param name="source">A sequence to return elements from.</param>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="publisherIdFunc">A function to extract the Source ID from a message payload.</param>
+        /// <param name="duration">A time duration during which to return data.</param>
+        /// <returns>An async-enumerable sequence that contains the elements from the input sequence for the given time period, starting when the first element is retrieved.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        private static IAsyncEnumerable<TSource> ConsumeDuring<TSource>(
+            this IAsyncEnumerable<TSource> source,
+            IIoTPlatformTestContext context,
+            Func<TSource, string> publisherIdFunc,
+            TimeSpan duration
+        ) {
+            // When the first message has been received for each simulator, the system is up and we
+            // "let the flag fall" to start computing event rates.
+            return source.SkipUntilDistinctCountReached(
+                    publisherIdFunc,
+                    context.PlcAciDynamicUrls.Length,
+                    () => context.OutputHelper?.WriteLine("Waiting for first message for each PLC"),
+                    () => context.OutputHelper?.WriteLine($"Consuming messages for {duration}")
+                )
+                .TakeDuring(duration);
+        }
+
+        /// <summary>
+        /// Returns elements from an async-enumerable sequence for a given time duration,
+        /// starting when one message has been published from every publishing source (PLC simulator).
+        /// </summary>
+        /// <typeparam name="TPayload">The type of the payloads in the Publisher messages.</typeparam>
+        /// <param name="source">A sequence to return elements from.</param>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="duration">A time duration during which to return data.</param>
+        /// <returns>An async-enumerable sequence that contains the elements from the input sequence for the given time period, starting when the first element is retrieved.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="source"/> is null.</exception>
+        public static IAsyncEnumerable<EventData<TPayload>> ConsumeDuring<TPayload>(
+            this IAsyncEnumerable<EventData<TPayload>> source,
+            IIoTPlatformTestContext context,
+            TimeSpan duration
+        ) where TPayload : BaseEventTypePayload {
+            return source.ConsumeDuring(context, m => m.PublisherId, duration);
+        }
+
+        public static DateTime Truncate(this DateTime dateTime, TimeSpan timeSpan) {
+            if (timeSpan == TimeSpan.Zero) {
+                return dateTime;
+            }
+
+            if (dateTime == DateTime.MinValue || dateTime == DateTime.MaxValue) {
+                return dateTime;
+            }
+
+            return dateTime.AddTicks(-(dateTime.Ticks % timeSpan.Ticks));
+        }
+
+        private static readonly JsonSerializer kSerializer = new JsonSerializer();
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PubSubMessages.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PubSubMessages.cs
@@ -1,0 +1,171 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.TestModels {
+    using System;
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public class PendingAlarmMessages<T> where T : BaseEventTypePayload {
+        [JsonProperty("i=2253")]
+        public List<T> PendingMessages { get; set; }
+    }
+
+    public class PendingAlarmEventData<T> where T : BaseEventTypePayload {
+        public bool IsPayloadCompressed { get; set; }
+
+        public PendingAlarmMessages<T> Messages { get; set; }
+    }
+
+    /// <summary>Event data with IoT Hub message enqueued time metadata.</summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public class EventData<T> where T : BaseEventTypePayload {
+        /// <summary>IoT Hub message enqueued time.</summary>
+        public DateTime EnqueuedTime { get; set; }
+
+        /// <summary>Message origin host.</summary>
+        public string PublisherId { get; set; }
+
+        /// <summary>Messages.</summary>
+        public PubSubMessages<T> Messages { get; set; }
+    }
+
+    /// <summary>Message sent by Publisher to IoT Hub.</summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public class PubSubMessages<T> : Dictionary<string, PubSubMessage<T>> where T : BaseEventTypePayload {
+    }
+
+    /// <summary>Container for payload.</summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public class PubSubMessage<T> {
+        /// <summary>Message payload.</summary>
+        public T Value { get; set; }
+
+        /// <summary>Source timestamp.</summary>
+        public DateTime SourceTimestamp { get; set; }
+    }
+
+    /// <summary>Base class for payload types.</summary>
+    public class BaseEventTypePayload {
+        /// <summary>Gets or sets event id.</summary>
+        /// <example>"V1_DoorOpen(294)" represented as JSON base-64 encoded string "VjFfRG9vck9wZW4oMjk0KQ==".</example>
+        public byte[] EventId { get; set; }
+
+        /// <summary>Gets or sets message.</summary>
+        /// <example>"The system cycle '29813' has started."</example>
+        public string Message { get; set; }
+
+        /// <summary>Gets or sets the severity.</summary>
+        /// <example>900</example>
+        public int Severity { get; set; }
+
+        /// <summary>Gets or sets the source name.</summary>
+        /// <example>"VendingMachine1"</example>
+        public string SourceName { get; set; }
+
+        /// <summary>Gets or sets the source node.</summary>
+        /// <example>"http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#s=VendingMachine1"</example>
+        public string SourceNode { get; set; }
+
+        /// <summary>Gets or sets the event type.</summary>
+        /// <example>"i=10751"</example>
+        public string EventType { get; set; }
+
+        /// <summary>Gets or sets the receive time.</summary>
+        public DateTime? ReceiveTime { get; set; }
+
+
+        /// <summary>Gets or sets the local time.</summary>
+        public DateTime? LocalTime { get; set; }
+    }
+
+
+    /// <summary>Base class for system events types.</summary>
+    public class SystemEventTypePayload : BaseEventTypePayload {
+        /// <summary>Gets or sets the time.</summary>
+        public DateTime? Time { get; set; }
+    }
+
+    /// <summary>Payload for conditions and alarms.</summary>
+    public class ConditionTypePayload : BaseEventTypePayload {
+        /// <summary>Gets or sets Condition Id.</summary>
+        /// <example>"http://microsoft.com/Opc/OpcPlc/DetermAlarmsInstance#i=1"</example>
+        public string ConditionId { get; set; }
+
+        /// <summary>Gets or sets comment source timestamp.</summary>
+        [JsonProperty("Comment/SourceTimestamp")]
+        public DateTime? CommentSourceTimestamp { get; set; }
+
+        /// <summary>Gets or sets the condition name.</summary>
+        /// <example>"VendingMachine1_DoorOpen"</example>
+        public string ConditionName { get; set; }
+
+        /// <summary>Gets or sets the enabled state.</summary>
+        /// <example>"Enabled"</example>
+        public string EnabledState { get; set; }
+
+        /// <summary>Gets or sets the enabled state effective display name.</summary>
+        /// <example>"Active | Unacknowledged"</example>
+        [JsonProperty("EnabledState/EffectiveDisplayName")]
+        public string EnabledStateEffectiveDisplayName { get; set; }
+
+        /// <summary>Gets or sets the enabled state effective transition time.</summary>
+        [JsonProperty("EnabledState/EffectiveTransitionTime")]
+        public DateTime? EnabledStateEffectiveTransitionTime { get; set; }
+
+        /// <summary>Gets or sets the enabled state Id.</summary>
+        /// <example>true</example>
+        [JsonProperty("EnabledState/Id")]
+        public bool EnabledStateId { get; set; }
+
+        /// <summary>Gets or sets the enabled state transition time.</summary>
+        [JsonProperty("EnabledState/TransitionTime")]
+        public DateTime? EnabledStateTransitionTime { get; set; }
+
+        /// <summary>Gets or sets the event last severity.</summary>
+        /// <example>500</example>
+        public int LastSeverity { get; set; }
+
+        /// <summary>Gets or sets the event last severity source timestamp.</summary>
+        [JsonProperty("LastSeverity/SourceTimestamp")]
+        public DateTime? LastSeveritySourceTimestamp { get; set; }
+
+        /// <summary>Gets or sets the quality.</summary>
+        public string Quality { get; set; }
+
+        /// <summary>Gets or sets the quality source timestamp.</summary>
+        [JsonProperty("Quality/SourceTimestamp")]
+        public DateTime? QualitySourceTimestamp { get; set; }
+
+        /// <summary>Gets or sets the retain flag.</summary>
+        public bool Retain { get; set; }
+
+        /// <summary>Gets or sets the time.</summary>
+        public DateTime? Time { get; set; }
+    }
+
+    /// <summary>Payload for simple events.</summary>
+    public class SystemCycleStatusEventTypePayload : SystemEventTypePayload {
+        /// <summary>Gets or sets the cycle id.</summary>
+        /// <example>"29813"</example>
+        [JsonProperty("http://microsoft.com/Opc/OpcPlc/SimpleEvents#CycleId")]
+        public string CycleId { get; set; }
+
+        /// <summary>Gets or sets the current step.</summary>
+        [JsonProperty("http://microsoft.com/Opc/OpcPlc/SimpleEvents#CurrentStep")]
+        public SimpleEventsStep CurrentStep { get; set; }
+    }
+
+    /// <summary>Simple event step.</summary>
+    public class SimpleEventsStep {
+        /// <summary>Gets or sets the step name.</summary>
+        /// <example>"Step 1"</example>
+        public string Name { get; set; }
+
+        /// <summary>Gets or sets the step duration in milliseconds.</summary>
+        /// <example>1000.0</example>
+        public double Duration { get; set; }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
@@ -51,6 +51,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
                 Cmd = new[] {
                 "PkiRootPath=" + TestConstants.PublishedNodesFolder + "/pki",
                 "--aa",
+                "--mm=PubSub",
                 "--pf=" + TestConstants.PublishedNodesFullName
             },
                 HostConfig = new {

--- a/e2e-tests/IIoTPlatform-E2E-Tests/opc-plc-files/sc001.json
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/opc-plc-files/sc001.json
@@ -1,0 +1,144 @@
+{
+    "folders": [
+      {
+        "name": "VendingMachines",
+        "sources": [
+          {
+            "objectType": "BaseObjectState",
+            "name": "VendingMachine1",
+            "alarms": [
+              {
+                "objectType": "TripAlarmType",
+                "name": "VendingMachine1_DoorOpen",
+                "id": "V1_DoorOpen"
+              },
+              {
+                "objectType": "LimitAlarmType",
+                "name": "VendingMachine1_TemperatureHigh",
+                "id": "V1_TemperatureHigh"
+              },
+              {
+                "objectType": "ConditionType",
+                "name": "VendingMachine1_AD_Lamp_Off",
+                "id": "V1_AD_Lamp_Off"
+              }
+            ]
+          },
+          {
+            "objectType": "BaseObjectState",
+            "name": "VendingMachine2",
+            "alarms": [
+              {
+                "objectType": "TripAlarmType",
+                "name": "VendingMachine2_DoorOpen",
+                "id": "V2_DoorOpen"
+              },
+              {
+                "objectType": "OffNormalAlarmType",
+                "name": "VendingMachine2_LightOff",
+                "id": "V2_LightOff"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "script": {
+      "waitUntilStartInSeconds": 10,
+      "isScriptInRepeatingLoop": true,
+      "runningForSeconds": 86400,
+      "steps": [
+        {
+          "event": {
+            "alarmId": "V1_DoorOpen",
+            "reason": "Door Open",
+            "severity": "High",
+            "eventId": "V1_DoorOpen-1",
+            "stateChanges": [
+              {
+                "stateType": "Enabled",
+                "state": true
+              },
+              {
+                "stateType": "Activated",
+                "state": true
+              }
+            ]
+          }
+        },
+        {
+          "sleepInSeconds": 5
+        },
+        {
+          "event": {
+            "alarmId": "V2_LightOff",
+            "reason": "Light Off in machine",
+            "severity": "Medium",
+            "eventId": "V2_LightOff-1",
+            "stateChanges": [
+              {
+                "stateType": "Enabled",
+                "state": true
+              },
+              {
+                "stateType": "Activated",
+                "state": true
+              }
+            ]
+          }
+        },
+        {
+          "event": {
+            "alarmId": "V1_AD_Lamp_Off",
+            "reason": "AD Lamp Off",
+            "severity": "Medium",
+            "eventId": "V1_AD_Lamp_Off-1",
+            "stateChanges": [
+              {
+                "stateType": "Enabled",
+                "state": true
+              }
+            ]
+          }
+        },
+        {
+          "sleepInSeconds": 5
+        },
+        {
+          "event": {
+            "alarmId": "V1_DoorOpen",
+            "reason": "Door Closed",
+            "severity": "Medium",
+            "eventId": "V1_DoorOpen-2",
+            "stateChanges": [
+              {
+                "stateType": "Activated",
+                "state": false
+              }
+            ]
+          }
+        },
+        {
+          "sleepInSeconds": 4
+        },
+        {
+          "event": {
+            "alarmId": "V1_TemperatureHigh",
+            "reason": "Temperature is HIGH (LAST EVENT IN LOOP)",
+            "severity": "High",
+            "eventId": "V1_TemperatureHigh-1",
+            "stateChanges": [
+              {
+                "stateType": "Activated",
+                "state": true
+              },
+              {
+                "stateType": "Enabled",
+                "state": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/readme.md
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/readme.md
@@ -58,8 +58,111 @@ Follow these steps:
 * Execute /tools/e2etesting/GetSecrets.ps1 -KeyVaultName &lt;YourKeyVaultName&gt;. You will be asked whether you want to overwrite the settings file or not.
   * if you choose 'yes' just wait for the script to finish and no further steps are needed
   * if you choose 'no' copy the script output to IIoTPlatform-E2E-Tests\Properties\launchSettings.json under environmentVariables
+* If you don't want to use the default subscription, add SUBSCRIPTION_ID: "<sub id" to launchSettings.json
 * Now you can use Visual Studio to execute your tests.
 * Don't forget to clean up by executing the pipeline with these variables set:
   * `Cleanup = false`
   * `UseExisting = true`
   * `ResourceGroupName = <your_resource_group_name>`
+
+### Monitoring Edge modules with Prometheus
+
+While running tests, it can be useful to monitor modules. A quick way to do this is to run a Prometheus Server locally on the Edge VM. Note that this configuration has no persistence and is only meant for experimentation.
+
+- Download the SSH private key in the depoyment Key Vault.
+- Open an SSH connection to the Edge VM, also tunneling the port used by the Prometheus Server. From  Bash:
+
+```bash
+chmod og-w edge_private_key
+
+ssh -L 9090:localhost:9090 -i edge_private_key sandboxuser@e2etesting-edgevm-XXXXX.westeurope.cloudapp.azure.com
+```
+
+- On the Edge VM, start Prometheus Node Exporter:
+
+```bash
+sudo docker run -d --net azure-iot-edge -p 9100:9100 --name exporter prom/node-exporter
+```
+
+- On the Edge VM, create a file `/tmp/prometheus.yml`:
+
+```yaml
+global:
+  scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+      monitor: 'edge'
+
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'prometheus'
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'edge-modules'
+
+    static_configs:
+      - targets: ['edgeHub:9600', 'edgeAgent:9600', 'publisher_standalone:9702', 'exporter:9100']
+```
+
+- On the Edge VM, start Prometheus Server:
+
+```bash
+sudo docker run -d --net azure-iot-edge -p 9090:9090 -v /tmp/prometheus.yml:/etc/prometheus/prometheus.yml   prom/prometheus
+```
+
+- On your local machine, connect to `http://localhost:9090/` (using the SSH tunnel) to browse metrics. Example queries:
+  - [IoT Hub messages per minute](http://localhost:9090/graph?g0.expr=sum%28rate%28iiot_edge_publisher_messages%5B1m%5D%29%29*60&g0.tab=0&g0.stacked=0&g0.range_input=1h
+    )
+  - [CPU usage](http://localhost:9090/graph?g0.expr=100%20-%20%28avg%20by%20%28instance%29%20%28irate%28node_cpu_seconds_total%7Bmode%3D%22idle%22%7D%5B1m%5D%29%29%20*%20100%29%20&g0.tab=0)
+
+### Create pipeline for forked Publisher
+
+For developing the Publisher on a forked repository, you may want to set up Azure Pipelines in your own tenant.
+
+* Create an Azure Container Registry (ACR) instance with public access.
+
+* Import the Edge module images from MCR into your ACR:
+
+```bash
+az acr import --name MYACR --force --source mcr.microsoft.com/azureiotedge-agent:1.1 --image events-and-alarms/azureiotedge-agent:1.1
+az acr import --name MYACR --force --source mcr.microsoft.com/azureiotedge-hub:1.1 --image events-and-alarms/azureiotedge-hub:1.1
+```
+
+* Build your Publisher:
+
+```bash
+pwsh tools/scripts/acr-build.ps1 -Path "modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src" -Registry "MYACR"
+```
+
+* Create an ARM service connection with Subscription-level access.
+
+* Update `tools/e2etesting/pipeline_standalone.yml`:
+  * Change  `name: '$(AgentPool)'` to `vmImage: windows-latest`
+
+* Import `tools/e2etesting/pipeline_standalone.yml` as a pipeline. Create the following pipeline variables:
+
+| Name                      | Default value                               |
+| ------------------------- | ------------------------------------------- |
+| `AzureSubscription`       | Your service connection name                |
+| `Cleanup`                 | `true`                                      |
+| `ContainerRegistryServer` | `YOURACR.azurecr.io/events-and-alarms`      |
+| `EdgeVersion`             | `1.1`                                       |
+| `PLCImage`                | `YOURACR.azurecr.io/iotedge/opc-plc:latest` |
+| `PLCUsername`             | Your ACR username*                          |
+| `PLCPassword`             | Your ACR password*                          |
+| `Region`                  | `westus`                                    |
+| `ResourceGroupName`       | Your resource group name                    |
+| `UseExisting`             | `false`                                     |
+
+\* If using a repository with public access enabled, fill a dummy value for `PLCUsername`  and  `PLCPassword`.
+
+* Run the pipeline.

--- a/tools/e2etesting/DeployPLCs.ps1
+++ b/tools/e2etesting/DeployPLCs.ps1
@@ -20,6 +20,10 @@ Param(
     [string]
     $PLCImage = "mcr.microsoft.com/iotedge/opc-plc:latest",
     [string]
+    $PLCUsername = "dummy",
+    [string]
+    $PLCPassword = "dummy",
+    [string]
     $ResourcesPrefix = "e2etesting",
     [Double]
     $MemoryInGb = 0.5,
@@ -93,8 +97,8 @@ if ($aciNamesToCreate.Length -gt 0) {
     if ($UsePrivateIp -eq $false) {
         $script = {
             Param($Name)
-            $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
-            az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --os-type Linux --command $aciCommand --ports @(50000,80) --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Public --dns-name-label $Name
+            $aciCommand = "/bin/sh -c './opcplc --ses --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
+            az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --registry-username $using:PLCUsername --registry-password $using:PLCPassword --os-type Linux --command $aciCommand --ports @(50000,80) --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Public --dns-name-label $Name
             if ($LASTEXITCODE -ne 0) {
                 throw "Job failed with exit code: $LASTEXITCODE"
             }
@@ -110,8 +114,8 @@ if ($aciNamesToCreate.Length -gt 0) {
 
         $script = {
             Param($Name)
-            $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
-            az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --os-type Linux --command $aciCommand --ports @(50000,80) --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Private --vnet $using:vNet --subnet $using:subNet
+            $aciCommand = "/bin/sh -c './opcplc --ses --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
+            az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --registry-username $using:PLCUsername --registry-password $using:PLCPassword --os-type Linux --command $aciCommand --ports @(50000,80) --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Private --vnet $using:vNet --subnet $using:subNet
             if ($LASTEXITCODE -ne 0) {
                 throw "Job failed with exit code: $LASTEXITCODE"
             }

--- a/tools/e2etesting/DeployPLCs.ps1
+++ b/tools/e2etesting/DeployPLCs.ps1
@@ -20,9 +20,9 @@ Param(
     [string]
     $PLCImage = "mcr.microsoft.com/iotedge/opc-plc:latest",
     [string]
-    $PLCUsername = "dummy",
+    $PLCUsername = "",
     [string]
-    $PLCPassword = "dummy",
+    $PLCPassword = "",
     [string]
     $ResourcesPrefix = "e2etesting",
     [Double]

--- a/tools/e2etesting/DeployTestEventProcessor.ps1
+++ b/tools/e2etesting/DeployTestEventProcessor.ps1
@@ -6,7 +6,8 @@ Param(
     $StorageAccountName,
     $IoTHubName,
     $TenantId,
-    $StorageContainerName
+    $StorageContainerName,
+    $StorageFileShareName = "acishare"
 )
 
 # Stop execution when an error occurs.
@@ -140,6 +141,15 @@ $storageContainer = Get-AzStorageContainer -Name $StorageContainerName -Context 
 if (!$storageContainer) {
     Write-Host "Creating storage container '$($StorageContainerName)' in storage account '$($storageAccount.StorageAccountName)'..."
     $storageContainer = New-AzStorageContainer -Name $StorageContainerName -Context $storageContext -Permission Container | Out-Null
+}
+
+## Ensure file share for ACI mount and files to be able to support dynamic ACI:s in test
+
+$storageShare = Get-AzStorageShare -Context $storageContext.Context -Name $StorageFileShareName -ErrorAction SilentlyContinue 
+
+if (!$storageShare) {
+    Write-Host "Creating storage share '$($StorageFileShareName )' in storage account '$($storageAccount.StorageAccountName)'..."
+    $storageShare = New-AzStorageShare -Context $storageContext.Context -Name $StorageFileShareName | Out-Null
 }
 
 ## Ensure AppServicePlan ##

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/IncrementalIntValueChecker.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/IncrementalIntValueChecker.cs
@@ -7,6 +7,7 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
     using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Threading;
 
     /// <summary>
@@ -15,11 +16,17 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
     /// </summary>
     class IncrementalIntValueChecker {
 
-        private readonly IDictionary<string, int> _latestValuePerNodeId;
+        /// <summary>
+        /// Format to be used for Timestamps
+        /// </summary>
+        private const string _dateTimeFormat = "yyyy-MM-dd HH:mm:ss.fffffffZ";
+
+        private readonly IDictionary<string, Tuple<int, DateTime>> _latestValuePerNodeId;
         private uint _duplicateValues = 0;
         private uint _droppedValues = 0;
         private readonly SemaphoreSlim _lock;
         private readonly ILogger _logger;
+        private readonly DateTimeFormatInfo _dateTimeFormatInfo;
 
         /// <summary>
         /// Constructor for IncrementalIntValueChecker.
@@ -30,20 +37,28 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
         ) {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            _latestValuePerNodeId = new Dictionary<string, int>();
+            _latestValuePerNodeId = new Dictionary<string, Tuple<int, DateTime>>();
             _lock = new SemaphoreSlim(1, 1);
+            _dateTimeFormatInfo = new DateTimeFormatInfo();
         }
 
         /// <summary>
         /// Method that should be called for processing of events.
         /// </summary>
         /// <param name="nodeId"></param>
+        /// <param name="timestamp"></param>
         /// <param name="value"></param>
         public void ProcessEvent(
             string nodeId,
+            DateTime timestamp,
             object value
         ) {
             int curValue;
+
+            // do not process if we miss data
+            if (string.IsNullOrEmpty(nodeId) || value == null) {
+                return;
+            }
 
             try {
                 curValue = Convert.ToInt32(value);
@@ -57,24 +72,36 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
             try {
                 if (!_latestValuePerNodeId.ContainsKey(nodeId)) {
                     // There is no previous value.
-                    _latestValuePerNodeId[nodeId] = curValue;
+                    _latestValuePerNodeId[nodeId] = Tuple.Create(curValue, timestamp);
                     return;
                 }
 
-                if (curValue == _latestValuePerNodeId[nodeId] + 1) {
-                    _latestValuePerNodeId[nodeId] = curValue;
+                if (curValue == _latestValuePerNodeId[nodeId].Item1 + 1) {
+                    _latestValuePerNodeId[nodeId] = Tuple.Create(curValue, timestamp);
                     return;
                 }
 
-                if (curValue == _latestValuePerNodeId[nodeId]) {
+                if (curValue == _latestValuePerNodeId[nodeId].Item1) {
                     _duplicateValues++;
-                    _logger.LogWarning("Duplicate value detected for {nodeId}", nodeId);
-                } else {
-                    _droppedValues++;
-                    _logger.LogWarning("Dropped value detected for {nodeId}, previous value is {prevValue} " +
-                        "and current value is {curValue}.", nodeId, _latestValuePerNodeId[nodeId], curValue);
 
-                    _latestValuePerNodeId[nodeId] = curValue;
+                    _logger.LogWarning("Duplicate value detected for {nodeId}, previous timestamp is {prevTimestamp}, " +
+                        "current timestamp is {curTimestamp}.",
+                        nodeId,
+                        _latestValuePerNodeId[nodeId].Item2.ToString(_dateTimeFormat, _dateTimeFormatInfo),
+                        timestamp.ToString(_dateTimeFormat, _dateTimeFormatInfo));
+
+                    _latestValuePerNodeId[nodeId] = Tuple.Create(curValue, timestamp);
+                }
+                else {
+                    _droppedValues++;
+                    _logger.LogWarning("Dropped value detected for {nodeId}, " +
+                        "previous value is {prevValue} with timestamp {prevTimestamp} " +
+                        "and current value is {curValue} with timestamp {curTimestamp}.",
+                        nodeId, _latestValuePerNodeId[nodeId].Item1,
+                        _latestValuePerNodeId[nodeId].Item2.ToString(_dateTimeFormat, _dateTimeFormatInfo),
+                        curValue, timestamp.ToString(_dateTimeFormat, _dateTimeFormatInfo));
+
+                    _latestValuePerNodeId[nodeId] = Tuple.Create(curValue, timestamp);
                 }
             }
             finally {

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MessageDeliveryDelayChecker.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MessageDeliveryDelayChecker.cs
@@ -57,6 +57,11 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
             DateTime sourceTimestamp,
             DateTime enqueuedimestamp
         ) {
+            // do not process if no source timestamp
+            if (sourceTimestamp == default(DateTime)) {
+                return;
+            }
+
             // Do not process if _expectedMaximalDuration is set to zero.
             if (_expectedMaximalDuration.Equals(TimeSpan.Zero)) {
                 return;

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MessageProcessingDelayChecker.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MessageProcessingDelayChecker.cs
@@ -49,7 +49,13 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
             DateTime sourceTimestamp,
             DateTime receivedTimestamp
         ) {
+            // do not process if we don't have source timestamp
+            if (sourceTimestamp == default(DateTime)) {
+                return;
+            }
+
             _lock.Wait();
+
             try {
                 // Check and report if processing delay has changed considerably, meaning more that the threshold.
                 var newOpcDiffToNow = receivedTimestamp - sourceTimestamp;

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MissingTimestampsChecker.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MissingTimestampsChecker.cs
@@ -76,6 +76,11 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
                 return;
             }
 
+            // Do not process if we don't have nodeId
+            if (string.IsNullOrEmpty(nodeId)) {
+                return;
+            }
+
             // Do not process if _expectedInterval is set to zero.
             if (_expectedInterval.Equals(TimeSpan.Zero)) {
                 return;
@@ -148,7 +153,7 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
         private void CheckForMissingTimestamps() {
             _lock.Wait();
             try {
-                foreach(var kvp in _sourceTimestamps) {
+                foreach (var kvp in _sourceTimestamps) {
                     if (kvp.Value.Count < 2) {
                         // Nothing to check as there are no enough timestamps to compare.
                         continue;

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MissingValueChangesChecker.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/MissingValueChangesChecker.cs
@@ -51,6 +51,11 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
                 return;
             }
 
+            // do not process if no source timestamp
+            if (sourceTimestamp == default(DateTime)) {
+                return;
+            }
+
             // Do not process if _expectedValueChangesPerTimestamp is set to zero.
             if (_expectedValueChangesPerTimestamp == 0) {
                 return;

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/ValueChangeCounterPerNodeId.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/Checkers/ValueChangeCounterPerNodeId.cs
@@ -43,6 +43,11 @@ namespace TestEventProcessor.BusinessLogic.Checkers {
             DateTime _0,
             object _1
         ) {
+            // do not process if we are missing data
+            if (string.IsNullOrEmpty(nodeId) || _0 == default(DateTime) || _1 == null) {
+                return;
+            }
+
             _lock.Wait();
             try {
                 if (_valueChangesPerNodeId.ContainsKey(nodeId)) {

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/ITelemetryValidator.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/ITelemetryValidator.cs
@@ -3,16 +3,13 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace TestEventProcessor.BusinessLogic
-{
-    using System;
+namespace TestEventProcessor.BusinessLogic {
     using System.Threading.Tasks;
 
     /// <summary>
     /// Interface to validate incoming message on an IoT Hub.
     /// </summary>
-    public interface ITelemetryValidator
-    {
+    public interface ITelemetryValidator {
         /// <summary>
         /// Method that runs asynchronously to connect to event hub and check
         /// a) if all expected value changes are delivered
@@ -27,5 +24,11 @@ namespace TestEventProcessor.BusinessLogic
         /// </summary>
         /// <returns></returns>
         Task<StopResult> StopAsync();
+
+        /// <summary>
+        /// This function returns the persisted messages as a JSON object
+        /// </summary>
+        /// <returns></returns>
+        string GetMessages();
     }
 }

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/TelemetryValidator.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/TelemetryValidator.cs
@@ -11,6 +11,7 @@ namespace TestEventProcessor.BusinessLogic {
     using Azure.Storage.Blobs;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
@@ -23,13 +24,13 @@ namespace TestEventProcessor.BusinessLogic {
     /// <summary>
     /// Validates the value changes within IoT Hub Methods
     /// </summary>
-    public class TelemetryValidator : ITelemetryValidator
-    {
+    public class TelemetryValidator : ITelemetryValidator {
         private CancellationTokenSource _cancellationTokenSource;
         private EventProcessorClient _client = null;
         private DateTime _startTime = DateTime.MinValue;
         private int _totalValueChangesCount = 0;
         private int _shuttingDown;
+        private readonly JArray _jContents = new JArray();
 
         // Checkers
         private MissingTimestampsChecker _missingTimestampsChecker;
@@ -55,8 +56,7 @@ namespace TestEventProcessor.BusinessLogic {
         /// Create instance of TelemetryValidator
         /// </summary>
         /// <param name="logger">Instance to write logs</param>
-        public TelemetryValidator(ILogger<TelemetryValidator> logger)
-        {
+        public TelemetryValidator(ILogger<TelemetryValidator> logger) {
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
@@ -67,8 +67,7 @@ namespace TestEventProcessor.BusinessLogic {
         /// </summary>
         /// <param name="token">Token to cancel the operation</param>
         /// <returns>Task that run until token is canceled</returns>
-        public async Task<StartResult> StartAsync(ValidatorConfiguration configuration)
-        {
+        public async Task<StartResult> StartAsync(ValidatorConfiguration configuration) {
             // Check if already started.
             if (_cancellationTokenSource != null) {
                 return new StartResult();
@@ -118,6 +117,7 @@ namespace TestEventProcessor.BusinessLogic {
             _client.ProcessEventAsync += Client_ProcessEventAsync;
             _client.ProcessErrorAsync += Client_ProcessErrorAsync;
 
+            _jContents.Clear();
             _logger.LogInformation("Starting monitoring of events...");
             await _client.StartProcessingAsync(_cancellationTokenSource.Token);
 
@@ -164,11 +164,10 @@ namespace TestEventProcessor.BusinessLogic {
         /// Stop monitoring of events.
         /// </summary>
         /// <returns></returns>
-        public async Task<StopResult> StopAsync()
-        {
+        public Task<StopResult> StopAsync() {
             // Check if already stopped.
             if (_cancellationTokenSource == null) {
-                return new StopResult();
+                return Task.FromResult(new StopResult());
             }
 
             Interlocked.Exchange(ref _shuttingDown, 1);
@@ -194,7 +193,7 @@ namespace TestEventProcessor.BusinessLogic {
 
                 // TODO collect "expected" parameter as groups related to OPC UA nodes
                 allExpectedValueChanges = valueChangesPerNodeId?
-                    .All(kvp => (_totalValueChangesCount / kvp.Value ) ==
+                    .All(kvp => (_totalValueChangesCount / kvp.Value) ==
                         _currentConfiguration.ExpectedValueChangesPerTimestamp
                     ) ?? false;
                 _logger.LogInformation("All expected value changes received: {AllExpectedValueChanges}",
@@ -205,7 +204,7 @@ namespace TestEventProcessor.BusinessLogic {
 
             var incrCheckerResult = _incrementalIntValueChecker.Stop();
 
-            var stopResult =  new StopResult() {
+            var stopResult = new StopResult() {
                 ValueChangesByNodeId = new ReadOnlyDictionary<string, int>(valueChangesPerNodeId ?? new Dictionary<string, int>()),
                 AllExpectedValueChanges = allExpectedValueChanges,
                 TotalValueChangesCount = _totalValueChangesCount,
@@ -218,19 +217,25 @@ namespace TestEventProcessor.BusinessLogic {
                 DuplicateValueCount = incrCheckerResult.DuplicateValueCount,
             };
 
-            return stopResult;
+            return Task.FromResult(stopResult);
+        }
+
+        /// <summary>
+        /// This function returns the persisted messages as a JSON object
+        /// </summary>
+        /// <returns></returns>
+        public string GetMessages() {
+            return JsonConvert.SerializeObject(_jContents);
         }
 
         /// <summary>
         /// Stops the Event Hub Client and deregisters event handlers.
         /// </summary>
         /// <returns></returns>
-        private async Task StopEventProcessorClientAsync()
-        {
+        private async Task StopEventProcessorClientAsync() {
             _logger.LogInformation("Stopping monitoring of events...");
 
-            if (_client != null)
-            {
+            if (_client != null) {
                 var tempClient = _client;
                 _client = null;
                 await tempClient.StopProcessingAsync();
@@ -247,46 +252,75 @@ namespace TestEventProcessor.BusinessLogic {
         /// </summary>
         /// <param name="arg"></param>
         /// <returns>Task that run until token is canceled</returns>
-        private async Task Client_ProcessEventAsync(ProcessEventArgs arg)
-        {
+        private Task Client_ProcessEventAsync(ProcessEventArgs arg) {
             var eventReceivedTimestamp = DateTime.UtcNow;
 
             // Check if already stopped.
             if (_cancellationTokenSource == null) {
                 _logger.LogWarning("Received Events but nothing to do, because already stopped");
-                return;
+                return Task.CompletedTask;
             }
 
             if (!arg.HasEvent) {
                 _logger.LogWarning("Received partition event without content");
-                return;
+                return Task.CompletedTask;
             }
 
             var body = arg.Data.Body.ToArray();
             var content = Encoding.UTF8.GetString(body);
+            lock (_jContents) {
+                while (_currentConfiguration.MaximalNumberOfMessages > 0 &&
+                    _currentConfiguration.MaximalNumberOfMessages <= _jContents.Count) {
+                    _jContents.RemoveAt(0);
+                }
+                _jContents.Add(JArray.Parse(content));
+            }
             dynamic json = JsonConvert.DeserializeObject(content);
             var valueChangesCount = 0;
 
-            // TODO build variant that works with PubSub
+            DateTime entrySourceTimestamp = default(DateTime);
+            string entryNodeId = null;
+            object entryValue = null;
 
-            foreach (dynamic entry in json)
-            {
-                DateTime entrySourceTimestamp;
-                string entryNodeId = null;
-                object entryValue;
-
-                try
-                {
-                    entrySourceTimestamp = (DateTime)entry.Value.SourceTimestamp;
-                    entryNodeId = entry.NodeId;
-                    entryValue = entry.Value.Value;
+            foreach (dynamic entry in json) {
+                if (entry.Messages != null) {
+                    try {
+                        // pub sub
+                        var dataSetMessages = entry.Messages;
+                        foreach (var dataSetMessage in dataSetMessages) {
+                            foreach (var payload in dataSetMessage.Payload) {
+                                foreach (var message in payload.Value) {
+                                    try {
+                                        entrySourceTimestamp = message.SourceTimestamp;
+                                    }
+                                    catch (Exception) {
+                                    }
+                                    valueChangesCount++;
+                                    Interlocked.Increment(ref _totalValueChangesCount);
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex) {
+                        _logger.LogError(ex, "Could not read from message. Please make sure that publisher is running with samples format and with --fm parameter set.");
+                        return Task.CompletedTask;
+                    }
                 }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "Could not read sequence number, nodeId and/or timestamp from " +
-                        "message. Please make sure that publisher is running with samples format and with " +
-                        "--fm parameter set.");
-                    continue;
+                else {
+                    try {
+                        entrySourceTimestamp = (DateTime)entry.Value.SourceTimestamp;
+                        entryNodeId = entry.NodeId;
+                        entryValue = entry.Value.Value;
+                    }
+                    catch (Exception ex) {
+                        _logger.LogError(ex, "Could not read value, nodeId and/or timestamp from " +
+                            "message. Please make sure that publisher is running with samples format and with " +
+                            "--fm parameter set.");
+                        continue;
+                    }
+
+                    Interlocked.Increment(ref _totalValueChangesCount);
+                    valueChangesCount++;
                 }
 
                 // Feed data to checkers.
@@ -295,14 +329,14 @@ namespace TestEventProcessor.BusinessLogic {
                 _messageDeliveryDelayChecker.ProcessEvent(entrySourceTimestamp, arg.Data.EnqueuedTime.UtcDateTime);
                 _valueChangeCounterPerNodeId.ProcessEvent(entryNodeId, entrySourceTimestamp, entryValue);
                 _missingValueChangesChecker.ProcessEvent(entrySourceTimestamp);
-                _incrementalIntValueChecker.ProcessEvent(entryNodeId, entryValue);
+                _incrementalIntValueChecker.ProcessEvent(entryNodeId, entrySourceTimestamp, entryValue);
 
-                Interlocked.Increment(ref _totalValueChangesCount);
-                valueChangesCount++;
             }
 
             _logger.LogDebug("Received {NumberOfValueChanges} messages from IoT Hub, partition {PartitionId}.",
                 valueChangesCount, arg.Partition.PartitionId);
+
+            return Task.CompletedTask;
         }
 
         /// <summary>
@@ -310,8 +344,7 @@ namespace TestEventProcessor.BusinessLogic {
         /// </summary>
         /// <param name="arg">Init event args</param>
         /// <returns>Completed Task, no async work needed</returns>
-        private Task Client_PartitionInitializingAsync(PartitionInitializingEventArgs arg)
-        {
+        private Task Client_PartitionInitializingAsync(PartitionInitializingEventArgs arg) {
             _logger.LogInformation("EventProcessorClient initializing, start with latest position for " +
                 "partition {PartitionId}", arg.PartitionId);
             arg.DefaultStartingPosition = EventPosition.Latest;
@@ -323,12 +356,10 @@ namespace TestEventProcessor.BusinessLogic {
         /// </summary>
         /// <param name="arg">Error event args</param>
         /// <returns>Completed Task, no async work needed</returns>
-        private Task Client_ProcessErrorAsync(ProcessErrorEventArgs arg)
-        {
+        private Task Client_ProcessErrorAsync(ProcessErrorEventArgs arg) {
             _logger.LogError(arg.Exception, "Issue reported by EventProcessorClient, partition " +
                 "{PartitionId}, operation {Operation}", arg.PartitionId, arg.Operation);
             return Task.CompletedTask;
         }
-
     }
 }

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/ValidatorConfiguration.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/ValidatorConfiguration.cs
@@ -3,13 +3,11 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace TestEventProcessor.BusinessLogic
-{
+namespace TestEventProcessor.BusinessLogic {
     /// <summary>
     /// Model class to encapsule the configuration required to monitor and validate IoT Hub events.
     /// </summary>
-    public class ValidatorConfiguration
-    {
+    public class ValidatorConfiguration {
         /// <summary>
         /// Gets or sets the connection string of the EventHub-Endpoint of the IoT Hub.
         /// </summary>
@@ -50,5 +48,11 @@ namespace TestEventProcessor.BusinessLogic
         /// Current Value need to be within range of Expected Value +/- threshold
         /// </summary>
         public int ThresholdValue { get; set; } = 100;
+
+        /// <summary>
+        /// Gets or sets the value sets the maximum number of messages we persist. We will only keep the most recent messages.
+        /// If this is set to 0, no maximum number is enforced
+        /// </summary>
+        public uint MaximalNumberOfMessages { get; set; } = 0;
     }
 }

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Service/Controllers/RuntimeController.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Service/Controllers/RuntimeController.cs
@@ -60,5 +60,10 @@ namespace TestEventProcessor.Service.Controllers
 
             return result;
         }
+
+        [HttpGet("messages")]
+        public string GetMessages() {
+            return _validator.GetMessages();
+        }
     }
 }

--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -11,6 +11,7 @@ steps:
     inlineScript: |
       Write-Host "##vso[task.setvariable variable=ServicePrincipalId]$($env:servicePrincipalId)"
       Write-Host "##vso[task.setvariable variable=ServicePrincipalKey]$($env:servicePrincipalKey)"
+      Write-Host "##vso[task.setvariable variable=TenantId]$($env:tenantId)"
 
 - task: DownloadPipelineArtifact@2
   inputs:

--- a/tools/e2etesting/steps/deploystandalone.yml
+++ b/tools/e2etesting/steps/deploystandalone.yml
@@ -10,6 +10,8 @@ steps:
     addSpnToEnvironment: true
     inlineScript: |
       Write-Host "##vso[task.setvariable variable=ServicePrincipalId]$($env:servicePrincipalId)"
+      Write-Host "##vso[task.setvariable variable=ServicePrincipalKey]$($env:servicePrincipalKey)"
+      Write-Host "##vso[task.setvariable variable=TenantId]$($env:tenantId)"
 
 - task: AzurePowerShell@5
   displayName: "Deploy standalone resources"
@@ -22,3 +24,4 @@ steps:
       -ResourceGroupName "$(ResourceGroupName)"
       -Region "$(Region)"
       -ServicePrincipalId "$(ServicePrincipalId)"
+      -TenantId "$(TenantId)"

--- a/tools/e2etesting/steps/deploytestresources.yml
+++ b/tools/e2etesting/steps/deploytestresources.yml
@@ -16,6 +16,9 @@ steps:
     arguments: >
       -ResourceGroupName "$(ResourceGroupName)"
       -UsePrivateIp $false
+      -PLCImage "$(PLCImage)"
+      -PLCUsername "$(PLCUsername)"
+      -PLCPassword "$(PLCPassword)" 
 
 - task: AzureCLI@2
   displayName: "Deploy containers with simulated PLCs with private ips"
@@ -29,6 +32,9 @@ steps:
     arguments: >
       -ResourceGroupName "$(ResourceGroupName)"
       -UsePrivateIp $true
+      -PLCImage "$(PLCImage)"
+      -PLCUsername "$(PLCUsername)"
+      -PLCPassword "$(PLCPassword)" 
 
 - task: AzurePowerShell@5
   displayName: "Deploy VM with IoT Edge Runtime"

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -16,6 +16,11 @@ steps:
     addSpnToEnvironment: true
     inlineScript: |
       Write-Host "##vso[task.setvariable variable=ServicePrincipalId]$($env:servicePrincipalId)"
+      Write-Host "##vso[task.setvariable variable=ServicePrincipalKey]$($env:servicePrincipalKey)"
+      Write-Host "##vso[task.setvariable variable=TenantId]$($env:tenantId)"
+      Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_ID]$env:servicePrincipalId"
+      Write-Host "##vso[task.setvariable variable=AZURE_CLIENT_SECRET;isSecret=true]$env:servicePrincipalKey"
+      Write-Host "##vso[task.setvariable variable=AZURE_TENANT_ID]$env:tenantId"
 
 - task: AzurePowerShell@5
   displayName: 'Set KeyVaultName-Variable'
@@ -45,7 +50,7 @@ steps:
   inputs:
     azureSubscription: '$(AzureSubscription)'
     KeyVaultName: '$(KeyVaultName)'
-    SecretsFilter: 'PCS-IOTHUB-CONNSTRING,plc-simulation-urls,iot-edge-vm-username,iot-edge-vm-publickey,iot-edge-vm-privatekey,iot-edge-device-id,iot-edge-device-dnsname,testeventprocessor-baseurl,testeventprocessor-username,testeventprocessor-password,iothub-eventhub-connectionstring,storageaccount-iothubcheckpoint-connectionstring'
+    SecretsFilter: 'PCS-IOTHUB-CONNSTRING,plc-simulation-urls,iot-edge-vm-username,iot-edge-vm-publickey,iot-edge-vm-privatekey,iot-edge-device-id,iot-edge-device-dnsname,testeventprocessor-baseurl,testeventprocessor-username,testeventprocessor-password,iothub-eventhub-connectionstring,storageaccount-iothubcheckpoint-connectionstring,SP-TENANT-ID'
 
 - task: AzureKeyVault@1
   displayName: 'Retrieve KeyVault secrets for API tests'
@@ -117,3 +122,7 @@ steps:
     IOT_EDGE_VERSION: "$(EdgeVersion)"
     NESTED_EDGE_FLAG: "$(NestedEdgeFlag)"
     NESTED_EDGE_SSH_CONNECTIONS: "$(NestedEdgeSshConnection)"
+    SP_TENANT_ID: '$(SP-TENANT-ID)'
+    RESOURCE_GROUP_NAME: '$(ResourceGroupName)'
+    REGION: '$(Region)'
+    AZURE_CLIENT_SECRET: '$(AZURE_CLIENT_SECRET)'


### PR DESCRIPTION
Adding E2E tests for events and alarms. Adds the ability to create ACI's on-demand for tests, improvements to the TestEventProcessor, direct connection to Azure IoT Hub to make assertions on the payload, etc. All tested in a copy of pipeline. 