### PR TITLE
enforce IoT Edge to TLS 1.2 usage

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
@@ -99,6 +99,11 @@ namespace Microsoft.Azure.IIoT.Hub.Services {
                     ""settings"": {
                         ""image"": ""mcr.microsoft.com/azureiotedge-hub:" + version + @""",
                         ""createOptions"": ""{\""HostConfig\"":{\""PortBindings\"":{\""443/tcp\"":[{\""HostPort\"":\""443\""}],\""5671/tcp\"":[{\""HostPort\"":\""5671\""}],\""8883/tcp\"":[{\""HostPort\"":\""8883\""}]}},\""ExposedPorts\"":{\""5671/tcp\"":{},\""8883/tcp\"":{}}}""
+                    },
+                    ""env"": {
+                        ""SslProtocols"": {
+                            ""value"": ""tls1.2""
+                        }
                     }
                 }
             },

--- a/docs/deploy/deployment-manifest.md
+++ b/docs/deploy/deployment-manifest.md
@@ -24,7 +24,7 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": ""
             }
           },
@@ -33,7 +33,7 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             },
             "env": {
@@ -113,7 +113,7 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
           "edgeAgent": {
             "type": "docker",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
               "createOptions": ""
             }
           },
@@ -122,7 +122,7 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
             "status": "running",
             "restartPolicy": "always",
             "settings": {
-              "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+              "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
             },
             "env": {

--- a/docs/deploy/deployment-manifest.md
+++ b/docs/deploy/deployment-manifest.md
@@ -35,6 +35,11 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+            },
+            "env": {
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },
@@ -119,6 +124,11 @@ An example manifest for the released Industrial-IoT IoT Edge modules included in
             "settings": {
               "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
               "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"5671/tcp\":[{\"HostPort\":\"5671\"}], \"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}]}}}"
+            },
+            "env": {
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubEdgeBaseDeployment.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubEdgeBaseDeployment.cs
@@ -86,6 +86,9 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
                                     },
                                     ""experimentalFeatures:nestedEdgeEnabled"": {
                                         ""value"": ""true""
+                                    },
+                                    ""SslProtocols"": {
+                                        ""value"": ""tls1.2""
                                     }
                                 }
                             }

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeployment.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeployment.template.json
@@ -41,7 +41,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeployment.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeployment.template.json
@@ -42,11 +42,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.json
@@ -48,11 +48,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.json
@@ -47,7 +47,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.template.json
@@ -48,11 +48,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/bottomLayerBaseDeploymentOtProxy.template.json
@@ -47,7 +47,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.json
@@ -41,7 +41,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.json
@@ -42,11 +42,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.template.json
@@ -41,7 +41,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeployment.template.json
@@ -42,11 +42,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeploymentOtProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeploymentOtProxy.template.json
@@ -48,11 +48,9 @@
               "httpSettings:enabled": {
                 "value": true
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              } 
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeploymentOtProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/middleLayerBaseDeploymentOtProxy.template.json
@@ -47,7 +47,12 @@
               },
               "httpSettings:enabled": {
                 "value": true
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/topLayerBaseDeploymentItProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/topLayerBaseDeploymentItProxy.template.json
@@ -49,11 +49,9 @@
               "https_proxy": {
                 "value": "http://10.16.8.4:3128"
               },
-              "env": {
-                "SslProtocols": {
-                  "value": "tls1.2"
-                }
-              }  
+              "SslProtocols": {
+                "value": "tls1.2"
+              }
             }
           }
         },

--- a/tools/e2etesting/NestedEdge/scripts/edgeDeployments/topLayerBaseDeploymentItProxy.template.json
+++ b/tools/e2etesting/NestedEdge/scripts/edgeDeployments/topLayerBaseDeploymentItProxy.template.json
@@ -48,7 +48,12 @@
               },
               "https_proxy": {
                 "value": "http://10.16.8.4:3128"
-              }
+              },
+              "env": {
+                "SslProtocols": {
+                  "value": "tls1.2"
+                }
+              }  
             }
           }
         },


### PR DESCRIPTION
By default the IoT Edge device exposes TLS channels that are declared non-recommended versions(1.0 and 1.1). Configuring the edgeHub to enforce exclusively us of 1.2 TLS version hardens the security of the edge device that we deploy through layer deployment as well as the VMs we use for E2E testing.