### PR TITLE
Updating IAI for deployment of 2.8.1 version of Industrial-Iot platform.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration {
 
         // Defaults
         public static string _defaultRepoUrl = "https://microsoft.github.io/charts/repo";
-        public static string _defaultChartVersion = "0.3.2";
-        public static string _defaultImageTag = "2.7.206";
+        public static string _defaultChartVersion = "0.4.1";
+        public static string _defaultImageTag = "2.8.1";
         public static string _defaultImageNamespace = "";
         public static string _defaultContainerRegistryServer = "mcr.microsoft.com";
         public static string _defaultContainerRegistryUsername = "";

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -477,15 +477,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                             _applicationsManager.GetAKSApplicationSP(),
                             cancellationToken
                         );
-
-                    // ToDo: Remove role assignment after telemetryCdmProcessor uses connection string.
-                    // Assign Service Principal of Service Application
-                    // "Storage Blob Data Contributor" IAM role for Subscription.
-                    await _authorizationManagementClient
-                        .AssignStorageBlobDataContributorRoleForSubscriptionAsync(
-                            _applicationsManager.GetServiceApplicationSP(),
-                            cancellationToken
-                        );
                 }
             }
             else if (RunMode.ResourceDeployment == runMode) {

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
         // Resource names
         private string _keyVaultName;
         private string _storageAccountGen2Name;
-        private string _storageAccountGen2HNSName;
         private string _iotHubName;
         private string _cosmosDBAccountName;
         private string _serviceBusNamespaceName;
@@ -631,16 +630,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                 _storageAccountGen2Name = StorageMgmtClient.GenerateStorageAccountName();
             }
 
-            // Storage Account Gen2 name
-            try {
-                _storageAccountGen2HNSName = await _storageManagementClient
-                    .GenerateAvailableNameAsync(cancellationToken);
-            }
-            catch (Microsoft.Rest.Azure.CloudException) {
-                Log.Warning(notAvailableApiFormat, "Storage Account");
-                _storageAccountGen2HNSName = StorageMgmtClient.GenerateStorageAccountName();
-            }
-
             // IoT hub names
             try {
                 _iotHubName = await _iotHubManagementClient
@@ -899,50 +888,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            // Create Storage Account Gen2 with hierarchical namespace enabled.
-            StorageAccountInner storageAccountGen2HNS;
-            StorageAccountKey storageAccountGen2HNSKey;
-            string storageAccountGen2HNSEndpointSuffix;
-            string storageAccountGen2HNSConectionString;
-            BlobContainerInner powerbiContainer;
-
-            storageAccountGen2HNS = await _storageManagementClient
-                .CreateStorageAccountGen2Async(
-                    _resourceGroup,
-                    _storageAccountGen2HNSName,
-                    true,
-                    _defaultTagsDict,
-                    cancellationToken
-                );
-
-            // NOTE: storageAccountGen2HNSKey and storageAccountGen2HNSEndpointSuffix are required for
-            // <2.8.5 version of components as processing of storageAccountGen2HNSConectionString is not
-            // present there.
-            storageAccountGen2HNSKey = await _storageManagementClient
-                .GetStorageAccountKeyAsync(
-                    _resourceGroup,
-                    storageAccountGen2HNS,
-                    cancellationToken
-                );
-            storageAccountGen2HNSEndpointSuffix = _storageManagementClient.GetDataLakeEndpointSuffix();
-            storageAccountGen2HNSConectionString = await _storageManagementClient
-                .GetStorageAccountDataLakeConectionStringAsync(
-                    _resourceGroup,
-                    storageAccountGen2HNS,
-                    cancellationToken
-                );
-
-            // Create Blob container for PowerBI storage.
-            powerbiContainer = await _storageManagementClient
-                .CreateBlobContainerAsync(
-                    _resourceGroup,
-                    storageAccountGen2HNS,
-                    StorageMgmtClient.STORAGE_ACCOUNT_POWERBI_CONTAINER_NAME,
-                    PublicAccess.None,
-                    _defaultTagsDict,
-                    cancellationToken
-                );
-
             // Create IoT Hub
             IotHubDescription iotHub;
 
@@ -978,16 +923,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     cancellationToken
                 );
 
-            // Create "tunnel" consumer group.
-            var iotHubEventHubCGTunnel = await _iotHubManagementClient
-                .CreateEventHubConsumerGroupAsync(
-                    _resourceGroup,
-                    iotHub,
-                    IotHubMgmtClient.IOT_HUB_EVENT_HUB_EVENTS_ENDPOINT_NAME,
-                    IotHubMgmtClient.IOT_HUB_EVENT_HUB_CONSUMER_GROUP_TUNNEL_NAME,
-                    cancellationToken
-                );
-
             // Create "onboarding" consumer group.
             var iotHubEventHubCGOnboarding = await _iotHubManagementClient
                 .CreateEventHubConsumerGroupAsync(
@@ -1019,7 +954,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
             // Create Azure Event Hub Namespace and Azure Event Hub
             EHNamespaceInner eventHubNamespace;
             EventhubInner eventHub;
-            ConsumerGroupInner telemetryCdm;
             ConsumerGroupInner telemetryUx;
 
             // Create Azure Event Hub Namespace
@@ -1040,16 +974,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                     EventHubMgmtClient.DEFAULT_MESSAGE_RETENTION_IN_DAYS,
                     EventHubMgmtClient.DEFUALT_PARTITION_COUNT,
                     _defaultTagsDict,
-                    cancellationToken
-                );
-
-            // Create "telemetry_cdm" consumer group.
-            telemetryCdm = await _eventHubManagementClient
-                .CreateConsumerGroupAsync(
-                    _resourceGroup,
-                    eventHubNamespace,
-                    eventHub,
-                    EventHubMgmtClient.EVENT_HUB_CONSUMER_GROUP_TELEMETRY_CDM,
                     cancellationToken
                 );
 
@@ -1144,24 +1068,15 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
                 IotHubMgmtClient.IOT_HUB_EVENT_HUB_EVENTS_ENDPOINT_NAME,
                 iotHubEventHubCGEvents,
                 iotHubEventHubCGTelemetry,
-                iotHubEventHubCGTunnel,
                 iotHubEventHubCGOnboarding,
                 // Cosmos DB
                 cosmosDBAccountConnectionString,
                 // Storage Account
                 storageAccountGen2ConectionString,
                 dataprotectionBlobContainer.Name,
-                // ADLS Gen2 Storage Account with enabled HNS
-                storageAccountGen2HNS.Name,
-                storageAccountGen2HNSKey.Value,
-                storageAccountGen2HNSEndpointSuffix,
-                storageAccountGen2HNSConectionString,
-                powerbiContainer.Name,
-                StorageMgmtClient.POWERBI_ROOT_FOLDER,
                 // Event Hub Namespace
                 eventHub,
                 eventHubNamespaceConnectionString,
-                telemetryCdm,
                 telemetryUx,
                 // Service Bus
                 serviceBusNamespaceConnectionString,

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public readonly string PCS_IOTHUB_EVENTHUBENDPOINT;
         public readonly string PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_EVENTS;
         public readonly string PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TELEMETRY;
-        public readonly string PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TUNNEL;
         public readonly string PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_ONBOARDING;
 
         // Cosmos DB
@@ -35,20 +34,9 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public readonly string PCS_STORAGE_CONNSTRING;
         public readonly string PCS_STORAGE_CONTAINER_DATAPROTECTION;
 
-        // ADLS Gen2 Storage Account
-        // NOTE: PCS_ADLSG2_ACCOUNT, PCS_ADLSG2_ACCOUNT_KEY and PCS_ADLSG2_ENDPOINTSUFFIX are required
-        // for <2.8.5 version of components as processing of PCS_ADLSG2_CONNSTRING is not present there.
-        public readonly string PCS_ADLSG2_ACCOUNT;
-        public readonly string PCS_ADLSG2_ACCOUNT_KEY;
-        public readonly string PCS_ADLSG2_ENDPOINTSUFFIX;
-        public readonly string PCS_ADLSG2_CONNSTRING;
-        public readonly string PCS_ADLSG2_CONTAINER_CDM;
-        public readonly string PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER;
-
         // Event Hub Namespace
         public readonly string PCS_EVENTHUB_CONNSTRING;
         public readonly string PCS_EVENTHUB_NAME;
-        public readonly string PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_CDM;
         public readonly string PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_UX;
 
         // Service Bus
@@ -74,7 +62,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public readonly string PCS_TWIN_REGISTRY_URL;
         public readonly string PCS_TWIN_SERVICE_URL;
         public readonly string PCS_HISTORY_SERVICE_URL;
-        public readonly string PCS_VAULT_SERVICE_URL;
         public readonly string PCS_PUBLISHER_SERVICE_URL;
         public readonly string PCS_PUBLISHER_ORCHESTRATOR_SERVICE_URL;
         public readonly string PCS_EVENTS_SERVICE_URL;
@@ -102,8 +89,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public readonly string PCS_TWIN_REGISTRY_SERVICE_PATH_BASE;
         public readonly string PCS_TWIN_SERVICE_PATH_BASE;
         public readonly string PCS_HISTORY_SERVICE_PATH_BASE;
-        public readonly string PCS_GATEWAY_SERVICE_PATH_BASE;
-        public readonly string PCS_VAULT_SERVICE_PATH_BASE;
         public readonly string PCS_PUBLISHER_SERVICE_PATH_BASE;
         public readonly string PCS_PUBLISHER_ORCHESTRATOR_SERVICE_PATH_BASE;
         public readonly string PCS_EVENTS_SERVICE_PATH_BASE;
@@ -127,24 +112,15 @@ namespace Microsoft.Azure.IIoT.Deployment {
             string iotHubEventHubEventsEndpointName,
             EventHubConsumerGroupInfo iotHubEventHubConsumerGroupEvents,
             EventHubConsumerGroupInfo iotHubEventHubConsumerGroupTelemetry,
-            EventHubConsumerGroupInfo iotHubEventHubConsumerGroupTunnel,
             EventHubConsumerGroupInfo iotHubEventHubConsumerGroupOnboarding,
             // Cosmos DB
             string cosmosDBAccountConnectionString,
             // Storage Account
             string storageAccountConectionString,
             string storageAccountContainerDataprotection,
-            // ADLS Gen2 Storage Account
-            string adlsAccount,
-            string adlsAccountKey,
-            string adlsEndpointSuffix,
-            string adlsConectionString,
-            string adlsContainerCdm,
-            string adlsContainerCdmRootFolder,
             // Event Hub Namespace
             EventhubInner eventHub,
             string eventHubConnectionString,
-            ConsumerGroupInner telemetryCdm,
             ConsumerGroupInner telemetryUx,
             // Service Bus
             string serviceBusConnectionString,
@@ -173,7 +149,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
             PCS_IOTHUB_EVENTHUBENDPOINT = iotHub.Properties.EventHubEndpoints[iotHubEventHubEventsEndpointName].Endpoint;
             PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_EVENTS = iotHubEventHubConsumerGroupEvents.Name;
             PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TELEMETRY = iotHubEventHubConsumerGroupTelemetry.Name;
-            PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TUNNEL = iotHubEventHubConsumerGroupTunnel.Name;
             PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_ONBOARDING = iotHubEventHubConsumerGroupOnboarding.Name;
 
             // Cosmos DB
@@ -183,20 +158,9 @@ namespace Microsoft.Azure.IIoT.Deployment {
             PCS_STORAGE_CONNSTRING = storageAccountConectionString;
             PCS_STORAGE_CONTAINER_DATAPROTECTION = storageAccountContainerDataprotection;
 
-            // ADLS Gen2 Storage Account
-            // NOTE: PCS_ADLSG2_ACCOUNT, PCS_ADLSG2_ACCOUNT_KEY and PCS_ADLSG2_ENDPOINTSUFFIX are required
-            // for <2.8.5 version of components as processing of PCS_ADLSG2_CONNSTRING is not present there.
-            PCS_ADLSG2_ACCOUNT = adlsAccount;
-            PCS_ADLSG2_ACCOUNT_KEY = adlsAccountKey;
-            PCS_ADLSG2_ENDPOINTSUFFIX = adlsEndpointSuffix;
-            PCS_ADLSG2_CONNSTRING = adlsConectionString;
-            PCS_ADLSG2_CONTAINER_CDM = adlsContainerCdm;
-            PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER = adlsContainerCdmRootFolder;
-
             // Event Hub Namespace
             PCS_EVENTHUB_CONNSTRING = eventHubConnectionString;
             PCS_EVENTHUB_NAME = eventHub.Name;
-            PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_CDM = telemetryCdm.Name;
             PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_UX = telemetryUx.Name;
 
             // Service Bus
@@ -222,7 +186,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
             PCS_TWIN_REGISTRY_URL = $"{serviceURL}/registry/";
             PCS_TWIN_SERVICE_URL = $"{serviceURL}/twin/";
             PCS_HISTORY_SERVICE_URL = $"{serviceURL}/history/";
-            PCS_VAULT_SERVICE_URL = $"{serviceURL}/vault/";
             PCS_PUBLISHER_SERVICE_URL = $"{serviceURL}/publisher/";
             PCS_PUBLISHER_ORCHESTRATOR_SERVICE_URL = $"{serviceURL}/edge/publisher/";
             PCS_EVENTS_SERVICE_URL = $"{serviceURL}/events/";
@@ -252,8 +215,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
             PCS_TWIN_REGISTRY_SERVICE_PATH_BASE = "/registry";
             PCS_TWIN_SERVICE_PATH_BASE = "/twin";
             PCS_HISTORY_SERVICE_PATH_BASE = "/history";
-            PCS_GATEWAY_SERVICE_PATH_BASE = "/ua";
-            PCS_VAULT_SERVICE_PATH_BASE = "/vault";
             PCS_PUBLISHER_SERVICE_PATH_BASE = "/publisher";
             PCS_PUBLISHER_ORCHESTRATOR_SERVICE_PATH_BASE = "/edge/publisher";
             PCS_EVENTS_SERVICE_PATH_BASE = "/events";
@@ -272,7 +233,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 { $"{nameof(PCS_IOTHUB_EVENTHUBENDPOINT)}", PCS_IOTHUB_EVENTHUBENDPOINT },
                 { $"{nameof(PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_EVENTS)}", PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_EVENTS },
                 { $"{nameof(PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TELEMETRY)}", PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TELEMETRY },
-                { $"{nameof(PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TUNNEL)}", PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_TUNNEL },
                 { $"{nameof(PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_ONBOARDING)}", PCS_IOTHUB_EVENTHUB_CONSUMER_GROUP_ONBOARDING },
 
                 // Cosmos DB
@@ -282,18 +242,9 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 { $"{nameof(PCS_STORAGE_CONNSTRING)}", PCS_STORAGE_CONNSTRING },
                 { $"{nameof(PCS_STORAGE_CONTAINER_DATAPROTECTION)}", PCS_STORAGE_CONTAINER_DATAPROTECTION },
 
-                // ADLS Gen2 Storage Account
-                { $"{nameof(PCS_ADLSG2_ACCOUNT)}", PCS_ADLSG2_ACCOUNT },
-                { $"{nameof(PCS_ADLSG2_ACCOUNT_KEY)}", PCS_ADLSG2_ACCOUNT_KEY },
-                { $"{nameof(PCS_ADLSG2_ENDPOINTSUFFIX)}", PCS_ADLSG2_ENDPOINTSUFFIX },
-                { $"{nameof(PCS_ADLSG2_CONNSTRING)}", PCS_ADLSG2_CONNSTRING },
-                { $"{nameof(PCS_ADLSG2_CONTAINER_CDM)}", PCS_ADLSG2_CONTAINER_CDM },
-                { $"{nameof(PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER)}", PCS_ADLSG2_CONTAINER_CDM_ROOTFOLDER },
-
                 // Event Hub Namespace
                 { $"{nameof(PCS_EVENTHUB_CONNSTRING)}", PCS_EVENTHUB_CONNSTRING },
                 { $"{nameof(PCS_EVENTHUB_NAME)}", PCS_EVENTHUB_NAME },
-                { $"{nameof(PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_CDM)}", PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_CDM },
                 { $"{nameof(PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_UX)}", PCS_EVENTHUB_CONSUMERGROUP_TELEMETRY_UX },
 
                 // Service Bus
@@ -319,7 +270,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 { $"{nameof(PCS_TWIN_REGISTRY_URL)}", PCS_TWIN_REGISTRY_URL },
                 { $"{nameof(PCS_TWIN_SERVICE_URL)}", PCS_TWIN_SERVICE_URL },
                 { $"{nameof(PCS_HISTORY_SERVICE_URL)}", PCS_HISTORY_SERVICE_URL },
-                { $"{nameof(PCS_VAULT_SERVICE_URL)}", PCS_VAULT_SERVICE_URL },
                 { $"{nameof(PCS_PUBLISHER_SERVICE_URL)}", PCS_PUBLISHER_SERVICE_URL },
                 { $"{nameof(PCS_PUBLISHER_ORCHESTRATOR_SERVICE_URL)}", PCS_PUBLISHER_ORCHESTRATOR_SERVICE_URL },
                 { $"{nameof(PCS_EVENTS_SERVICE_URL)}", PCS_EVENTS_SERVICE_URL },
@@ -347,8 +297,6 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 { $"{nameof(PCS_TWIN_REGISTRY_SERVICE_PATH_BASE)}", PCS_TWIN_REGISTRY_SERVICE_PATH_BASE },
                 { $"{nameof(PCS_TWIN_SERVICE_PATH_BASE)}", PCS_TWIN_SERVICE_PATH_BASE },
                 { $"{nameof(PCS_HISTORY_SERVICE_PATH_BASE)}", PCS_HISTORY_SERVICE_PATH_BASE },
-                { $"{nameof(PCS_GATEWAY_SERVICE_PATH_BASE)}", PCS_GATEWAY_SERVICE_PATH_BASE },
-                { $"{nameof(PCS_VAULT_SERVICE_PATH_BASE)}", PCS_VAULT_SERVICE_PATH_BASE },
                 { $"{nameof(PCS_PUBLISHER_SERVICE_PATH_BASE)}", PCS_PUBLISHER_SERVICE_PATH_BASE },
                 { $"{nameof(PCS_PUBLISHER_ORCHESTRATOR_SERVICE_PATH_BASE)}", PCS_PUBLISHER_ORCHESTRATOR_SERVICE_PATH_BASE },
                 { $"{nameof(PCS_EVENTS_SERVICE_PATH_BASE)}", PCS_EVENTS_SERVICE_PATH_BASE },

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/EventHubMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/EventHubMgmtClient.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string DEFAULT_EVENT_HUB_NAME_PREFIX = "eventhub-";
         public const int NUM_OF_MAX_NAME_AVAILABILITY_CHECKS = 5;
 
-        public const string EVENT_HUB_CONSUMER_GROUP_TELEMETRY_CDM = "telemetry_cdm";
         public const string EVENT_HUB_CONSUMER_GROUP_TELEMETRY_UX = "telemetry_ux";
         public const int DEFAULT_MESSAGE_RETENTION_IN_DAYS = 2;
         public const int DEFUALT_PARTITION_COUNT = 4;

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/IotHubMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/IotHubMgmtClient.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
 
         public const string IOT_HUB_EVENT_HUB_CONSUMER_GROUP_EVENTS_NAME = "events";
         public const string IOT_HUB_EVENT_HUB_CONSUMER_GROUP_TELEMETRY_NAME = "telemetry";
-        public const string IOT_HUB_EVENT_HUB_CONSUMER_GROUP_TUNNEL_NAME = "tunnel";
         public const string IOT_HUB_EVENT_HUB_CONSUMER_GROUP_ONBOARDING_NAME = "onboarding";
 
         public const string IOT_HUB_OWNER_KEY_NAME = "iothubowner";

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/StorageMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/StorageMgmtClient.cs
@@ -24,13 +24,9 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string STORAGE_ACCOUNT_IOT_HUB_CONTAINER_NAME = "iothub-default";
         public const string STORAGE_ACCOUNT_DATAPROTECTION_CONTAINER_NAME = "dataprotection";
         public const string STORAGE_ACCOUNT_DEPLOYMENT_SCRIPTS_CONTAINER_NAME = "deployment-scripts";
-        public const string STORAGE_ACCOUNT_POWERBI_CONTAINER_NAME = "powerbi";
-
-        public const string POWERBI_ROOT_FOLDER = "IIoTDataFlow";
 
         private const string kSTORAGE_ACCOUNT_CONECTION_STRING_FORMAT =
             "DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}";
-        private const string kDATA_LAKE_ENDPOINT_SUFFIX_FORMAT = "dfs.{0}";
 
         private readonly StorageManagementClient _storageManagementClient;
         private readonly AzureEnvironment _azureEnvironment;
@@ -401,50 +397,6 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         /// <returns></returns>
         public string GetEndpointSuffix() {
             return _azureEnvironment.StorageEndpointSuffix;
-        }
-
-        /// <summary>
-        /// Get data lake endpoint suffix.
-        /// </summary>
-        /// <returns></returns>
-        public string GetDataLakeEndpointSuffix() {
-            var dataLakeEndpointSuffix = string.Format(
-                kDATA_LAKE_ENDPOINT_SUFFIX_FORMAT,
-                _azureEnvironment.StorageEndpointSuffix
-            );
-            return dataLakeEndpointSuffix;
-        }
-
-        /// <summary>
-        /// Get connection string for Storage Account with data lake specific endpoint suffix.
-        /// </summary>
-        /// <param name="resourceGroup"></param>
-        /// <param name="storageAccount"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public async Task<string> GetStorageAccountDataLakeConectionStringAsync(
-            IResourceGroup resourceGroup,
-            StorageAccountInner storageAccount,
-            CancellationToken cancellationToken = default
-        ) {
-            if (resourceGroup is null) {
-                throw new ArgumentNullException(nameof(resourceGroup));
-            }
-            if (storageAccount is null) {
-                throw new ArgumentNullException(nameof(storageAccount));
-            }
-
-            var storageAccountKey = await GetStorageAccountKeyAsync(resourceGroup, storageAccount, cancellationToken);
-            var dataLakeEndpointSuffix = GetDataLakeEndpointSuffix();
-
-            var storageAccountConectionString = string.Format(
-                kSTORAGE_ACCOUNT_CONECTION_STRING_FORMAT,
-                storageAccount.Name,
-                storageAccountKey.Value,
-                dataLakeEndpointSuffix
-            );
-
-            return storageAccountConectionString;
         }
 
         /// <summary>

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
@@ -248,18 +248,16 @@ helm repo update
 kubectl create namespace ingress-nginx
 
 # Install ingress-nginx/ingress-nginx Helm chart
-helm install --atomic ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --version 3.12.0 --timeout 30m0s \
+helm install --atomic ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --version 4.0.6 --timeout 30m0s \
     --set controller.replicaCount=2 \
-    --set controller.nodeSelector."beta\.kubernetes\.io\/os"=linux \
     --set controller.service.loadBalancerIP=$LOAD_BALANCER_IP \
     --set controller.service.annotations."service\.beta\.kubernetes\.io\/azure-dns-label-name"=$PUBLIC_IP_DNS_LABEL \
-    --set controller.config.compute-full-forward-for='"true"' \
-    --set controller.config.use-forward-headers='"true"' \
+    --set controller.config.compute-full-forwarded-for='true' \
+    --set controller.config.use-forwarded-headers='true' \
     --set controller.config.proxy-buffer-size='"32k"' \
     --set controller.config.client-header-buffer-size='"32k"' \
     --set controller.metrics.enabled=true \
-    --set defaultBackend.enabled=true \
-    --set defaultBackend.nodeSelector."beta\.kubernetes\.io\/os"=linux
+    --set defaultBackend.enabled=true
 
 # Create cert-manager namespace
 kubectl create namespace cert-manager

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
@@ -335,6 +335,7 @@ if [ "$is_private_repo" = true ] ; then
         --set azure.auth.servicesApp.appId=$AIIOT_SERVICES_APP_ID \
         --set azure.auth.servicesApp.secret=$AIIOT_SERVICES_APP_SECRET \
         --set externalServiceUrl="https://$AIIOT_SERVICES_HOSTNAME" \
+        --set deployment.microServices.engineeringTool.enabled=true \
         --set deployment.ingress.enabled=true \
         --set deployment.ingress.annotations."kubernetes\.io\/ingress\.class"=nginx \
         --set deployment.ingress.annotations."nginx\.ingress\.kubernetes\.io\/affinity"=cookie \
@@ -347,8 +348,6 @@ if [ "$is_private_repo" = true ] ; then
         --set deployment.ingress.tls[0].hosts[0]=$AIIOT_SERVICES_HOSTNAME \
         --set deployment.ingress.tls[0].secretName=tls-secret \
         --set deployment.ingress.hostName=$AIIOT_SERVICES_HOSTNAME \
-        --set deployment.microServices.engineeringTool.enabled=true \
-        --set deployment.microServices.telemetryCdmProcessor.enabled=true \
         $setsvc
 else
     # Install aiiot/azure-industrial-iot Helm chart
@@ -361,7 +360,6 @@ else
         --set azure.auth.servicesApp.secret=$AIIOT_SERVICES_APP_SECRET \
         --set externalServiceUrl="https://$AIIOT_SERVICES_HOSTNAME" \
         --set deployment.microServices.engineeringTool.enabled=true \
-        --set deployment.microServices.telemetryCdmProcessor.enabled=true \
         --set deployment.ingress.enabled=true \
         --set deployment.ingress.annotations."kubernetes\.io\/ingress\.class"=nginx \
         --set deployment.ingress.annotations."nginx\.ingress\.kubernetes\.io\/affinity"=cookie \

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
@@ -265,7 +265,7 @@ helm install --atomic ingress-nginx ingress-nginx/ingress-nginx --namespace ingr
 kubectl create namespace cert-manager
 
 # Install jetstack/cert-manager Helm chart
-helm install --atomic cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --timeout 30m0s \
+helm install --atomic cert-manager jetstack/cert-manager --namespace cert-manager --version v1.6.1 --timeout 30m0s \
     --set installCRDs=true
 
 # Create Let's Encrypt ClusterIssuer

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Resources/scripts/jumpbox.sh
@@ -222,7 +222,7 @@ fi
 az aks install-cli
 
 # Install Helm
-az acr helm install-cli --client-version "3.3.4" -y
+az acr helm install-cli --client-version "3.7.1" -y
 
 ################################################################################
 # Login to az using manaed identity

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
@@ -110,9 +110,9 @@
     // Helm repository URL
     "RepoUrl": "https://microsoft.github.io/charts/repo",
     // azure-industrial-iot Helm chart version
-    "ChartVersion": "0.3.2",
+    "ChartVersion": "0.4.1",
     // Azure IIoT components image tag
-    "ImageTag": "2.7.206",
+    "ImageTag": "2.8.1",
     // Azure IIoT components image namespace
     // "ImageNamespace": "",
     // Container registry server to use

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
@@ -113,8 +113,14 @@
     "ChartVersion": "0.3.2",
     // Azure IIoT components image tag
     "ImageTag": "2.7.206",
-    // Default docker container registry
+    // Azure IIoT components image namespace
+    // "ImageNamespace": "",
+    // Container registry server to use
     "ContainerRegistryServer": "mcr.microsoft.com"
+    // Container registry username
+    // "ContainerRegistryUsername": "",
+    // Container registry password
+    // "ContainerRegistryPassword": ""
   },
 
   // Provides definitions of applications and Service Principals to be used.

--- a/docs/deploy/howto-add-aks-to-ps1.md
+++ b/docs/deploy/howto-add-aks-to-ps1.md
@@ -74,7 +74,7 @@ that application if you are starting from scratch:
   Alternatively, you can run the following command to install `helm` using Azure CLI:
 
   ```bash
-  az acr helm install-cli --client-version "3.2.0"
+  az acr helm install-cli --client-version "3.7.1"
   ```
 
 ## Deployment Steps
@@ -162,29 +162,25 @@ Apply the following changes:
 ```yaml
 controller:
   replicaCount: 2
-  nodeSelector:
-    beta.kubernetes.io/os: linux
   service:
     loadBalancerIP: 20.50.19.169
     annotations:
       service.beta.kubernetes.io/azure-dns-label-name: aks-cluster-ip
   config:
-    compute-full-forward-for: "true"
-    use-forward-headers: "true"
+    compute-full-forwarded-for: true
+    use-forwarded-headers: true
     proxy-buffer-size: "32k"
     client-header-buffer-size: "32k"
   metrics:
     enabled: true
 defaultBackend:
   enabled: true
-  nodeSelector:
-    beta.kubernetes.io/os: linux
 ```
 
 Install `ingress-nginx/ingress-nginx` Helm chart using `ingress-nginx.yaml` file created above.
 
 ```bash
-helm install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --version 3.12.0 -f ingress-nginx.yaml
+helm install ingress-nginx ingress-nginx/ingress-nginx --namespace ingress-nginx --version 4.0.6 -f ingress-nginx.yaml
 ```
 
 Documentation for `ingress-nginx/ingress-nginx` Helm chart can be found [here](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx).
@@ -207,7 +203,7 @@ helm repo update
 Install `jetstack/cert-manager` Helm chart:
 
 ```bash
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --set installCRDs=true
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.6.1 --set installCRDs=true
 ```
 
 Documentation for `jetstack/cert-manager` Helm chart can be found [here](https://artifacthub.io/packages/helm/jetstack/cert-manager).
@@ -313,7 +309,7 @@ Note the following values in the YAML file:
 
 ```yaml
 image:
-  tag: 2.8.0
+  tag: 2.8.1
 
 loadConfFromKeyVault: true
 
@@ -353,8 +349,8 @@ deployment:
     hostName: aks-cluster-ip.westeurope.cloudapp.azure.com
 ```
 
-> **NOTE**: Please note that we have used `2.8.0` as the value of `image:tag` configuration parameter
-> above. That will result in `2.8.0` version of microservices and edge modules to be deployed. If you want
+> **NOTE**: Please note that we have used `2.8.1` as the value of `image:tag` configuration parameter
+> above. That will result in `2.8.1` version of microservices and edge modules to be deployed. If you want
 > to deploy a different version of the platform, please specify it as the value of `image:tag` parameter.
 
 #### Passing Azure resource details through YAML file
@@ -395,7 +391,7 @@ Note the following values in the YAML file:
 
 ```yaml
 image:
-  tag: 2.8.0
+  tag: 2.8.1
 
 azure:
   tenantId: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
@@ -484,8 +480,8 @@ deployment:
     hostName: aks-cluster-ip.westeurope.cloudapp.azure.com
 ```
 
-> **NOTE**: Please note that we have used `2.8.0` as the value of `image:tag` configuration parameter
-> above. That will result in `2.8.0` version of microservices and edge modules to be deployed. If you want
+> **NOTE**: Please note that we have used `2.8.1` as the value of `image:tag` configuration parameter
+> above. That will result in `2.8.1` version of microservices and edge modules to be deployed. If you want
 > to deploy a different version of the platform, please specify it as the value of `image:tag` parameter.
 
 #### Installing `azure-industrial-iot` Helm chart
@@ -502,7 +498,7 @@ For installing the chart, please use `aiiot.yaml` that you created above and run
 helm install aiiot --namespace aiiot .\deploy\helm\azure-industrial-iot\ -f aiiot.yaml
 ```
 
-`aiiot.yaml` that we created above is for `0.4.0` or `0.3.2` versions of the Helm chart. Please modify it
+`aiiot.yaml` that we created above is for `0.4.x` or `0.3.2` versions of the Helm chart. Please modify it
 accordingly if you want to install a different version of the chart. Please check documentation of each
 version for a list of applicable values for that specific version. Documentation links of different versions
 of the chart can be found in [Deploying Azure Industrial IoT Platform Microservices Using Helm](howto-deploy-helm.md).

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -30,7 +30,7 @@
 
 `Microsoft.Azure.IIoT.Deployment` is a command line application for deploying Azure Industrial IoT solution.
 It takes care of deploying Azure infrastructure resources and microservices of Azure Industrial IoT solution.
-By default, it deploys `2.8` version of Azure Industrial IoT microservices.
+By default, it deploys `2.8.1` version of Azure Industrial IoT microservices.
 
 The main difference compared to the [script based deployment](howto-deploy-all-in-one.md) option is that
 from an infrastructure perspective `Microsoft.Azure.IIoT.Deployment` deploys microservices to an Azure
@@ -41,11 +41,25 @@ Source codes of `Microsoft.Azure.IIoT.Deployment` can be found in the following 
 
 ## Download `Microsoft.Azure.IIoT.Deployment` Binaries
 
-Latest compiled binaries of `Microsoft.Azure.IIoT.Deployment` can be found here:
+Latest compiled binaries of `Microsoft.Azure.IIoT.Deployment` for deployment of `2.8.x` version of
+Industrial IoT solution can be found here:
 
 * [linux-x64](https://azureiiot.blob.core.windows.net/binaries/main/preview/linux-x64/Microsoft.Azure.IIoT.Deployment)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/main/preview/linux-x64/Microsoft.Azure.IIoT.Deployment.md5))
 * [osx-x64](https://azureiiot.blob.core.windows.net/binaries/main/preview/osx-x64/Microsoft.Azure.IIoT.Deployment)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/main/preview/osx-x64/Microsoft.Azure.IIoT.Deployment.md5))
 * [win-x64](https://azureiiot.blob.core.windows.net/binaries/main/preview/win-x64/Microsoft.Azure.IIoT.Deployment.exe)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/main/preview/win-x64/Microsoft.Azure.IIoT.Deployment.md5))
+
+Compiled binaries of `Microsoft.Azure.IIoT.Deployment` for deployment of `2.7.x` version of
+Industrial IoT solution can be found here:
+
+* [linux-x64](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/linux-x64/Microsoft.Azure.IIoT.Deployment)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/linux-x64/Microsoft.Azure.IIoT.Deployment.md5))
+* [osx-x64](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/osx-x64/Microsoft.Azure.IIoT.Deployment)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/osx-x64/Microsoft.Azure.IIoT.Deployment.md5))
+* [win-x64](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/win-x64/Microsoft.Azure.IIoT.Deployment.exe)
+  ([md5](https://azureiiot.blob.core.windows.net/binaries/release/2.8.1/2.8.1/win-x64/Microsoft.Azure.IIoT.Deployment.md5))
 
 ## Running Microsoft.Azure.IIoT.Deployment
 
@@ -448,25 +462,29 @@ Command line argument key-value pairs can be specified with:
 
 ### Parameters
 
-| Key                         | Value details                                       | Description                                                                                  | Default                                   |
-|-----------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------------------------------|
-| `RunMode`                   | Check bellow for list of valid values.              | Determines which steps of Industrial IoT solution deployment will be executed.               | `Full`                                    |
-| `Auth:AzureEnvironment`     | Check bellow for list of valid values.              | Defines which Azure cloud to use.                                                            | `AzureGlobalCloud`                        |
-| `Auth:TenantId`             | Should be Guid.                                     | Id of the tenant to be used.                                                                 |                                           |
-| `Auth:ClientId`             | Should be Guid.                                     | ClientId of Service Principal.                                                               |                                           |
-| `Auth:ClientSecret`         | String                                              | ClientSecret of Service Principal.                                                           |                                           |
-| `SubscriptionId`            | Should be Guid.                                     | Id of Azure Subscription within tenant.                                                      |                                           |
-| `ApplicationName`           | Should be globally unique name.                     | Name of the application deployment.                                                          |                                           |
-| `ApplicationUrl`            | Used only in `ApplicationRegistration` run mode.    | Base URL that will be used for generating RedirectUris for client application.               |                                           |
-| `ResourceGroup:Name`        |                                                     | Name of the Resource Group where Azure resources will be created.                            |                                           |
-| `ResourceGroup:UseExisting` | If set, should be `true` or `false`.                | Determines whether an existing Resource Group should be used or a new one should be created. |                                           |
-| `ResourceGroup:Region`      | Check bellow for list of supported Azure regions.   | Region where new Resource Group should be created.                                           |                                           |
-| `Helm:RepoUrl`              | Should be URL.                                      | Helm repository URL for `azure-industrial-iot` Helm chart.                                   | `https://microsoft.github.io/charts/repo` |
-| `Helm:ChartVersion`         |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.3.2`                                   |
-| `Helm:ImageTag`             |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.7.206`                                 |
-| `ApplicationRegistration`   | Object, see [Special Notes](#special-notes) bellow. | Provides definitions of existing Applications and Service Principals to be used.             |                                           |
-| `SaveEnvFile`               | If set, should be `true` or `false`.                | Defines whether to create .env file after successful deployment or not.                      |                                           |
-| `NoCleanup`                 | If set, should be `true` or `false`.                | Defines whether to perform cleanup if an error occurs during deployment.                     |                                           |
+| Key                              | Value details                                       | Description                                                                                  | Default                                   |
+|----------------------------------|-----------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------------------------------|
+| `RunMode`                        | Check bellow for list of valid values.              | Determines which steps of Industrial IoT solution deployment will be executed.               | `Full`                                    |
+| `Auth:AzureEnvironment`          | Check bellow for list of valid values.              | Defines which Azure cloud to use.                                                            | `AzureGlobalCloud`                        |
+| `Auth:TenantId`                  | Should be Guid.                                     | Id of the tenant to be used.                                                                 |                                           |
+| `Auth:ClientId`                  | Should be Guid.                                     | ClientId of Service Principal.                                                               |                                           |
+| `Auth:ClientSecret`              | String                                              | ClientSecret of Service Principal.                                                           |                                           |
+| `SubscriptionId`                 | Should be Guid.                                     | Id of Azure Subscription within tenant.                                                      |                                           |
+| `ApplicationName`                | Should be globally unique name.                     | Name of the application deployment.                                                          |                                           |
+| `ApplicationUrl`                 | Used only in `ApplicationRegistration` run mode.    | Base URL that will be used for generating RedirectUris for client application.               |                                           |
+| `ResourceGroup:Name`             |                                                     | Name of the Resource Group where Azure resources will be created.                            |                                           |
+| `ResourceGroup:UseExisting`      | If set, should be `true` or `false`.                | Determines whether an existing Resource Group should be used or a new one should be created. |                                           |
+| `ResourceGroup:Region`           | Check bellow for list of supported Azure regions.   | Region where new Resource Group should be created.                                           |                                           |
+| `Helm:RepoUrl`                   | Should be URL.                                      | Helm repository URL for `azure-industrial-iot` Helm chart.                                   | `https://microsoft.github.io/charts/repo` |
+| `Helm:ChartVersion`              |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.4.1`                                   |
+| `Helm:ImageTag`                  |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.8.1`                                   |
+| `Helm:ImageNamespace`            |                                                     | Docker image namespace for Azure Industrial IoT components to be deployed.                   | `""`                                      |
+| `Helm:ContainerRegistryServer`   |                                                     | Docker container registry server to use for pulling images.                                  | `mcr.microsoft.com`                       |
+| `Helm:ContainerRegistryUsername` |                                                     | Username for Docker container registry.                                                      | `""`                                      |
+| `Helm:ContainerRegistryPassword` |                                                     | Password for Docker container registry.                                                      | `""`                                      |
+| `ApplicationRegistration`        | Object, see [Special Notes](#special-notes) bellow. | Provides definitions of existing Applications and Service Principals to be used.             |                                           |
+| `SaveEnvFile`                    | If set, should be `true` or `false`.                | Defines whether to create .env file after successful deployment or not.                      |                                           |
+| `NoCleanup`                      | If set, should be `true` or `false`.                | Defines whether to perform cleanup if an error occurs during deployment.                     |                                           |
 
 #### RunMode <!-- omit in toc -->
 
@@ -607,8 +625,8 @@ Kubernetes Dashboard.
 `azure-industrial-iot` Helm chart will be deployed. For more details about the chart please check its
 [documentation](../../deploy/helm/azure-industrial-iot/README.md).
 
-By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.4.0` version of `azure-industrial-iot` Helm chart
-with `2.8` version of Azure Industrial IoT components. Both chart version and components version can be
+By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.4.1` version of `azure-industrial-iot` Helm chart
+with `2.8.1` version of Azure Industrial IoT components. Both chart version and components version can be
 changed using configuration parameters. Please check `Helm:ChartVersion` and `Helm:ImageTag` parameters for
 that.
 

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -25,7 +25,7 @@ jobs:
     displayName: 'Publish Artifacts'
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
-      artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+      artifact: iiot_deployment_release_$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)_${{ parameters.runtime }}
   - task: AzureCLI@2
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
@@ -35,9 +35,9 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -25,7 +25,7 @@ jobs:
     displayName: 'Publish Artifacts'
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
-      artifact: iiot_deployment_release_$(setVersionInfo.Version_Full)_${{ parameters.runtime }}
+      artifact: iiot_deployment_release_$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)_${{ parameters.runtime }}
   - task: AzureCLI@2
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
@@ -35,9 +35,9 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -93,7 +93,7 @@ jobs:
     displayName: 'Publish Artifacts'
     inputs:
       path: $(Build.ArtifactStagingDirectory)/
-      artifact: iiot_deployment_release_$(setVersionInfo.Version_Prefix)_${{ parameters.runtime }}
+      artifact: iiot_deployment_release_$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)_${{ parameters.runtime }}
   - task: AzureCLI@2
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
@@ -103,9 +103,9 @@ jobs:
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
         az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5


### PR DESCRIPTION
Changes:
* Removed the following resources that were used for `2.7.x` version of the platform:
  * `tunnel` consumer group of IoT Hub built-in Event Hub that was used by removed Http Tunnel Processor.
  * ADLS Gen2 Storage Account that was used by removed Telemetry CDM Processor.
  * `telemetry_cdm` consumer group of Event Hub that was used by removed Telemetry CDM Processor.
* Updated `Microsoft.Azure.IIoT.Deployment` application to:
  * Use `0.4.1` version of `azure-industrial-iot` Helm chart by default.
  * Use `2.8.1` images by default.
  * Use `3.7.1` version of Helm CLI.
  * Use `v1.6.1` version of [`cert-manager`](https://artifacthub.io/packages/helm/cert-manager/cert-manager/1.6.1) chart.
  * Use `4.0.6` version of [`ingress-nginx`](https://artifacthub.io/packages/helm/ingress-nginx/ingress-nginx/4.0.6) Helm chart.
* Updated `docs\deploy\howto-add-aks-to-ps1.md` doc with values for new versions of `cert-manager` and `ingress-nginx` Helm charts.
* Updated `docs\deploy\howto-deploy-aks.md` doc to align with updates of `Microsoft.Azure.IIoT.Deployment` application. Added links for versions of application that deploy `2.7.x` and `2.8.x` versions of the platform.
* Updated pipeline components that publish compiled `Microsoft.Azure.IIoT.Deployment` application to use full `2.8.2-rc.x` format in path.