### PR TITLE
Fix E2E tests for events after encoding change

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventNamespaceTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_EventNamespaceTestTheory.cs
@@ -104,7 +104,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
         }
 
         private static void VerifyPayloads(PubSubMessages<SystemCycleStatusEventTypePayload> payloads) {
-            foreach (var payload in payloads.Select(x => x.Value.Value)) {
+            foreach (var payload in payloads.Select(x => x.Value)) {
                 payload.Message.Should().Match("The system cycle '*' has started.");
                 payload.CycleId.Should().MatchRegex("^\\d+$");
             }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishSingleNodeStandaloneEventsTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishSingleNodeStandaloneEventsTestTheory.cs
@@ -39,7 +39,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 .FirstAsync(_timeoutToken);
 
             var payload = firstMessage.Messages["SimpleEvents"];
-            var data = payload.Value;
+            var data = payload;
             Assert.NotEmpty(data.EventId);
             Assert.StartsWith("The system cycle '", data.Message);
             Assert.EndsWith("' has started.", data.Message);
@@ -66,9 +66,9 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 TestConstants.PublishedNodesConfigurations.SimpleEventFilter());
             await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(pnJson, _context, _timeoutToken);
 
-            const int nMessages = 6; 
+            const int nMessages = 6;
             var payloads = await messages
-                .Select(e => e.Messages["i=2253"].Value)
+                .Select(e => e.Messages["i=2253"])
                 .Skip(nMessages) // First batch of alarms are from a ConditionRefresh, therefore not in order
                 .SkipWhile(c => !c.Message.Contains("LAST EVENT IN LOOP"))
                 .Skip(1)

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_WhereClauseTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_WhereClauseTestTheory.cs
@@ -97,10 +97,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 .First()
                     .Children()
                         .First()
-                            .Children()
-                                .First()
-                                    .Children()
-                                        .First();
+                            .Children();
             Assert.NotNull(fields);
             Assert.Equal(8, fields.Count());
             Assert.True(fields.Where(x => x.Path.EndsWith("EventId")).Any());
@@ -119,10 +116,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 .First()
                     .Children()
                         .First()
-                            .Children()
-                                .First()
-                                    .Children()
-                                        .First();
+                            .Children();
             Assert.NotNull(fields);
             Assert.Equal(4, fields.Count());
             Assert.True(fields.Where(x => x.Path.EndsWith("EventId")).Any());

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PubSubMessages.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PubSubMessages.cs
@@ -34,17 +34,7 @@ namespace IIoTPlatform_E2E_Tests.TestModels {
 
     /// <summary>Message sent by Publisher to IoT Hub.</summary>
     /// <typeparam name="T">Payload type.</typeparam>
-    public class PubSubMessages<T> : Dictionary<string, PubSubMessage<T>> where T : BaseEventTypePayload {
-    }
-
-    /// <summary>Container for payload.</summary>
-    /// <typeparam name="T">Payload type.</typeparam>
-    public class PubSubMessage<T> {
-        /// <summary>Message payload.</summary>
-        public T Value { get; set; }
-
-        /// <summary>Source timestamp.</summary>
-        public DateTime SourceTimestamp { get; set; }
+    public class PubSubMessages<T> : Dictionary<string, T> where T : BaseEventTypePayload {
     }
 
     /// <summary>Base class for payload types.</summary>
@@ -75,7 +65,6 @@ namespace IIoTPlatform_E2E_Tests.TestModels {
 
         /// <summary>Gets or sets the receive time.</summary>
         public DateTime? ReceiveTime { get; set; }
-
 
         /// <summary>Gets or sets the local time.</summary>
         public DateTime? LocalTime { get; set; }


### PR DESCRIPTION
Previous PR made a slight change to the encoding of events to align better with specification. See [here](https://github.com/Azure/Industrial-IoT/pull/1423). The E2E tests need to be changed to support this.