### PR TITLE
IAI: Fixed Kubernetes version selection. Using 1.19.11 as fallback.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION_FALLBACK = "1.19.9";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.19.11";
         public const string KUBERNETES_VERSION_MAJ_MIN = "1.19";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;


### PR DESCRIPTION
Changes:
* Changed Kubernetes version selection logic to use APIs mentioned in [#1242](https://github.com/Azure/azure-libraries-for-net/issues/1242).
* Upgraded fallback version of Kubernetes from `1.19.9` to `1.19.11` as `1.19.9` version is being gradually deprecated from AKS regions now.