### PR TITLE
Implemented sliding window to calculate values changes/s

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -224,10 +224,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             kDataChangesCount.WithLabels(deviceId, moduleId, Name)
                 .Set(_messageTrigger.DataChangesCount);
             kDataChangesPerSecond.WithLabels(deviceId, moduleId, Name)
+                .Set(dataChangesPerSec);
+            kDataChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
                 .Set(dataChangesPerSecLastMin);
             kValueChangesCount.WithLabels(deviceId, moduleId, Name)
                 .Set(_messageTrigger.ValueChangesCount);
             kValueChangesPerSecond.WithLabels(deviceId, moduleId, Name)
+                .Set(valueChangesPerSec);
+            kValueChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
                 .Set(valueChangesPerSecLastMin);
             kNotificationsProcessedCount.WithLabels(deviceId, moduleId, Name)
                 .Set(_messageEncoder.NotificationsProcessedCount);
@@ -336,12 +340,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         private static readonly Gauge kValueChangesPerSecond = Metrics.CreateGauge(
             "iiot_edge_publisher_value_changes_per_second",
             "Opc ValuesChanges/second delivered for processing", kGaugeConfig);
+        private static readonly Gauge kValueChangesPerSecondLastMin = Metrics.CreateGauge(
+            "iiot_edge_publisher_value_changes_per_second_last_min",
+            "Opc ValuesChanges/second delivered for processing in last 60s", kGaugeConfig);
         private static readonly Gauge kDataChangesCount = Metrics.CreateGauge(
             "iiot_edge_publisher_data_changes",
             "Opc DataChanges delivered for processing", kGaugeConfig);
         private static readonly Gauge kDataChangesPerSecond = Metrics.CreateGauge(
             "iiot_edge_publisher_data_changes_per_second",
             "Opc DataChanges/second delivered for processing", kGaugeConfig);
+        private static readonly Gauge kDataChangesPerSecondLastMin = Metrics.CreateGauge(
+            "iiot_edge_publisher_data_changes_per_second_last_min",
+            "Opc DataChanges/second delivered for processing in last 60s", kGaugeConfig);
         private static readonly Gauge kIoTHubQueueBuffer = Metrics.CreateGauge(
             "iiot_edge_publisher_iothub_queue_size",
             "IoT messages queued sending", kGaugeConfig);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// </summary>
         private void IncreaseRingBuffer(int[] array, ref int lastPointer, int bucketWidth, int difference) {
             var indexPointer = DateTime.UtcNow.Second % bucketWidth;
-            while (lastPointer != indexPointer && lastPointer < array.Length) {
+            while (lastPointer != indexPointer && (lastPointer + 1) < array.Length) {
                 lastPointer++;
-                array[indexPointer] = 0;
+                array[lastPointer] = 0;
             }
 
             array[indexPointer] += difference;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
@@ -31,10 +31,20 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         int ValueChangesCount { get; }
 
         /// <summary>
-        /// The number of all dataChange Notifications 
+        /// <see cref="ValueChangesCount"/> from the last minute
+        /// </summary>
+        int ValueChangesCountLastMinute { get; }
+
+        /// <summary>
+        /// The number of all dataChange Notifications
         /// that have been invoked by this message source.
         /// </summary>
         int DataChangesCount { get; }
+
+        /// <summary>
+        /// <see cref="DataChangesCount"/> from the last minute
+        /// </summary>
+        int DataChangesCountLastMinute { get; }
 
         /// <summary>
         /// Writer events

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
@@ -28,23 +28,23 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         /// The number of all monitored items value changes
         /// that have been invoked by this message source.
         /// </summary>
-        int ValueChangesCount { get; }
+        ulong ValueChangesCount { get; }
 
         /// <summary>
         /// <see cref="ValueChangesCount"/> from the last minute
         /// </summary>
-        int ValueChangesCountLastMinute { get; }
+        ulong ValueChangesCountLastMinute { get; }
 
         /// <summary>
         /// The number of all dataChange Notifications
         /// that have been invoked by this message source.
         /// </summary>
-        int DataChangesCount { get; }
+        ulong DataChangesCount { get; }
 
         /// <summary>
         /// <see cref="DataChangesCount"/> from the last minute
         /// </summary>
-        int DataChangesCountLastMinute { get; }
+        ulong DataChangesCountLastMinute { get; }
 
         /// <summary>
         /// Writer events


### PR DESCRIPTION
* Extended IMessageTrigger 
  *  property `DataChangesCountLastMinute` that calculates all OPC UA data changes in the last 60 seconds
  *  property `ValueChangesCountLastMinute` that calculates all OPC UA value changes in the last 60 seconds
* Updated diagnostic log with values of last 60 seconds
* Reset diagnostic log after first data is received, to align timings

![image](https://user-images.githubusercontent.com/5366648/129878755-ade38498-6d00-42f8-80e2-37f95b2536d0.png)

[ADO #10205715](https://msazure.visualstudio.com/One/_workitems/edit/10205715/)
Improved logging for #912 