### PR TITLE
[Helm] Bumped version of azure-industrial-iot Helm chart to 0.4.2 in main.

### DIFF
--- a/deploy/helm/azure-industrial-iot/Chart.yaml
+++ b/deploy/helm/azure-industrial-iot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: azure-industrial-iot
-version: 0.4.1
+version: 0.4.2
 description: Azure Industrial IoT allows plant operators to discover OPC UA enabled servers in a factory network and register them in Azure IoT Hub.
 type: application
 keywords:


### PR DESCRIPTION
Changes:
* Bumped version of `azure-industrial-iot` Helm chart to `0.4.2` in `main` branch as `0.4.1` version is now released.