### PR TITLE
Improve encoding for events

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Extensions/MonitoredItemNotificationModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Extensions/MonitoredItemNotificationModelEx.cs
@@ -146,35 +146,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Models {
             if (eventFields == null) {
                 return new DataValue(StatusCodes.BadNoData);
             }
-
             return new DataValue {
-                ServerPicoseconds = 0,
-                ServerTimestamp = eventFields.GetEventValue<DateTime>(
-                    BrowseNames.Time, monitoredItem),
-                SourcePicoseconds = 0,
-                SourceTimestamp = eventFields.GetEventValue<DateTime>(
-                    BrowseNames.ReceiveTime, monitoredItem),
-                StatusCode = eventFields.GetEventValue<StatusCode>(
-                    BrowseNames.StatusCode, monitoredItem),
                 Value = new EncodeableDictionary(eventFields.EventFields
                     .Select((value, i) => new KeyDataValuePair {
                         Key = SubscriptionServices.GetFieldDisplayName(monitoredItem, i),
                         Value = new DataValue(value)
                     }))
             };
-        }
-
-        /// <summary>
-        /// Returns value of the field name containing the event type.
-        /// </summary>
-        public static T GetEventValue<T>(this EventFieldList eventFields, string name,
-            MonitoredItem monitoredItem, T defaultValue = default) {
-            // get value
-            var value = monitoredItem.GetFieldValue(eventFields, ObjectTypes.BaseEventType, name);
-            if (value != null) {
-                return value.As<T>();
-            }
-            return defaultValue;
         }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -1183,18 +1183,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
 
                     // let's keep track of the internal fields we add so that they don't show up in the output
                     var internalSelectClauses = new List<SimpleAttributeOperand>();
-
-                    // Add SourceTimestamp and ServerTimestamp select clauses.
-                    if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == BrowseNames.Time)) {
-                        var selectClause = new SimpleAttributeOperand(ObjectTypeIds.BaseEventType, BrowseNames.Time);
-                        eventFilter.SelectClauses.Add(selectClause);
-                        internalSelectClauses.Add(selectClause);
-                    }
-                    if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == BrowseNames.ReceiveTime)) {
-                        var selectClause = new SimpleAttributeOperand(ObjectTypeIds.BaseEventType, BrowseNames.ReceiveTime);
-                        eventFilter.SelectClauses.Add(selectClause);
-                        internalSelectClauses.Add(selectClause);
-                    }
                     if (!eventFilter.SelectClauses.Any(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType && x.BrowsePath?.FirstOrDefault() == BrowseNames.EventType)) {
                         var selectClause = new SimpleAttributeOperand(ObjectTypeIds.BaseEventType, BrowseNames.EventType);
                         eventFilter.SelectClauses.Add(selectClause);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Services/GetSimpleEventFilterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Services/GetSimpleEventFilterTests.cs
@@ -33,15 +33,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             var eventFilter = (EventFilter)monitoredItemWrapper.Item.Filter;
 
             Assert.NotNull(eventFilter.SelectClauses);
-            Assert.Equal(4, eventFilter.SelectClauses.Count);
+            Assert.Equal(2, eventFilter.SelectClauses.Count);
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[0].TypeDefinitionId);
             Assert.Equal(BrowseNames.Message, eventFilter.SelectClauses[0].BrowsePath.ElementAtOrDefault(0));
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[1].TypeDefinitionId);
-            Assert.Equal(BrowseNames.Time, eventFilter.SelectClauses[1].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[2].TypeDefinitionId);
-            Assert.Equal(BrowseNames.ReceiveTime, eventFilter.SelectClauses[2].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[3].TypeDefinitionId);
-            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[3].BrowsePath.ElementAtOrDefault(0));
+            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[1].BrowsePath.ElementAtOrDefault(0));
 
             Assert.NotNull(eventFilter.WhereClause);
             Assert.NotNull(eventFilter.WhereClause.Elements);
@@ -74,7 +70,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             var eventFilter = (EventFilter)monitoredItemWrapper.Item.Filter;
 
             Assert.NotNull(eventFilter.SelectClauses);
-            Assert.Equal(9, eventFilter.SelectClauses.Count);
+            Assert.Equal(7, eventFilter.SelectClauses.Count);
             Assert.Equal(Attributes.NodeId, eventFilter.SelectClauses[0].AttributeId);
             Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[0].TypeDefinitionId);
             Assert.Empty(eventFilter.SelectClauses[0].BrowsePath);
@@ -90,11 +86,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[5].TypeDefinitionId);
             Assert.Equal(BrowseNames.Message, eventFilter.SelectClauses[5].BrowsePath.ElementAtOrDefault(0));
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[6].TypeDefinitionId);
-            Assert.Equal(BrowseNames.Time, eventFilter.SelectClauses[6].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[7].TypeDefinitionId);
-            Assert.Equal(BrowseNames.ReceiveTime, eventFilter.SelectClauses[7].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[8].TypeDefinitionId);
-            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[8].BrowsePath.ElementAtOrDefault(0));
+            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[6].BrowsePath.ElementAtOrDefault(0));
 
             Assert.NotNull(eventFilter.WhereClause);
             Assert.NotNull(eventFilter.WhereClause.Elements);
@@ -130,7 +122,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             var eventFilter = (EventFilter)monitoredItemWrapper.Item.Filter;
 
             Assert.NotNull(eventFilter.SelectClauses);
-            Assert.Equal(10, eventFilter.SelectClauses.Count);
+            Assert.Equal(8, eventFilter.SelectClauses.Count);
             Assert.Equal(Attributes.NodeId, eventFilter.SelectClauses[0].AttributeId);
             Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[0].TypeDefinitionId);
             Assert.Empty(eventFilter.SelectClauses[0].BrowsePath);
@@ -146,13 +138,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[5].TypeDefinitionId);
             Assert.Equal(BrowseNames.Message, eventFilter.SelectClauses[5].BrowsePath.ElementAtOrDefault(0));
             Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[6].TypeDefinitionId);
-            Assert.Equal(BrowseNames.Time, eventFilter.SelectClauses[6].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[7].TypeDefinitionId);
-            Assert.Equal(BrowseNames.ReceiveTime, eventFilter.SelectClauses[7].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[8].TypeDefinitionId);
-            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[8].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[9].TypeDefinitionId);
-            Assert.Equal(BrowseNames.Retain, eventFilter.SelectClauses[9].BrowsePath.ElementAtOrDefault(0));
+            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[6].BrowsePath.ElementAtOrDefault(0));
+            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[7].TypeDefinitionId);
+            Assert.Equal(BrowseNames.Retain, eventFilter.SelectClauses[7].BrowsePath.ElementAtOrDefault(0));
 
             Assert.NotNull(eventFilter.WhereClause);
             Assert.NotNull(eventFilter.WhereClause.Elements);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Services/MonitoredItemWrapperTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Services/MonitoredItemWrapperTests.cs
@@ -124,25 +124,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
         }
 
         [Fact]
-        public void AddTimestampSelectClausesWhenBaseTemplateIsEventTemplate() {
-            var template = new EventMonitoredItemModel();
-            var monitoredItemWrapper = GetMonitoredItemWrapper(template);
-
-            Assert.NotNull(monitoredItemWrapper.Item.Filter);
-            Assert.IsType<EventFilter>(monitoredItemWrapper.Item.Filter);
-
-            var eventFilter = (EventFilter)monitoredItemWrapper.Item.Filter;
-            Assert.NotNull(eventFilter.SelectClauses);
-            Assert.Equal(3, eventFilter.SelectClauses.Count);
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[0].TypeDefinitionId);
-            Assert.Equal(BrowseNames.Time, eventFilter.SelectClauses[0].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[1].TypeDefinitionId);
-            Assert.Equal(BrowseNames.ReceiveTime, eventFilter.SelectClauses[1].BrowsePath.ElementAtOrDefault(0));
-            Assert.Equal(ObjectTypeIds.BaseEventType, eventFilter.SelectClauses[2].TypeDefinitionId);
-            Assert.Equal(BrowseNames.EventType, eventFilter.SelectClauses[2].BrowsePath.ElementAtOrDefault(0));
-        }
-
-        [Fact]
         public void AddConditionTypeSelectClausesWhenPendingAlarmsIsSetInEventTemplate() {
             var template = new EventMonitoredItemModel {
                 PendingAlarms = new PendingAlarmsOptionsModel {
@@ -156,13 +137,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
 
             var eventFilter = (EventFilter)monitoredItemWrapper.Item.Filter;
             Assert.NotNull(eventFilter.SelectClauses);
-            Assert.Equal(5, eventFilter.SelectClauses.Count);
-            Assert.Equal(Attributes.NodeId, eventFilter.SelectClauses[3].AttributeId);
-            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[3].TypeDefinitionId);
-            Assert.Empty(eventFilter.SelectClauses[3].BrowsePath);
-            Assert.Equal(Attributes.Value, eventFilter.SelectClauses[4].AttributeId);
-            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[4].TypeDefinitionId);
-            Assert.Equal("Retain", eventFilter.SelectClauses[4].BrowsePath.FirstOrDefault());
+            Assert.Equal(3, eventFilter.SelectClauses.Count);
+            Assert.Equal(Attributes.NodeId, eventFilter.SelectClauses[1].AttributeId);
+            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[1].TypeDefinitionId);
+            Assert.Empty(eventFilter.SelectClauses[1].BrowsePath);
+            Assert.Equal(Attributes.Value, eventFilter.SelectClauses[2].AttributeId);
+            Assert.Equal(ObjectTypeIds.ConditionType, eventFilter.SelectClauses[2].TypeDefinitionId);
+            Assert.Equal("Retain", eventFilter.SelectClauses[2].BrowsePath.FirstOrDefault());
         }
 
         [Fact]

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             // Assert
             Assert.Single(messages);
             Assert.Equal("i=2253", messages[0].RootElement[0].GetProperty("NodeId").GetString());
-            Assert.NotEmpty(messages[0].RootElement[0].GetProperty("Value").GetProperty("Value").GetProperty("EventId").GetString());
+            Assert.NotEmpty(messages[0].RootElement[0].GetProperty("Value").GetProperty("EventId").GetString());
         }
 
         [Theory]

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
 
             // Assert
             Assert.All(messages, m => {
-                var value = m.GetProperty("Payload").GetProperty("SimpleEvents").GetProperty("Value");
+                var value = m.GetProperty("Payload").GetProperty("SimpleEvents");
                 var eventId = value.GetProperty(kEventId);
                 var message = value.GetProperty(kMessage);
                 var cycleId = value.GetProperty(kCycleId);
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
 
             // Assert
             Assert.All(messages, m => {
-                var value = m.GetProperty("Payload").GetProperty("SimpleEvents").GetProperty("Value");
+                var value = m.GetProperty("Payload").GetProperty("SimpleEvents");
                 var type = value.GetProperty("Type").GetString();
                 var body = value.GetProperty("Body");
                 Assert.Equal("ExtensionObject", type);
@@ -112,7 +112,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             Assert.All(messages, m => {
                 var json = m.GetProperty("Payload")
                     .GetProperty("SimpleEvents")
-                    .GetProperty("Value")
                     .GetProperty("Body")
                     .GetProperty("Body")
                     .GetRawText();


### PR DESCRIPTION
Remove redundant fields (ServerTimestamp and SourceTimestamp). If wanted, they can be included in the SelectClauses to be part of the payload instead. Aligns better with specification (as there is no ServerTimestamp or SourceTimestamp on BaseEventType). 

The specification for BaseEventType is available [here](https://reference.opcfoundation.org/v104/Core/docs/Part5/6.4.2/). If Time and ReceiveTime is wanted, it should be retrieved with the appropriate SelectClauses (see [spec](https://reference.opcfoundation.org/v104/Core/docs/Part4/7.17.3/)) instead (and not mandatory by the OPC Publisher). For example:

```json
[
    {
        "EndpointUrl": "...",
        "UseSecurity": false,
        "OpcEvents": [
            {
                "Id": "ns=0;i=2253",
                "DisplayName": "...",
                "SelectClauses": [
                    {
                        "TypeDefinitionId": "i=2041",
                        "BrowsePath": [
                            "EventId"
                        ]
                    },
                    {
                        "TypeDefinitionId": "i=2041",
                        "BrowsePath": [
                            "Message"
                        ]
                    },
                    {
                        "TypeDefinitionId": "i=2041",
                        "BrowsePath": [
                            "Time"
                        ]
                    },
                    {
                        "TypeDefinitionId": "i=2041",
                        "BrowsePath": [
                            "ReceiveTime"
                        ]
                    }
                ],
                "WhereClause": {
                    "Elements": [
                        {
                            "FilterOperator": "OfType",
                            "FilterOperands": [
                                {
                                    "Value": "ns=2;i=235"
                                }
                            ]
                        }
                    ]
                }
            }
        ]
    }
]
```
