### PR TITLE
Upgraded JsonSchema.Net NuGet package to 1.11.3 version.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="1.10.7" />
+    <PackageReference Include="JsonSchema.Net" Version="1.11.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded `JsonSchema.Net` NuGet package to `1.11.3` version as it is the root package for `System.Text.Encodings.Web` NuGet which has a vulnerability.