### PR TITLE
IAI: Updated documentation to mention 1.19 version of Kubernetes.

### DIFF
--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -590,7 +590,7 @@ The following Azure regions are supported by `Microsoft.Azure.IIoT.Deployment` f
 ### AKS
 
 All cloud microservices of Azure Industrial IoT solution are deployed to an AKS Kubernetes cluster.
-`Microsoft.Azure.IIoT.Deployment` deploys latest available patch version of `1.18` Kubernetes.
+`Microsoft.Azure.IIoT.Deployment` deploys latest available patch version of `1.19` Kubernetes.
 
 #### Kubernetes Dashboard
 


### PR DESCRIPTION
Changes:
* Updated IAI documentation to mention `1.19` as the version of Kubernetes that is deployed instead of `1.18`.