### PR TITLE
Simplified payload identifier detection in NetworkMessageEncoder.

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -135,6 +135,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 _batchNetworkMessageBlock.LinkTo(_sinkBlock);
 
                 _messageTrigger.OnMessage += MessageTriggerMessageReceived;
+
+                if (_batchTriggerInterval > TimeSpan.Zero) {
+                    _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
+                }
+
                 if (_diagnosticInterval > TimeSpan.Zero) {
                     _diagnosticsOutputTimer.Change(_diagnosticInterval, _diagnosticInterval);
                 }
@@ -272,10 +277,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private void MessageTriggerMessageReceived(object sender, DataSetMessageModel args) {
             if (_diagnosticStart == DateTime.MinValue) {
                 _diagnosticStart = DateTime.UtcNow;
-
-                if (_batchTriggerInterval > TimeSpan.Zero) {
-                    _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
-                }
             }
 
             if(_sinkBlock.InputCount >= _maxOutgressMessages) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -136,10 +136,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
 
                 _messageTrigger.OnMessage += MessageTriggerMessageReceived;
 
-                if (_batchTriggerInterval > TimeSpan.Zero) {
-                    _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
-                }
-
                 if (_diagnosticInterval > TimeSpan.Zero) {
                     _diagnosticsOutputTimer.Change(_diagnosticInterval, _diagnosticInterval);
                 }
@@ -277,6 +273,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private void MessageTriggerMessageReceived(object sender, DataSetMessageModel args) {
             if (_diagnosticStart == DateTime.MinValue) {
                 _diagnosticStart = DateTime.UtcNow;
+
+                if (_batchTriggerInterval > TimeSpan.Zero) {
+                    _batchTriggerIntervalTimer.Change(_batchTriggerInterval, Timeout.InfiniteTimeSpan);
+                }
             }
 
             if(_sinkBlock.InputCount >= _maxOutgressMessages) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 var resultJson = EncodeAsJson(messages, maxMessageSize);
                 var resultUadp = EncodeAsUadp(messages, maxMessageSize);
                 var result = resultJson.Concat(resultUadp);
-                return Task.FromResult(result);
+                return Task.FromResult<IEnumerable<NetworkMessageModel>>(result.ToList());
             }
             catch (Exception e) {
                 _logger.Error(e, "Failed to encode {numOfMessages} messages", messages.Count());

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 var resultJson = EncodeBatchAsJson(messages, maxMessageSize);
                 var resultUadp = EncodeBatchAsUadp(messages, maxMessageSize);
                 var result = resultJson.Concat(resultUadp);
-                return Task.FromResult(result);
+                return Task.FromResult<IEnumerable<NetworkMessageModel>>(result.ToList());
             }
             catch (Exception e) {
                 _logger.Error(e, "Failed to encode {numOfMessages} messages", messages.Count());


### PR DESCRIPTION
Changes:
* Changed `NetworkMessageEncoder.GetPayloadIdentifier()` to also cache values that were not found by the lookup but were the fallback mechanism. This is usually expanded node id.