### PR TITLE
fix execution of IoT edge modules as root

### DIFF
--- a/tools/scripts/docker-source.ps1
+++ b/tools/scripts/docker-source.ps1
@@ -124,21 +124,27 @@ if ($projFile) {
             runtimeId = "linux-arm"
             image = "mcr.microsoft.com/dotnet/core/runtime-deps:3.1"
             platformTag = "linux-arm32v7"
-            runtimeOnly = "RUN chmod +x $($assemblyName)"
+            runtimeOnly = "RUN chmod +x $($assemblyName)
+                RUN useradd -ms /bin/bash moduleuser
+                USER moduleuser"
             entryPoint = "[`"./$($assemblyName)`"]"
         }
         "linux/arm64" = @{
             runtimeId = "linux-musl-arm64"
             image = "mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine-arm64v8"
             platformTag = "linux-arm64v8"
-            runtimeOnly = "RUN chmod +x $($assemblyName)"
+            runtimeOnly = "RUN chmod +x $($assemblyName)
+                RUN adduser -Ds /bin/bash moduleuser
+                USER moduleuser"
             entryPoint = "[`"./$($assemblyName)`"]"
         }
         "linux/amd64" = @{
             runtimeId = "linux-musl-x64"
             image = "mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine"
             platformTag = "linux-amd64"
-            runtimeOnly = "RUN chmod +x $($assemblyName)"
+            runtimeOnly = "RUN chmod +x $($assemblyName)
+                RUN adduser -Ds /bin/bash moduleuser
+                USER moduleuser"
             entryPoint = "[`"./$($assemblyName)`"]"
         }
         "windows/amd64:10.0.17763.1457" = @{


### PR DESCRIPTION
fix [OPC Publisher runs as root](https://msazure.visualstudio.com/One/_workitems/edit/11020295)

IoT edge Modules are not executed as root:
![image](https://user-images.githubusercontent.com/7942439/141460378-bffbc8aa-fc73-4933-b1ac-c6fd166168a0.png)
