### PR TITLE
Upgraded several NuGet packages to fix two vulnerabilities.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
@@ -5,8 +5,8 @@
     <Description>Azure Industrial IoT common ASP.net Core abstractions and utilities</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.18" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.14" />

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSchema.Net" Version="1.11.3" />
+    <!-- Explicit reference to System.Text.Encodings.Web 4.7.2 is required as
+    there is a vulnerability in 4.7.1 that is picked up by default.
+    This can be removed once JsonSchema.Net references patched version of the package. -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.19" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Using `4.7.2` version of `System.Text.Encodings.Web` NuGet package to fix [CVE-2021-26701](https://github.com/advisories/GHSA-ghhp-997w-qr28).
Using `3.1.19` version of `Microsoft.AspNetCore.Authentication.*` NuGet packages to fix [CVE-2021-34532](https://github.com/advisories/GHSA-q7cg-43mg-qp69). 