### PR TITLE
Removed bad nodes from E2E publisher test subscriptions.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
@@ -94,7 +94,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var testPlc = _context.SimulatedPublishedNodes[_context.ConsumedOpcUaNodes.First().Key];
 
-            // We will filter out bad fast and slow nodes as they to drop messages by design.
+            // We will filter out bad fast and slow nodes as they drop messages by design.
             _context.ConsumedOpcUaNodes.First().Value.OpcNodes = testPlc.OpcNodes
                 .Where(node => !node.Id.Contains("bad", StringComparison.OrdinalIgnoreCase))
                 .Skip(250).ToArray();
@@ -187,7 +187,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
 
             var testPlc = _context.SimulatedPublishedNodes[_context.ConsumedOpcUaNodes.First().Key];
 
-            // We will filter out bad fast and slow nodes as they to drop messages by design.
+            // We will filter out bad fast and slow nodes as they drop messages by design.
             _context.ConsumedOpcUaNodes.First().Value.OpcNodes = testPlc.OpcNodes
                 .Where(node => !node.Id.Contains("bad", StringComparison.OrdinalIgnoreCase))
                 .Skip(250).ToArray();

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
@@ -186,7 +186,12 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             var testPlc = _context.SimulatedPublishedNodes[_context.ConsumedOpcUaNodes.First().Key];
-            _context.ConsumedOpcUaNodes.First().Value.OpcNodes = testPlc.OpcNodes.Skip(250).ToArray();
+
+            // We will filter out bad fast and slow nodes as they to drop messages by design.
+            _context.ConsumedOpcUaNodes.First().Value.OpcNodes = testPlc.OpcNodes
+                .Where(node => !node.Id.Contains("bad", StringComparison.OrdinalIgnoreCase))
+                .Skip(250).ToArray();
+
             var body = new {
                 NodesToRemove = _context.ConsumedOpcUaNodes.First().Value.OpcNodes.Select(node => node.Id ).ToArray()
             };

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/TelemetryValidator.cs
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Businesslogic/TelemetryValidator.cs
@@ -289,6 +289,12 @@ namespace TestEventProcessor.BusinessLogic {
                     continue;
                 }
 
+                // OPC PLC contains bad fast and slow nodes that drop messages by design.
+                // We will ignore entries that do not have a value.
+                if (entryValue is null) {
+                    continue;
+                }
+
                 // Feed data to checkers.
                 _missingTimestampsChecker.ProcessEvent(entryNodeId, entrySourceTimestamp, entryValue);
                 _messageProcessingDelayChecker.ProcessEvent(entrySourceTimestamp, eventReceivedTimestamp);


### PR DESCRIPTION
OPC PLC now has bad nodes that drop messages by design. In this PR I have removed those bad nodes from E2E publisher tests to make sure that they don't interfere with our dropped and duplicate message detection logic.