### PR TITLE
Fixed schema of IdentifierUris.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/ApplicationsManager.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/ApplicationsManager.cs
@@ -531,7 +531,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     DisplayName = serviceApplicationName,
                     IsFallbackPublicClient = false,
                     IdentifierUris = new List<string> {
-                        $"https://{_tenantId.ToString()}/{serviceApplicationName}"
+                        $"api://{_tenantId.ToString()}/{serviceApplicationName}"
                     },
                     Tags = tags,
                     SignInAudience = "AzureADMyOrg",
@@ -728,7 +728,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     DisplayName = clientApplicationName,
                     IsFallbackPublicClient = true,
                     IdentifierUris = new List<string> {
-                        $"https://{_tenantId.ToString()}/{clientApplicationName}"
+                        $"api://{_tenantId.ToString()}/{clientApplicationName}"
                     },
                     Tags = tags,
                     SignInAudience = "AzureADMyOrg",
@@ -823,7 +823,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     DisplayName = aksApplicationName,
                     IsFallbackPublicClient = false,
                     IdentifierUris = new List<string> {
-                        $"https://{_tenantId.ToString()}/{aksApplicationName}"
+                        $"api://{_tenantId.ToString()}/{aksApplicationName}"
                     },
                     Tags = tags,
                     SignInAudience = "AzureADMyOrg",


### PR DESCRIPTION
We've been facing the following error when running `IAI` in our Orchestrated E2E tests starting from `19.10.2021` ([sample run](https://iotcat.visualstudio.com/Industrial-IoT-E2E-Testing/_build/results?buildId=2591&view=results)):

```log
2021-10-19T06:43:12.9538239Z ##[section]Starting: Run deployment with IAI
2021-10-19T06:43:12.9661593Z ==============================================================================
2021-10-19T06:43:12.9662352Z Task         : Command line
2021-10-19T06:43:12.9662876Z Description  : Run a command line script using Bash on Linux and macOS and cmd.exe on Windows
2021-10-19T06:43:12.9663336Z Version      : 2.182.0
2021-10-19T06:43:12.9663721Z Author       : Microsoft Corporation
2021-10-19T06:43:12.9664196Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/command-line
2021-10-19T06:43:12.9664725Z ==============================================================================
2021-10-19T06:43:13.9099281Z Generating script.
2021-10-19T06:43:13.9189028Z Script contents:
2021-10-19T06:43:13.9197306Z Microsoft.Azure.IIoT.Deployment.exe
2021-10-19T06:43:13.9491855Z ========================== Starting Command Output ===========================
2021-10-19T06:43:13.9742259Z ##[command]"C:\Windows\system32\cmd.exe" /D /E:ON /V:OFF /S /C "CALL "C:\agent\_work\_temp\ccde4685-ad1b-428f-a8ec-d6cf4450cba4.cmd""
2021-10-19T06:43:15.2020190Z [06:43:15 INF] Starting full deployment of Industrial IoT solution.
2021-10-19T06:43:15.2072250Z [06:43:15 INF] Configured Azure environment will be used: AzureGlobalCloud
2021-10-19T06:43:15.2073824Z [06:43:15 INF] Configured TenantId will be used: ***
2021-10-19T06:43:15.2074734Z [06:43:15 INF] Configured ClientId will be used: ***
2021-10-19T06:43:15.2075379Z [06:43:15 INF] Configured ClientSecret will be used.
2021-10-19T06:43:16.4314578Z [06:43:16 INF] Configured subscription will be used: DisplayName: 'IOT-OPC-WALLS', SubscriptionId: '9dd2b4d0-3dad-4aeb-85d8-c3addb78127a'
2021-10-19T06:43:17.0446715Z [06:43:17 INF] Configured application name will be used: e2etesting2021101945
2021-10-19T06:43:17.5870210Z [06:43:17 INF] Configured to use existing resource group: False
2021-10-19T06:43:17.7867652Z [06:43:17 INF] Configured region will be used: eastus
2021-10-19T06:43:17.7998915Z [06:43:17 INF] Configured resource group name will be used: e2etesting2021101945
2021-10-19T06:43:17.8002619Z [06:43:17 INF] Creating Resource Group: e2etesting2021101945 ...
2021-10-19T06:43:18.1307647Z [06:43:18 INF] Created Resource Group: e2etesting2021101945
2021-10-19T06:43:18.1313604Z [06:43:18 INF] Registering resource providers ...
2021-10-19T06:43:20.7557626Z [06:43:20 INF] Registered resource providers
2021-10-19T06:43:20.7578444Z [06:43:20 INF] Creating service application registration ...
2021-10-19T06:43:20.8625236Z [06:43:20 ERR] Failed to create service application registration.
2021-10-19T06:43:20.8814458Z [06:43:20 ERR] Failed to deploy Industrial IoT solution.
2021-10-19T06:43:20.8815522Z Status Code: BadRequest
2021-10-19T06:43:20.8816341Z Microsoft.Graph.ServiceException: Code: HostNameNotOnVerifiedDomain
2021-10-19T06:43:20.8817627Z Message: Values of identifierUris property must use a verified domain of the organization or its subdomain: 'https://***/e2etesting2021101945-service'
2021-10-19T06:43:20.8818628Z Inner error:
2021-10-19T06:43:20.8819117Z 	AdditionalData:
2021-10-19T06:43:20.8819608Z 	date: 2021-10-19T06:43:20
2021-10-19T06:43:20.8820258Z 	request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8820881Z 	client-request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8821502Z ClientRequestId: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8821957Z 
2021-10-19T06:43:20.8823105Z    at Microsoft.Graph.HttpProvider.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, Cancellation*** cancellation***)
2021-10-19T06:43:20.8824103Z    at Microsoft.Graph.BaseRequest.SendRequestAsync(Object serializableObject, Cancellation*** cancellation***, HttpCompletionOption completionOption)
2021-10-19T06:43:20.8825282Z    at Microsoft.Graph.BaseRequest.SendAsync[T](Object serializableObject, Cancellation*** cancellation***, HttpCompletionOption completionOption)
2021-10-19T06:43:20.8826262Z    at Microsoft.Azure.IIoT.Deployment.Infrastructure.MicrosoftGraphServiceClient.CreateApplicationAsync(Application applicationDefinition, Cancellation*** cancellation***)
2021-10-19T06:43:20.8829463Z    at Microsoft.Azure.IIoT.Deployment.Deployment.ApplicationsManager.RegisterServiceApplicationAsync(String serviceApplicationName, DirectoryObject owner, IEnumerable`1 tags, Cancellation*** cancellation***)
2021-10-19T06:43:20.8831327Z    at Microsoft.Azure.IIoT.Deployment.Deployment.ApplicationsManager.RegisterApplicationsAsync(String applicationName, DirectoryObject owner, IEnumerable`1 tags, Cancellation*** cancellation***)
2021-10-19T06:43:20.8832774Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.SetupApplicationsAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8833813Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.RunFullDeploymentAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8834489Z [06:43:20 INF] Configured to perform cleanup: False
2021-10-19T06:43:20.8835075Z [06:43:20 ERR] Unhandled exception
2021-10-19T06:43:20.8835659Z System.AggregateException: One or more errors occurred. (Code: HostNameNotOnVerifiedDomain
2021-10-19T06:43:20.8836535Z Message: Values of identifierUris property must use a verified domain of the organization or its subdomain: 'https://***/e2etesting2021101945-service'
2021-10-19T06:43:20.8837365Z Inner error:
2021-10-19T06:43:20.8838011Z 	AdditionalData:
2021-10-19T06:43:20.8838676Z 	date: 2021-10-19T06:43:20
2021-10-19T06:43:20.8839399Z 	request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8840824Z 	client-request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8842261Z ClientRequestId: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8843030Z )
2021-10-19T06:43:20.8843712Z  ---> Status Code: BadRequest
2021-10-19T06:43:20.8844574Z Microsoft.Graph.ServiceException: Code: HostNameNotOnVerifiedDomain
2021-10-19T06:43:20.8845982Z Message: Values of identifierUris property must use a verified domain of the organization or its subdomain: 'https://***/e2etesting2021101945-service'
2021-10-19T06:43:20.8847170Z Inner error:
2021-10-19T06:43:20.8848153Z 	AdditionalData:
2021-10-19T06:43:20.8848911Z 	date: 2021-10-19T06:43:20
2021-10-19T06:43:20.8849759Z 	request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8850687Z 	client-request-id: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8851619Z ClientRequestId: d468a602-02c5-4fd5-a0d0-7ed9fe12ed0f
2021-10-19T06:43:20.8852132Z 
2021-10-19T06:43:20.8853365Z    at Microsoft.Graph.HttpProvider.SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, Cancellation*** cancellation***)
2021-10-19T06:43:20.8854873Z    at Microsoft.Graph.BaseRequest.SendRequestAsync(Object serializableObject, Cancellation*** cancellation***, HttpCompletionOption completionOption)
2021-10-19T06:43:20.8856376Z    at Microsoft.Graph.BaseRequest.SendAsync[T](Object serializableObject, Cancellation*** cancellation***, HttpCompletionOption completionOption)
2021-10-19T06:43:20.8857941Z    at Microsoft.Azure.IIoT.Deployment.Infrastructure.MicrosoftGraphServiceClient.CreateApplicationAsync(Application applicationDefinition, Cancellation*** cancellation***)
2021-10-19T06:43:20.8859933Z    at Microsoft.Azure.IIoT.Deployment.Deployment.ApplicationsManager.RegisterServiceApplicationAsync(String serviceApplicationName, DirectoryObject owner, IEnumerable`1 tags, Cancellation*** cancellation***)
2021-10-19T06:43:20.8861783Z    at Microsoft.Azure.IIoT.Deployment.Deployment.ApplicationsManager.RegisterApplicationsAsync(String applicationName, DirectoryObject owner, IEnumerable`1 tags, Cancellation*** cancellation***)
2021-10-19T06:43:20.8863241Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.SetupApplicationsAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8864539Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.RunFullDeploymentAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8866694Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.RunFullDeploymentAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8867888Z    at Microsoft.Azure.IIoT.Deployment.Deployment.DeploymentExecutor.RunAsync(Cancellation*** cancellation***)
2021-10-19T06:43:20.8868893Z    --- End of inner exception stack trace ---
2021-10-19T06:43:20.8869854Z    at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
2021-10-19T06:43:20.8871148Z    at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, Cancellation*** cancellation***)
2021-10-19T06:43:20.8872167Z    at System.Threading.Tasks.Task.Wait()
2021-10-19T06:43:20.8873167Z    at Microsoft.Azure.IIoT.Deployment.Program.Run(IConfigurationRoot configuration)
2021-10-19T06:43:20.9572598Z ##[error]Cmd.exe exited with code '1'.
2021-10-19T06:43:20.9954393Z ##[section]Finishing: Run deployment with IAI
```

The cause of the error is that the schema that we were using for generating values of `IdentifierUris` when creating new App Registrations is no longer supported. We were using the following schema:

*  `https://{TenantId}/{ApplicationName}`

Recently the following requirement has been added when performing API calls to Active Directory, which defines fixed schemas for `IdentifierUris` property:

* [AppId Uri in single tenant applications will require use of default scheme or verified domains](https://docs.microsoft.com/en-us/azure/active-directory/develop/reference-breaking-changes#appid-uri-in-single-tenant-applications-will-require-use-of-default-scheme-or-verified-domains)

I've changed our code to use the following schema for `IdentifierUris` properties:

*  `api://{TenantId}/{ApplicationName}`