### PR TITLE
fix publisher backwards compatibility when --fm (fullfeaturedmessage) is disabled

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -174,8 +174,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                     (legacyCliModel.FullFeaturedMessage ? DataSetFieldContentMask.ServerTimestamp : 0) |
                                     DataSetFieldContentMask.NodeId |
                                     DataSetFieldContentMask.DisplayName |
-                                    DataSetFieldContentMask.ApplicationUri |
-                                    (legacyCliModel.FullFeaturedMessage ? DataSetFieldContentMask.EndpointUrl : 0) |
+                                    (legacyCliModel.FullFeaturedMessage ? DataSetFieldContentMask.ApplicationUri : 0) |
+                                    DataSetFieldContentMask.EndpointUrl |
                                     (legacyCliModel.FullFeaturedMessage ? DataSetFieldContentMask.ExtensionFields : 0),
                             MessageSettings = new DataSetWriterMessageSettingsModel() {
                                 DataSetMessageContentMask =


### PR DESCRIPTION
* include `EndpointUrl` instead of `ApplicationUri` in the telemetry when --fm (fullfeaturedmessage) is disabled 
* fix for Missing EndpointUrl in telemetry format #1385