### PR TITLE
Installing .NET Core SDK for deploying the platform.

### DIFF
--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -1,4 +1,12 @@
 steps:
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK for building'
+  inputs:
+    packageType: sdk
+    version: 3.1.x
+    includePreviewVersions: false
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - task: AzureCLI@2
   displayName: 'Set Service Principal Environment Variables'
   name: promoteserviceprincipal

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -5,6 +5,14 @@ parameters:
   type: string
 
 steps:
+- task: UseDotNet@2
+  displayName: 'Install .NET Core SDK'
+  inputs:
+    packageType: sdk
+    version: 3.1.x
+    includePreviewVersions: false
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+
 - task: AzureCLI@2
   displayName: 'Set Service Principal Environment Variables'
   name: promoteserviceprincipal


### PR DESCRIPTION
Azure DevOps Bug: [10621286](https://msazure.visualstudio.com/One/_workitems/edit/10621286)

We need to make sure that `dotnet` is present on the host machine for platform deployment stage in E2E Orchestrated pipeline as it has versioning step which requires it.