### PR TITLE
Fix issue with long name issue for publisher #1385

### DIFF
--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Program.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
                 .AddJsonFile("appsettings.json", true)
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
-                .AddLegacyPublisherCommandLine(args)
                 .AddCommandLine(args)
+                .AddLegacyPublisherCommandLine(args) // making sure the Legacy arguments are processed at last so they are not overriden
                 .Build();
 
 #if DEBUG

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         (bool b) => this[LegacyCliConfigKeys.SkipFirstDefault] = b.ToString() },
 
                     { "fm|fullfeaturedmessage=", "The full featured mode for messages (all fields filled in)." +
-                        "Default is 'true', for legacy compatibility use 'false'",
+                        "Default is 'false' for legacy compatibility.",
                         (bool b) => this[LegacyCliConfigKeys.FullFeaturedMessage] = b.ToString() },
 
                     // Client settings
@@ -192,6 +192,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                     { "vc|verboseconsole=", "Legacy - do not use.", _ => {} },
                     { "as|autotrustservercerts=", "Legacy - do not use.", _ => {} }
                 };
+            
             options.Parse(args);
 
             Config = ToAgentConfigModel();
@@ -311,7 +312,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             };
         }
 
-        private AgentConfigModel ToAgentConfigModel() {
+        private static AgentConfigModel ToAgentConfigModel() {
             return new AgentConfigModel {
                 AgentId = "StandalonePublisher",
                 Capabilities = new Dictionary<string, string>(),
@@ -330,6 +331,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             return (T)converter.ConvertFrom(this[key]);
         }
 
-        private LegacyCliModel _legacyCliModel = null;
+        private LegacyCliModel _legacyCliModel;
     }
 }


### PR DESCRIPTION
addressing #1385
* when publisher CLI arguments are provided as longnames, they with config settings ending up being ignored. The issue is fixed now by changing the order of processing the arguments.
 * correction of the default value of `fullfeaturedmessage ` argument.
