### PR TITLE
SignalR: removed deprecated calls.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Abstractions/src/Messaging/IEndpoint.cs
+++ b/common/src/Microsoft.Azure.IIoT.Abstractions/src/Messaging/IEndpoint.cs
@@ -16,11 +16,5 @@ namespace Microsoft.Azure.IIoT.Messaging {
         /// Resource name
         /// </summary>
         string Resource { get; }
-
-        /// <summary>
-        /// Get client endpoint
-        /// </summary>
-        /// <returns>Client endpoint</returns>
-        Uri EndpointUrl { get; }
     }
 }

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.5.0" />
+    <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.11.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Serializers.MessagePack\src\Microsoft.Azure.IIoT.Serializers.MessagePack.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Services/SignalRServiceHost.cs
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Services/SignalRServiceHost.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.IIoT.Messaging.SignalR.Services {
             var hub = _hub;
             try {
                 if (hub == null) {
-                    hub = await _serviceManager.CreateHubContextAsync(Resource);
+                    hub = await _serviceManager.CreateHubContextAsync(Resource, ct);
                 }
                 await hub.Clients.All.SendCoreAsync("ping", new object[0], ct);
                 return HealthCheckResult.Healthy();
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.IIoT.Messaging.SignalR.Services {
                 }
                 else {
                     _logger.Debug("Starting SignalR service host...");
-                    _hub = await _serviceManager.CreateHubContextAsync(Resource);
+                    _hub = await _serviceManager.CreateHubContextAsync(Resource, default);
                     _logger.Information("SignalR service host started.");
                 }
                 // (re)start the timer no matter what
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.IIoT.Messaging.SignalR.Services {
         private async void RenewHubTimer_ElapesedAsync(object sender) {
             var hub = _hub;
             try {
-                _hub = await _serviceManager.CreateHubContextAsync(Resource);
+                _hub = await _serviceManager.CreateHubContextAsync(Resource, default);
             }
             finally {
                 if (hub != _hub) {


### PR DESCRIPTION
Changes:
* Upgraded to `1.11.0` version of `Microsoft.Azure.SignalR.Management` NuGet package.
* Removed deprecated calls of `ServiceManagerBuilder` and changed the calls according to [`IServiceManager` to `ServiceManager` Migration Guidance](https://github.com/Azure/azure-signalr/blob/dev/docs/management-sdk-migration.md).
