### PR TITLE
Fixed scope property of the request to get API token.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -75,7 +75,7 @@ namespace IIoTPlatform_E2E_Tests {
             var request = new RestRequest(Method.POST);
             request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
             request.AddParameter("grant_type", "client_credentials");
-            request.AddParameter("scope", $"https://{tenantId}/{applicationName}-service/.default");
+            request.AddParameter("scope", $"api://{tenantId}/{applicationName}-service/.default");
 
             var response = await client.ExecuteAsync(request, ct);
             Assert.True(response.IsSuccessful, $"Request OAuth2.0 failed, Status {response.StatusCode}, ErrorMessage: {response.ErrorMessage}");


### PR DESCRIPTION
Changes:
* Fixed `scope` property of the request to get API token.

This PR is a continuation of the work that has been done in #1432. This aligns the `scope` property with change of `IdentifierUris`.