### PR TITLE
Fixing GitHub issue #1207 Publishing interval of 0 (max rate) together with non-zero HeartbeatInterval causes DivideByZero exception 

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -565,8 +565,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                     .GetValueOrDefault(session.DefaultSubscription.KeepAliveCount);
                 _subscription.MonitoredItems?.ForEach(m => {
                     if (m.HeartbeatInterval != null && m.HeartbeatInterval != TimeSpan.Zero) {
-                        var itemKeepAliveCount = (uint)m.HeartbeatInterval.Value.TotalMilliseconds /
-                            (uint)_subscription.Configuration.PublishingInterval.Value.TotalMilliseconds;
+                        var _publishingInterval = (uint)(_subscription.Configuration.PublishingInterval == TimeSpan.Zero? 
+                                                  TimeSpan.FromSeconds(1) : _subscription.Configuration.PublishingInterval).Value.TotalMilliseconds;
+                        var itemKeepAliveCount = (uint)m.HeartbeatInterval.Value.TotalMilliseconds / _publishingInterval;
                         revisedKeepAliveCount = GreatCommonDivisor(revisedKeepAliveCount, itemKeepAliveCount);
                     }
                 });

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -534,6 +534,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 return noErrorFound;
             }
 
+            /// <summary>
+            /// Helper to calculate greatest common divisor for the parameter of keep alive
+            /// count used to allow the trigger of heart beats in a given interval.
+            /// </summary>
             private static uint GreatCommonDivisor(uint a, uint b) {
                 return b == 0 ? a : GreatCommonDivisor(b, a % b);
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -563,11 +563,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 // calculate the KeepAliveCount no matter what, perhaps monitored items were changed
                 var revisedKeepAliveCount = _subscription.Configuration.KeepAliveCount
                     .GetValueOrDefault(session.DefaultSubscription.KeepAliveCount);
+                var publishInterval = (uint)(_subscription.Configuration.PublishingInterval == TimeSpan.Zero ?
+                                      TimeSpan.FromSeconds(1) : _subscription.Configuration.PublishingInterval).Value.TotalMilliseconds;
                 _subscription.MonitoredItems?.ForEach(m => {
                     if (m.HeartbeatInterval != null && m.HeartbeatInterval != TimeSpan.Zero) {
-                        var _publishingInterval = (uint)(_subscription.Configuration.PublishingInterval == TimeSpan.Zero? 
-                                                  TimeSpan.FromSeconds(1) : _subscription.Configuration.PublishingInterval).Value.TotalMilliseconds;
-                        var itemKeepAliveCount = (uint)m.HeartbeatInterval.Value.TotalMilliseconds / _publishingInterval;
+                        var itemKeepAliveCount = (uint)m.HeartbeatInterval.Value.TotalMilliseconds / publishInterval;
                         revisedKeepAliveCount = GreatCommonDivisor(revisedKeepAliveCount, itemKeepAliveCount);
                     }
                 });


### PR DESCRIPTION
When Publishing interval is 0, taking the default as 1 sec so that it does not result in DivideByException when heartbeat interval is non-zero.

This PR fixes this issue: https://github.com/Azure/Industrial-IoT/issues/1207
PBI [link](https://dev.azure.com/msazure/One/_boards/board/t/IoT-Industrial-Edge-Data/Backlog%20items/?workitem=10143600)