### PR TITLE
Remove encoded Keys and Count from EncodeableDictionary

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/Models/EncodeableDictionary.cs
@@ -54,8 +54,8 @@ namespace Opc.Ua.Encoders {
                 .Where(x => !(x.Value.Value is LocalizedText lt) || lt.Locale != null || lt.Text != null)
                 .ToDictionary(x => x.Key, x => x.Value);
 
-            foreach (var value in dictionary) {
-                encoder.WriteDataValue(value.Key, value.Value);
+            foreach (var keyValuePair in dictionary) {
+                encoder.WriteDataValue(keyValuePair.Key, keyValuePair.Value);
             }
         }
 
@@ -66,11 +66,10 @@ namespace Opc.Ua.Encoders {
                 throw new Exception($"Cannot decode using the decoder: {decoder.GetType()}.");
             }
             var dictionary = jsonDecoder.ReadDataValueDictionary(null);
-
-            foreach (var kvp in dictionary) {
+            foreach (var keyValuePair in dictionary) {
                 Add(new KeyDataValuePair {
-                    Key = kvp.Key,
-                    Value = kvp.Value
+                    Key = keyValuePair.Key,
+                    Value = keyValuePair.Value
                 });
             }
         }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Stack/Encoders/Models/EncodeableDictionaryTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Stack/Encoders/Models/EncodeableDictionaryTests.cs
@@ -139,17 +139,5 @@ namespace Opc.Ua.Encoders {
                 Assert.Null(eof);
             }
         }
-
-        [Fact]
-        public void ThrowServiceResultExceptionWhenKeysIdentifierIsUsed() {
-            var encodeableDictionary = new EncodeableDictionary {
-                new KeyDataValuePair { Key = "_Keys", Value = new DataValue(new Variant(123)) },
-            };
-
-            var context = new ServiceMessageContext();
-            using var stream = new MemoryStream();
-            using var encoder = new JsonEncoderEx(stream, context, JsonEncoderEx.JsonEncoding.Object);
-            Assert.Throws<ServiceResultException>(() => encodeableDictionary.Encode(encoder));
-        }
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
@@ -74,11 +74,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
                 Assert.Equal("s=EncodeableDictionary", typeId);
                 Assert.Equal("Json", encoding);
 
-                var count = body.GetProperty("_Count").GetInt32();
-                var keys = body.GetProperty("_Keys").EnumerateArray().Select(x => x.GetString()).ToArray();
-                Assert.Equal(4, count);
-                Assert.Equal(new[] { kEventId, kMessage, kCycleId, kCurrentStep }, keys);
-
                 var eventId = body.GetProperty(kEventId);
                 Assert.Equal("ByteString", eventId.GetProperty("Type").GetString());
                 Assert.Equal(JsonValueKind.String, eventId.GetProperty("Body").ValueKind);


### PR DESCRIPTION
By taking a dependency on the JsonDecoderEx, which can decode a dictionary, we no longer need to encode Count and Keys separately.