### PR TITLE
temporarily disable default pn.json schema validation 

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/LegacyJobOrchestrator.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
 
                             try {
                                 if (!File.Exists(_legacyCliModel.PublishedNodesSchemaFile)) {
-                                    _logger.Warning("File {PublishedNodesSchemaFile} does not exist, ignoring schema validation of {publishedNodesFile} file...",
+                                    _logger.Information("Validation schema file {PublishedNodesSchemaFile} does not exist or is disabled, ignoring validation of {publishedNodesFile} file...",
                                     _legacyCliModel.PublishedNodesSchemaFile, _legacyCliModel.PublishedNodesFile);
 
                                     jobs = _publishedNodesJobConverter.Read(fileReader, null, _legacyCliModel);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// Key for default published nodes schema file.
         /// </summary>
-        public const string DefaultPublishedNodesSchemaFilename = "schemas/publishednodesschema.json";
+        public const string DefaultPublishedNodesSchemaFilename = "";
 
         /// <summary>
         /// Key for the publisher site.

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                     // Publisher configuration options
                     { "pf|publishfile=", "The filename to configure the nodes to publish.",
                         s => this[LegacyCliConfigKeys.PublishedNodesConfigurationFilename] = s },
-                    { "pfs|publishfileschema=", "The validation schema filename for publish file.",
+                    { "pfs|publishfileschema=", "The validation schema filename for publish file. Disabled by default.",
                         s => this[LegacyCliConfigKeys.PublishedNodesConfigurationSchemaFilename] = s },
                     { "s|site=", "The site OPC Publisher is working in.",
                         s => this[LegacyCliConfigKeys.PublisherSite] = s },


### PR DESCRIPTION
Temporarily disable default pn.json schema validation because of backwards compatibility issues:
* the validation schema is too restrictive with non-standard OPC UA namespace uris like the ones used by Kepserver. Even though the namespace uri definition is well defined in the OPC UA Spec, we find many opc ua servers in the field that use non-compliant uri strings. E.g.  "nsu=KEPServerEX;s=Sim.xxx". 
* the schema validation does not support NodeID in the IIoT Platform (twin defined) ExpandedNodeId format: "Namespaceuri#IdentifierUnion" e.g. `"Id": "http://test.org/UA/Data/#i=10847",`
* ExpandedNodeId is missing from OpcNode definition

Validation can enabled by specifying the right file using --pfs(publishfileschema) argument