### PR TITLE
Add event when counter are reseted

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 _batchNetworkMessageBlock.LinkTo(_sinkBlock);
 
                 _messageTrigger.OnMessage += MessageTriggerMessageReceived;
+                _messageTrigger.OnCounterReset += MessageTriggerCounterResetReceived;
                 if (_diagnosticInterval > TimeSpan.Zero) {
                     _diagnosticsOutputTimer.Change(_diagnosticInterval, _diagnosticInterval);
                 }
@@ -144,6 +145,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             }
             finally {
                 IsRunning = false;
+                _messageTrigger.OnCounterReset -= MessageTriggerCounterResetReceived;
                 _messageTrigger.OnMessage -= MessageTriggerMessageReceived;
                 _diagnosticsOutputTimer.Change(Timeout.Infinite, Timeout.Infinite);
                 _batchTriggerIntervalTimer.Change(Timeout.Infinite, Timeout.Infinite);
@@ -278,8 +280,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// <summary>
         /// Message received handler
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="args"></param>
         private void MessageTriggerMessageReceived(object sender, DataSetMessageModel args) {
             if (_diagnosticStart == DateTime.MinValue) {
                 if (_batchTriggerInterval > TimeSpan.Zero) {
@@ -299,6 +299,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             else {
                 _batchDataSetMessageBlock.Post(args);
             }
+        }
+
+        private void MessageTriggerCounterResetReceived(object sender, EventArgs e) {
+            _diagnosticStart = DateTime.MinValue;
         }
 
         private readonly int _dataSetMessageBufferSize = 1;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
@@ -52,6 +52,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         event EventHandler<DataSetMessageModel> OnMessage;
 
         /// <summary>
+        /// Called when ValueChangesCount or DataChangesCount are resetted
+        /// </summary>
+        event EventHandler<EventArgs> OnCounterReset;
+
+        /// <summary>
         /// Run the group triggering
         /// </summary>
         /// <param name="ct"></param>


### PR DESCRIPTION
* Extended `IMessageTrigger` with event `OnCounterReset`
  * Event is fired when properties `DataChangesCount`and `ValueChangesCount` are reset before overflow
* DataFlowProcessingEngine register to event to reset timestamp for calculation of total changes per second

[ADO #10205715](https://msazure.visualstudio.com/One/_workitems/edit/10205715/)
Partial address #912 