### PR TITLE
Moving E2E pipelines to iotcat Azure DevOps organizatoin.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,3 +59,5 @@ stages:
   - build
   jobs:
   - template: tools/templates/e2e_tests.yml
+    parameters:
+      branchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,6 +57,10 @@ stages:
   condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
   - build
+  - pack
+  - iiot_deployment
+  - images
+  - coverage
   jobs:
   - template: tools/templates/e2e_tests.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ stages:
   - template: tools/templates/cc.yml
 - stage: e2e_tests
   displayName: 'Triggering E2E tests'
-  # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
   dependsOn:
   - build
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,3 +52,10 @@ stages:
   - build
   jobs:
   - template: tools/templates/cc.yml
+- stage: e2e_tests
+  displayName: 'Triggering E2E tests'
+  # condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  dependsOn:
+  - build
+  jobs:
+  - template: tools/templates/e2e_tests.yml

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.Service/TestEventProcessor.Service.csproj
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.Service/TestEventProcessor.Service.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TestEventProcessor.BusinessLogic\TestEventProcessor.BusinessLogic.csproj" />
+    <ProjectReference Include="..\TestEventProcessor.Businesslogic\TestEventProcessor.Businesslogic.csproj" />
   </ItemGroup>
 
 

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor.sln
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.30523.141
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestEventProcessor", "TestEventProcessor\TestEventProcessor.csproj", "{9A73DD25-978F-4C82-A63C-6D1968B38C32}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestEventProcessor.BusinessLogic", "TestEventProcessor.BusinessLogic\TestEventProcessor.BusinessLogic.csproj", "{088745BA-3A1D-487B-9FFE-A75F59938147}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestEventProcessor.BusinessLogic", "TestEventProcessor.Businesslogic\TestEventProcessor.Businesslogic.csproj", "{088745BA-3A1D-487B-9FFE-A75F59938147}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestEventProcessor.Service", "TestEventProcessor.Service\TestEventProcessor.Service.csproj", "{8FBF91D6-3B8B-4726-B1A8-E8548B3EB8DF}"
 EndProject

--- a/tools/e2etesting/TestEventProcessor/TestEventProcessor/TestEventProcessor.csproj
+++ b/tools/e2etesting/TestEventProcessor/TestEventProcessor/TestEventProcessor.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TestEventProcessor.BusinessLogic\TestEventProcessor.BusinessLogic.csproj" />
+    <ProjectReference Include="..\TestEventProcessor.Businesslogic\TestEventProcessor.Businesslogic.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -12,17 +12,17 @@ schedules:
     - releases
   always: true
 
-# Trigger Orchestrated E2E Pipeline post completion of build pipeline.
-resources:
-  pipelines:
-  - pipeline: Orchestrated-E2E-CD-Pipeline
-    source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
-    trigger:
-      branches:
-        include:
-        - refs/heads/releases
-        - refs/heads/release/*
-        - refs/heads/main
+# # Trigger Orchestrated E2E Pipeline post completion of build pipeline.
+# resources:
+#   pipelines:
+#   - pipeline: Orchestrated-E2E-CD-Pipeline
+#     source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
+#     trigger:
+#       branches:
+#         include:
+#         - refs/heads/releases
+#         - refs/heads/release/*
+#         - refs/heads/main
 
 pool:
   name: '$(AgentPool)'

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -26,6 +26,8 @@ schedules:
 
 pool:
   name: '$(AgentPool)'
+  demands:
+  - agent.name -equals $(AgentName)
 
 variables:
 - template: steps/variables.yml

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -12,6 +12,9 @@ schedules:
     - releases
   always: true
 
+# # Pipeline completion triggers work only for pipelines within the same organization.
+# # We will trigger this pipeline via a REST API call from the main pipeline.
+#
 # # Trigger Orchestrated E2E Pipeline post completion of build pipeline.
 # resources:
 #   pipelines:

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -68,12 +68,8 @@ stages:
 
   - job: deploytestresources
     condition: and(eq(dependencies.deployplatform.result, 'Succeeded'), or(eq(dependencies.deploynestedtestresources.result, 'Succeeded'), eq(dependencies.deploynestedtestresources.result, 'Skipped')))
-    dependsOn:
-      - deployplatform
-      - deploynestedtestresources
+    dependsOn: deploynestedtestresources
     displayName: 'Deploy Test Resources'
-    pool:
-      name: '$(AgentPool)'
     steps:
     - template: steps/deploytestresources.yml
 

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -27,7 +27,7 @@ schedules:
 pool:
   name: '$(AgentPool)'
   demands:
-  - agent.name -equals $(AgentName)
+  - agent.os -equals Windows_NT
 
 variables:
 - template: steps/variables.yml

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -13,6 +13,9 @@ schedules:
     - releases
   always: true
 
+# # Pipeline completion triggers work only for pipelines within the same organization.
+# # We will trigger this pipeline via a REST API call from the main pipeline.
+#
 # # Trigger Stand Alone E2E Pipeline post completion of build pipeline.
 # resources:
 #   pipelines:

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -13,19 +13,22 @@ schedules:
     - releases
   always: true
 
-# Trigger Stand Alone E2E Pipeline post completion of build pipeline.
-resources:
-  pipelines:
-  - pipeline: Standalone-E2E-CD-Pipeline
-    source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
-    trigger:
-      branches:
-        include:
-        - refs/heads/releases
-        - refs/heads/release/*
-        - refs/heads/main
+# # Trigger Stand Alone E2E Pipeline post completion of build pipeline.
+# resources:
+#   pipelines:
+#   - pipeline: Standalone-E2E-CD-Pipeline
+#     source: Custom\Azure_IOT\Industrial\Components\Azure.Industrial-IoT
+#     trigger:
+#       branches:
+#         include:
+#         - refs/heads/releases
+#         - refs/heads/release/*
+#         - refs/heads/main
+
 pool:
   name: '$(AgentPool)'
+  demands:
+  - agent.os -equals Windows_NT
 
 variables:
 - template: steps/variables.yml

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -5,6 +5,7 @@ variables:
   AgentPool: Azure-IoT-Manufacturing
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
-  Runtime: 'win-x64'
+  # Runtime: 'win-x64'
+  Runtime: 'linux-x64 '
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
     BranchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -3,7 +3,6 @@ variables:
   ClientCredentialsKeyVaultName: automatedtesting
   AzureSubscription: IOT-OPC-WALLS-SP # Use Services-Connection with Service-Principal-Authentication as subscription
   AgentPool: Azure-IoT-Manufacturing
-  AgentName: iiot-win-opcplc1
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
   Runtime: 'win-x64'

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -6,6 +6,5 @@ variables:
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
   Runtime: 'win-x64'
-  # Runtime: 'linux-x64 '
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
     BranchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -3,9 +3,10 @@ variables:
   ClientCredentialsKeyVaultName: automatedtesting
   AzureSubscription: IOT-OPC-WALLS-SP # Use Services-Connection with Service-Principal-Authentication as subscription
   AgentPool: Azure-IoT-Manufacturing
+  AgentName: iiot-win-opcplc1
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
-  # Runtime: 'win-x64'
-  Runtime: 'linux-x64 '
+  Runtime: 'win-x64'
+  # Runtime: 'linux-x64 '
   ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/') }}:
     BranchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]

--- a/tools/templates/build_iiot_deployment.yml
+++ b/tools/templates/build_iiot_deployment.yml
@@ -1,5 +1,5 @@
 parameters:
-  runtime: 'win-x64' 
+  runtime: 'win-x64'
 
 steps:
 - task: UseDotNet@2

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -9,10 +9,6 @@ parameters:
   e2eStandalonePipelineId: 21
   branchName: main
 
-# variables:
-# - name: branchName
-#   value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
-
 jobs:
 - job: buildprep
   displayName: Triggering E2E tests

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -13,6 +13,7 @@ jobs:
       connectionType: 'connectedServiceName' # Options: connectedServiceName, connectedServiceNameARM
       serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting-Orchestrated # Required when connectionType == ConnectedServiceName
       method: 'POST'
+      urlSuffix: /runs?api-version=6.0-preview.1
       headers: '{Content-Type:application/json}'
       body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
       waitForCompletion: 'false' # Options: true, false

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -1,20 +1,35 @@
+#
+# Triggering the following E2E pipelines in iotcat:
+# - Azure.Industrial-IoT-E2ETesting-Orchestrated
+# - Azure.Industrial-IoT-E2ETesting-Standalone
+#
+
+parameters:
+  e2eOrchestratedPipelineId: 20
+  e2eStandalonePipelineId: 21
+
 jobs:
 - job: buildprep
   displayName: Triggering E2E tests
   pool: server
-#   pool:
-#     vmImage: 'windows-2019'
-#   variables:
-#     secret: tbd
   steps:
   - task: InvokeRESTAPI@1
     displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Orchestrated'
     inputs:
-      connectionType: 'connectedServiceName' # Options: connectedServiceName, connectedServiceNameARM
-      serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting-Orchestrated # Required when connectionType == ConnectedServiceName
+      connectionType: 'connectedServiceName'
+      serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting
       method: 'POST'
-      urlSuffix: /runs?api-version=6.0-preview.1
+      urlSuffix: ${{ parameters.e2eOrchestratedPipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
       body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
-      waitForCompletion: 'false' # Options: true, false
-      #successCriteria: # Optional
+      waitForCompletion: 'false'
+  - task: InvokeRESTAPI@1
+    displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Standalone'
+    inputs:
+      connectionType: 'connectedServiceName'
+      serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting
+      method: 'POST'
+      urlSuffix: ${{ parameters.e2eStandalonePipelineId }}/runs?api-version=6.0-preview.1
+      headers: '{ "Content-Type": "application/json" }'
+      body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
+      waitForCompletion: 'false'

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -14,7 +14,7 @@ jobs:
       serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting-Orchestrated # Required when connectionType == ConnectedServiceName
       method: 'POST'
       urlSuffix: /runs?api-version=6.0-preview.1
-      headers: '{Content-Type:application/json}'
+      headers: '{ "Content-Type": "application/json" }'
       body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
       waitForCompletion: 'false' # Options: true, false
       #successCriteria: # Optional

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -7,7 +7,10 @@
 parameters:
   e2eOrchestratedPipelineId: 20
   e2eStandalonePipelineId: 21
-  branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+
+variables:
+- name: branchName
+  value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 jobs:
 - job: buildprep
@@ -22,7 +25,7 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eOrchestratedPipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "$(branchName)" }}}}'
       waitForCompletion: 'false'
   - task: InvokeRESTAPI@1
     displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Standalone'
@@ -32,5 +35,5 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eStandalonePipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "$(branchName)" }}}}'
       waitForCompletion: 'false'

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -1,0 +1,19 @@
+jobs:
+- job: buildprep
+  displayName: Triggering E2E tests
+  pool: server
+#   pool:
+#     vmImage: 'windows-2019'
+#   variables:
+#     secret: tbd
+  steps:
+  - task: InvokeRESTAPI@1
+    displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Orchestrated'
+    inputs:
+      connectionType: 'connectedServiceName' # Options: connectedServiceName, connectedServiceNameARM
+      serviceConnection: iotcat-Azure.Industrial-IoT-E2ETesting-Orchestrated # Required when connectionType == ConnectedServiceName
+      method: 'POST'
+      headers: '{Content-Type:application/json}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
+      waitForCompletion: 'false' # Options: true, false
+      #successCriteria: # Optional

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -7,6 +7,7 @@
 parameters:
   e2eOrchestratedPipelineId: 20
   e2eStandalonePipelineId: 21
+  branchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
 
 # variables:
 # - name: branchName
@@ -25,7 +26,7 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eOrchestratedPipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "$( replace(variables['Build.SourceBranch'], 'refs/heads/', '') )" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
       waitForCompletion: 'false'
   - task: InvokeRESTAPI@1
     displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Standalone'
@@ -35,5 +36,5 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eStandalonePipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "$( replace(variables['Build.SourceBranch'], 'refs/heads/', '') )" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
       waitForCompletion: 'false'

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -7,6 +7,7 @@
 parameters:
   e2eOrchestratedPipelineId: 20
   e2eStandalonePipelineId: 21
+  branchName: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 jobs:
 - job: buildprep
@@ -21,7 +22,7 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eOrchestratedPipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
       waitForCompletion: 'false'
   - task: InvokeRESTAPI@1
     displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Standalone'
@@ -31,5 +32,5 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eStandalonePipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "kakostan/iotcat" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "${{ parameters.branchName }}" }}}}'
       waitForCompletion: 'false'

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -8,9 +8,9 @@ parameters:
   e2eOrchestratedPipelineId: 20
   e2eStandalonePipelineId: 21
 
-variables:
-- name: branchName
-  value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
+# variables:
+# - name: branchName
+#   value: $[ replace(variables['Build.SourceBranch'], 'refs/heads/', '') ]
 
 jobs:
 - job: buildprep
@@ -25,7 +25,7 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eOrchestratedPipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "$(branchName)" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "$( replace(variables['Build.SourceBranch'], 'refs/heads/', '') )" }}}}'
       waitForCompletion: 'false'
   - task: InvokeRESTAPI@1
     displayName: 'Trigger Azure.Industrial-IoT-E2ETesting-Standalone'
@@ -35,5 +35,5 @@ jobs:
       method: 'POST'
       urlSuffix: ${{ parameters.e2eStandalonePipelineId }}/runs?api-version=6.0-preview.1
       headers: '{ "Content-Type": "application/json" }'
-      body: '{ "resources": { "repositories": { "self": { "refName": "$(branchName)" }}}}'
+      body: '{ "resources": { "repositories": { "self": { "refName": "$( replace(variables['Build.SourceBranch'], 'refs/heads/', '') )" }}}}'
       waitForCompletion: 'false'

--- a/tools/templates/e2e_tests.yml
+++ b/tools/templates/e2e_tests.yml
@@ -7,7 +7,7 @@
 parameters:
   e2eOrchestratedPipelineId: 20
   e2eStandalonePipelineId: 21
-  branchName: ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}
+  branchName: main
 
 # variables:
 # - name: branchName

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -3,7 +3,7 @@
 #
 parameters:
   runtime: linux-x64
-  poolName: 'Hosted Ubuntu 1604'
+  poolName: 'Hosted Ubuntu 1804'
 
 jobs:
 - job: iiot_deployment_linux

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -3,13 +3,13 @@
 #
 parameters:
   runtime: linux-x64
-  poolName: 'Hosted Ubuntu 1804'
+  vmImage: ubuntu-18.04
 
 jobs:
 - job: iiot_deployment_linux
   displayName: Generate Linux Executables
   pool:
-    name: ${{ parameters.poolName }}
+    vmImage: ${{ parameters.vmImage }}
   steps:
   - template: build_iiot_deployment.yml
     parameters:

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -3,13 +3,13 @@
 #
 parameters:
   runtime: 'osx-x64'
-  poolName: 'Hosted macOS'
+  vmImage: macOS-10.15
 
 jobs:
 - job: iiot_deployment_mac
   displayName: Generate MacOS Executables
   pool:
-    name: ${{ parameters.poolName }}
+    vmImage: ${{ parameters.vmImage }}
   steps:
   - template: build_iiot_deployment.yml
     parameters:

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -4,13 +4,13 @@
 parameters:
   sign: 'False'
   runtime: win-x64
-  poolName: 'Hosted Windows 2019 with VS2019'
+  vmImage: windows-2019
 
 jobs:
 - job: iiot_deployment_win
   displayName: Generate Windows Executables
   pool:
-    name: ${{ parameters.poolName }}
+    vmImage: ${{ parameters.vmImage }}
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET Core SDK for signing'


### PR DESCRIPTION
Moving E2E orchestrated and standalone pipelines to run in `iotcat` organization. The reason for the move is that for our integration tests we need custom build agents and in `One` organization those custom agents are no longer allowed.

Changes:
- Triggering of both E2E pipelines is now done via a REST API call since pipeline completion triggers that were used previously work only for pipeline within the same organization.
- Fixed paths of some `csproj` files.