### PR TITLE
Fixed reporting of average notifications per message for NetworkMessageEncoder.

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     }
                 }
-                if (!processing || messageCompleted) {
+                if (messageCompleted || (!processing && chunk.Count > 0)) {
                     var writer = new StringWriter();
                     var encoder = new JsonEncoderEx(writer, encodingContext,
                         JsonEncoderEx.JsonEncoding.Array) {
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     }
                 }
-                if (!processing || messageCompleted) {
+                if (messageCompleted || (!processing && chunk.Count > 0)) {
                     var encoder = new BinaryEncoder(encodingContext);
                     encoder.WriteBoolean(null, true); // is Batch
                     encoder.WriteEncodeableArray(null, chunk);
@@ -255,7 +255,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     // this message is too large to be processed. Drop it
                     // TODO Trace
                     NotificationsDroppedCount++;
-                    yield break;
+                    continue;
                 }
                 NotificationsProcessedCount++;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     // this message is too large to be processed. Drop it
                     // TODO Trace
                     NotificationsDroppedCount++;
-                    yield break;
+                    continue;
                 }
                 NotificationsProcessedCount++;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Opc.Ua.Encoders;
     using Opc.Ua.Extensions;
     using Opc.Ua.PubSub;
+    using Serilog;
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
@@ -39,6 +40,17 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
 
         /// <inheritdoc/>
         public double AvgMessageSize { get; private set; }
+
+        /// <summary> Logger for reporting. </summary>
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Create instance of MonitoredItemMessageEncoder.
+        /// </summary>
+        /// <param name="logger"> Logger to be used for reporting. </param>
+        public MonitoredItemMessageEncoder(ILogger logger) {
+            _logger = logger;
+        }
 
         /// <inheritdoc/>
         public Task<IEnumerable<NetworkMessageModel>> EncodeAsync(
@@ -253,8 +265,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 };
                 if (encoded.Body.Length > maxMessageSize) {
                     // this message is too large to be processed. Drop it
-                    // TODO Trace
                     NotificationsDroppedCount++;
+                    _logger.Warning("Message too large, dropped 1 value.");
                     continue;
                 }
                 NotificationsProcessedCount++;
@@ -297,8 +309,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 };
                 if (encoded.Body.Length > maxMessageSize) {
                     // this message is too large to be processed. Drop it
-                    // TODO Trace
                     NotificationsDroppedCount++;
+                    _logger.Warning("Message too large, dropped 1 value.");
                     continue;
                 }
                 NotificationsProcessedCount++;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/MonitoredItemMessageEncoder.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         (MessagesProcessedCount + 1);
                     AvgNotificationsPerMessage = (AvgNotificationsPerMessage * MessagesProcessedCount +
                         chunk.Count) / (MessagesProcessedCount + 1);
-                        MessagesProcessedCount++;
+                    MessagesProcessedCount++;
                     chunk.Clear();
                     messageSize = 2;
                     yield return encoded;
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             IEnumerable<DataSetMessageModel> messages, MessageEncoding encoding,
             ServiceMessageContext context) {
             if (context?.NamespaceUris == null) {
-                // declare all notifications in messages dropped 
+                // declare all notifications in messages dropped
                 foreach (var message in messages) {
                     NotificationsDroppedCount += (uint)(message?.Notifications?.Count() ?? 0);
                 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     }
                 }
-                if (!processing || messageCompleted) {
+                if (messageCompleted || (!processing && chunk.Count > 0)) {
                     var writer = new StringWriter();
                     var encoder = new JsonEncoderEx(writer, encodingContext,
                         JsonEncoderEx.JsonEncoding.Array) {
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         }
                     }
                 }
-                if (!processing || messageCompleted) {
+                if (messageCompleted || (!processing && chunk.Count > 0)) {
                     var encoder = new BinaryEncoder(encodingContext);
                     encoder.WriteBoolean(null, true); // is Batch
                     encoder.WriteEncodeableArray(null, chunk);
@@ -287,7 +287,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     // Message too large, drop it.
                     NotificationsDroppedCount += (uint)notificationsPerMessage;
                     _logger.Warning("Message too large, dropped {notificationsPerMessage} values", notificationsPerMessage);
-                    yield break;
+                    continue;
                 }
                 NotificationsProcessedCount += (uint)notificationsPerMessage;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /
@@ -333,7 +333,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     // Message too large, drop it.
                     NotificationsDroppedCount += (uint)notificationsPerMessage;
                     _logger.Warning("Message too large, dropped {notificationsPerMessage} values", notificationsPerMessage);
-                    yield break;
+                    continue;
                 }
                 NotificationsProcessedCount += (uint)notificationsPerMessage;
                 AvgMessageSize = (AvgMessageSize * MessagesProcessedCount + encoded.Body.Length) /

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/NetworkMessageEncoder.cs
@@ -129,18 +129,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     notification.Encode(helperEncoder);
                     helperEncoder.Close();
                     var notificationSize = Encoding.UTF8.GetByteCount(helperWriter.ToString());
-                    notificationsPerMessage = notification.Messages.Sum(m => m.Payload.Count);
+                    var notificationsInBatch = notification.Messages.Sum(m => m.Payload.Count);
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
-                        NotificationsDroppedCount += (uint)notificationsPerMessage;
-                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values", notificationsPerMessage);
+                        NotificationsDroppedCount += (uint)notificationsInBatch;
+                        _logger.Warning("Message too large, dropped {notificationsInBatch} values", notificationsInBatch);
                         processing = current.MoveNext();
                     }
                     else {
                         messageCompleted = maxMessageSize < (messageSize + notificationSize);
                         if (!messageCompleted) {
                             chunk.Add(notification);
-                            NotificationsProcessedCount += (uint)notificationsPerMessage;
+                            NotificationsProcessedCount += (uint)notificationsInBatch;
+                            notificationsPerMessage += notificationsInBatch;
                             processing = current.MoveNext();
                             messageSize += notificationSize + (processing ? 1 : 0);
                         }
@@ -207,18 +208,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                     var helperEncoder = new BinaryEncoder(encodingContext);
                     helperEncoder.WriteEncodeable(null, notification);
                     var notificationSize = helperEncoder.CloseAndReturnBuffer().Length;
-                    notificationsPerMessage = notification.Messages.Sum(m => m.Payload.Count);
+                    var notificationsInBatch = notification.Messages.Sum(m => m.Payload.Count);
                     if (notificationSize > maxMessageSize) {
                         // Message too large, drop it.
-                        NotificationsDroppedCount += (uint)notificationsPerMessage;
-                        _logger.Warning("Message too large, dropped {notificationsPerMessage} values", notificationsPerMessage);
+                        NotificationsDroppedCount += (uint)notificationsInBatch;
+                        _logger.Warning("Message too large, dropped {notificationsInBatch} values", notificationsInBatch);
                         processing = current.MoveNext();
                     }
                     else {
                         messageCompleted = maxMessageSize < (messageSize + notificationSize);
                         if (!messageCompleted) {
                             chunk.Add(notification);
-                            NotificationsProcessedCount += (uint)notificationsPerMessage;
+                            NotificationsProcessedCount += (uint)notificationsInBatch;
+                            notificationsPerMessage += notificationsInBatch;
                             processing = current.MoveNext();
                             messageSize += notificationSize;
                         }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/MonitoredItemMessageEncoderTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/MonitoredItemMessageEncoderTests.cs
@@ -6,22 +6,21 @@
 namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine;
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
-    using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
     using Moq;
-    using Opc.Ua;
-    using Opc.Ua.Client;
     using Serilog;
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Xunit;
 
     public class MonitoredItemMessageEncoderTests {
+
+        private readonly Mock<ILogger> _loggerMock;
         private readonly MonitoredItemMessageEncoder _encoder;
 
         public MonitoredItemMessageEncoderTests() {
-            _encoder = new MonitoredItemMessageEncoder();
+            _loggerMock = new Mock<ILogger>();
+            _encoder = new MonitoredItemMessageEncoder(_loggerMock.Object);
         }
 
         [Theory]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/NetworkMessageEncoderTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/NetworkMessageEncoderTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class NetworkMessageEncoderTests {
@@ -30,14 +31,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void EmptyMessagesTest(bool encodeBatchFlag) {
+        public async Task EmptyMessagesTest(bool encodeBatchFlag) {
             var maxMessageSize = 256 * 1024;
             var messages = new List<DataSetMessageModel>();
 
-            var networkMessages = (encodeBatchFlag
+            var networkMessages = await (encodeBatchFlag
                 ?_encoder.EncodeBatchAsync(messages, maxMessageSize)
                 : _encoder.EncodeAsync(messages, maxMessageSize)
-            ).ConfigureAwait(false).GetAwaiter().GetResult();
+            );
 
             Assert.Empty(networkMessages);
             Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
@@ -48,14 +49,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void EmptyDataSetMessageModelTest(bool encodeBatchFlag) {
+        public async Task EmptyDataSetMessageModelTest(bool encodeBatchFlag) {
             var maxMessageSize = 256 * 1024;
             var messages = new[] { new DataSetMessageModel() };
 
-            var networkMessages = (encodeBatchFlag
+            var networkMessages = await (encodeBatchFlag
                 ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
                 : _encoder.EncodeAsync(messages, maxMessageSize)
-            ).ConfigureAwait(false).GetAwaiter().GetResult();
+            );
 
             Assert.Empty(networkMessages);
             Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
@@ -68,14 +69,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData(true, MessageEncoding.Json)]
         [InlineData(false, MessageEncoding.Uadp)]
         [InlineData(true, MessageEncoding.Uadp)]
-        public void EncodeTooBigMessageTest(bool encodeBatchFlag, MessageEncoding encoding) {
+        public async Task EncodeTooBigMessageTest(bool encodeBatchFlag, MessageEncoding encoding) {
             var maxMessageSize = 100;
             var messages = GenerateSampleMessages(3, encoding);
 
-            var networkMessages = (encodeBatchFlag
+            var networkMessages = await (encodeBatchFlag
                 ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
                 : _encoder.EncodeAsync(messages, maxMessageSize)
-            ).ConfigureAwait(false).GetAwaiter().GetResult().ToList();
+            );
 
             Assert.Empty(networkMessages);
             Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
@@ -88,24 +89,24 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData(true, MessageEncoding.Json)]
         [InlineData(false, MessageEncoding.Uadp)]
         [InlineData(true, MessageEncoding.Uadp)]
-        public void EncodeTest(bool encodeBatchFlag, MessageEncoding encoding) {
+        public async Task EncodeTest(bool encodeBatchFlag, MessageEncoding encoding) {
             var maxMessageSize = 256 * 1024;
             var messages = GenerateSampleMessages(20, encoding);
 
-            var networkMessages = (encodeBatchFlag
+            var networkMessages = await (encodeBatchFlag
                 ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
                 : _encoder.EncodeAsync(messages, maxMessageSize)
-            ).ConfigureAwait(false).GetAwaiter().GetResult().ToList();
+            );
 
             if (encodeBatchFlag) {
-                Assert.Equal(1, networkMessages.Count);
+                Assert.Equal(1, networkMessages.Count());
                 Assert.Equal((uint)210, _encoder.NotificationsProcessedCount);
                 Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
                 Assert.Equal((uint)1, _encoder.MessagesProcessedCount);
                 Assert.Equal(210, _encoder.AvgNotificationsPerMessage);
             }
             else {
-                Assert.Equal(20, networkMessages.Count);
+                Assert.Equal(20, networkMessages.Count());
                 Assert.Equal((uint)210, _encoder.NotificationsProcessedCount);
                 Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
                 Assert.Equal((uint)20, _encoder.MessagesProcessedCount);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/NetworkMessageEncoderTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/NetworkMessageEncoderTests.cs
@@ -1,0 +1,178 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
+    using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine;
+    using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
+    using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
+    using Microsoft.Azure.IIoT.OpcUa.Publisher.Models;
+    using Moq;
+    using Opc.Ua;
+    using Opc.Ua.Client;
+    using Serilog;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Xunit;
+
+    public class NetworkMessageEncoderTests {
+
+        private readonly Mock<ILogger> _loggerMock;
+        private readonly NetworkMessageEncoder _encoder;
+
+        public NetworkMessageEncoderTests() {
+            _loggerMock = new Mock<ILogger>();
+            _encoder = new NetworkMessageEncoder(_loggerMock.Object);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EmptyMessagesTest(bool encodeBatchFlag) {
+            var maxMessageSize = 256 * 1024;
+            var messages = new List<DataSetMessageModel>();
+
+            var networkMessages = (encodeBatchFlag
+                ?_encoder.EncodeBatchAsync(messages, maxMessageSize)
+                : _encoder.EncodeAsync(messages, maxMessageSize)
+            ).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            Assert.Empty(networkMessages);
+            Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
+            Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
+            Assert.Equal((uint)0, _encoder.MessagesProcessedCount);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EmptyDataSetMessageModelTest(bool encodeBatchFlag) {
+            var maxMessageSize = 256 * 1024;
+            var messages = new[] { new DataSetMessageModel() };
+
+            var networkMessages = (encodeBatchFlag
+                ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
+                : _encoder.EncodeAsync(messages, maxMessageSize)
+            ).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            Assert.Empty(networkMessages);
+            Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
+            Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
+            Assert.Equal((uint)0, _encoder.MessagesProcessedCount);
+        }
+
+        [Theory]
+        [InlineData(false, MessageEncoding.Json)]
+        [InlineData(true, MessageEncoding.Json)]
+        [InlineData(false, MessageEncoding.Uadp)]
+        [InlineData(true, MessageEncoding.Uadp)]
+        public void EncodeTooBigMessageTest(bool encodeBatchFlag, MessageEncoding encoding) {
+            var maxMessageSize = 100;
+            var messages = GenerateSampleMessages(3, encoding);
+
+            var networkMessages = (encodeBatchFlag
+                ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
+                : _encoder.EncodeAsync(messages, maxMessageSize)
+            ).ConfigureAwait(false).GetAwaiter().GetResult().ToList();
+
+            Assert.Empty(networkMessages);
+            Assert.Equal((uint)0, _encoder.NotificationsProcessedCount);
+            Assert.Equal((uint)6, _encoder.NotificationsDroppedCount);
+            Assert.Equal((uint)0, _encoder.MessagesProcessedCount);
+        }
+
+        [Theory]
+        [InlineData(false, MessageEncoding.Json)]
+        [InlineData(true, MessageEncoding.Json)]
+        [InlineData(false, MessageEncoding.Uadp)]
+        [InlineData(true, MessageEncoding.Uadp)]
+        public void EncodeTest(bool encodeBatchFlag, MessageEncoding encoding) {
+            var maxMessageSize = 256 * 1024;
+            var messages = GenerateSampleMessages(20, encoding);
+
+            var networkMessages = (encodeBatchFlag
+                ? _encoder.EncodeBatchAsync(messages, maxMessageSize)
+                : _encoder.EncodeAsync(messages, maxMessageSize)
+            ).ConfigureAwait(false).GetAwaiter().GetResult().ToList();
+
+            if (encodeBatchFlag) {
+                Assert.Equal(1, networkMessages.Count);
+                Assert.Equal((uint)210, _encoder.NotificationsProcessedCount);
+                Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
+                Assert.Equal((uint)1, _encoder.MessagesProcessedCount);
+                Assert.Equal(210, _encoder.AvgNotificationsPerMessage);
+            }
+            else {
+                Assert.Equal(20, networkMessages.Count);
+                Assert.Equal((uint)210, _encoder.NotificationsProcessedCount);
+                Assert.Equal((uint)0, _encoder.NotificationsDroppedCount);
+                Assert.Equal((uint)20, _encoder.MessagesProcessedCount);
+                Assert.Equal(10.5, _encoder.AvgNotificationsPerMessage);
+            }
+        }
+
+        private static IList<DataSetMessageModel> GenerateSampleMessages(
+            uint numOfMessages,
+            MessageEncoding encoding = MessageEncoding.Json
+        ) {
+            var messages = new List<DataSetMessageModel>();
+
+            for (uint i = 0; i < numOfMessages; i++) {
+                var suffix = $"-{i}";
+
+                var notifications = new List<MonitoredItemNotificationModel>();
+
+                for (uint k = 0; k < i + 1; k++) {
+                    var notificationSuffix = suffix + $"-{k}";
+
+                    var monitoredItemNotification = new MonitoredItemNotification {
+                        ClientHandle = k,
+                        Value = new DataValue(new Variant(k), new StatusCode(0), DateTime.UtcNow),
+                        Message = new NotificationMessage()
+                    };
+
+                    var monitoredItem = new MonitoredItem {
+                        DisplayName = "DisplayName" + notificationSuffix,
+                        StartNodeId = new NodeId("NodeId" + notificationSuffix),
+                        AttributeId = k
+                    };
+
+                    var notification = monitoredItemNotification.ToMonitoredItemNotification(monitoredItem);
+                    notifications.Add(notification);
+                }
+
+                var message = new DataSetMessageModel {
+                    SequenceNumber = i,
+                    PublisherId = "PublisherId" + suffix,
+                    Writer = new DataSetWriterModel {
+                        DataSet = new PublishedDataSetModel {
+                            DataSetSource = new PublishedDataSetSourceModel {
+                                PublishedVariables = new PublishedDataItemsModel {
+                                    PublishedData = new List<PublishedDataSetVariableModel>()
+                                }
+                            }
+                        }
+                    },
+                    WriterGroup = new WriterGroupModel {
+                        MessageSettings = new WriterGroupMessageSettingsModel {
+                            NetworkMessageContentMask = (NetworkMessageContentMask) 0xffff
+                        },
+                        MessageType = encoding
+                    },
+                    TimeStamp = DateTime.UtcNow,
+                    ServiceMessageContext = new ServiceMessageContext { },
+                    Notifications = notifications,
+                    SubscriptionId = "SubscriptionId" + suffix,
+                    EndpointUrl = "EndpointUrl" + suffix,
+                    ApplicationUri = "ApplicationUri" + suffix
+                };
+
+                messages.Add(message);
+            }
+
+            return messages;
+        }
+    }
+}


### PR DESCRIPTION
Changes:
* Fixed reporting of average notifications per message for `NetworkMessageEncoder`.
* Fixed bug in calls of `EncodeAsync()` methods of `NetworkMessageEncoder` and `MonitoredItemMessageEncoder` which caused further messages to be disregarded after one of the messages was too big to be encoded.
* Fixed bug in calls of `EncodeBatchAsync()` methods of `NetworkMessageEncoder` and `MonitoredItemMessageEncoder` which would generate an empty `NetworkMessageModel` at the end of processing even if there were no messages in the chunk.
* Added tests for reported metrics of `NetworkMessageEncoder` and `MonitoredItemMessageEncoder`.