### PR TITLE
Updated release version.

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8.1-rc.{height}",
+  "version": "2.8.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
Removed `-rc.{height}` from the version number so that the reported version is `2.8.1`.