### PR TITLE
bugfix for metrics collector deployment through IAI

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/src/Deploy/Runtime/LogWorkspaceConfig.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Deploy/Runtime/LogWorkspaceConfig.cs
@@ -29,14 +29,22 @@ namespace Microsoft.Azure.IIoT.Deploy.Runtime {
             () => GetStringOrDefault(PcsVariable.PCS_WORKSPACE_KEY));
 
         /// <inheritdoc/>
-        public string IoTHubResourceId =>
-            "/subscriptions/" +
-            GetStringOrDefault(kSubscriptionId, () => GetStringOrDefault(PcsVariable.PCS_SUBSCRIPTION_ID)) +
-            "/resourceGroups/" +
-            GetStringOrDefault(kResourceGroupName, () => GetStringOrDefault(PcsVariable.PCS_RESOURCE_GROUP)) +
-            "/providers/Microsoft.Devices/IotHubs/" +
-            ConnectionString.Parse(GetStringOrDefault(kIoTHubConnectionString, () => GetStringOrDefault(PcsVariable.PCS_IOTHUB_CONNSTRING))).HubName;
-
+        public string IoTHubResourceId 
+        {
+            get {
+                string subscriptionId = GetStringOrDefault(kSubscriptionId, () => GetStringOrDefault(PcsVariable.PCS_SUBSCRIPTION_ID));
+                string resourceGroup = GetStringOrDefault(kResourceGroupName, () => GetStringOrDefault(PcsVariable.PCS_RESOURCE_GROUP));
+                if (string.IsNullOrEmpty(resourceGroup) || string.IsNullOrEmpty(subscriptionId)) {
+                    return string.Empty;
+                } else {
+                    return "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroup +
+                            "/providers/Microsoft.Devices/IotHubs/" +
+                            ConnectionString.Parse(GetStringOrDefault(kIoTHubConnectionString,
+                                    () => GetStringOrDefault(PcsVariable.PCS_IOTHUB_CONNSTRING))).HubName;
+                }
+            }
+        }
+            
         /// <summary>
         /// Configuration constructor
         /// </summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Deploy/IoTHubMetricsCollectorDeployment.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/src/Deploy/IoTHubMetricsCollectorDeployment.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Deploy {
 
         /// <inheritdoc/>
         public async Task StartAsync() {
-            if (string.IsNullOrEmpty(_config.LogWorkspaceId) || string.IsNullOrEmpty(_config.LogWorkspaceKey)) {
+            if (string.IsNullOrEmpty(_config.LogWorkspaceId) || string.IsNullOrEmpty(_config.LogWorkspaceKey)
+                    || string.IsNullOrEmpty(_config.IoTHubResourceId)) {
                 _logger.Warning("Azure Log Analytics Workspace configuration is not set." +
                     " Cannot proceed with metricscollector deployment.");
                 return;

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Deploy/IoTHubMetricsCollectorDeploymentTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Deploy/IoTHubMetricsCollectorDeploymentTests.cs
@@ -107,6 +107,34 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Tests.Deploy {
         }
 
         [Fact]
+        public async Task EmptyIotHubResourceIdConfigTestAsync() {
+
+            IList<ConfigurationModel> configurationModelList = new List<ConfigurationModel>();
+
+            var ioTHubConfigurationServicesMock = new Mock<IIoTHubConfigurationServices>();
+            ioTHubConfigurationServicesMock
+                .Setup(e => e.CreateOrUpdateConfigurationAsync(It.IsAny<ConfigurationModel>(), true, CancellationToken.None))
+                .Callback<ConfigurationModel, bool, CancellationToken>(
+                    (confModel, forceUpdate, ct) => configurationModelList.Add(confModel))
+                .Returns((ConfigurationModel configuration, bool forceUpdate, CancellationToken ct) => Task.FromResult(configuration));
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection()
+                .Build();
+            configuration["Docker:WorkspaceId"] = "WorkspaceId";
+            configuration["Docker:WorkspaceKey"] = "WorkspaceKey";
+            configuration["SubscriptionId"] = "";
+            configuration["ResourceGroupName"] = null;
+            configuration["IoTHubConnectionString"] = "HostName=test.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=test";
+
+            using (var mock = Setup(ioTHubConfigurationServicesMock, configuration)) {
+                var metricsCollectorDeploymentService = mock.Create<IoTHubMetricsCollectorDeployment>();
+                await metricsCollectorDeploymentService.StartAsync();
+                Assert.Equal(0, configurationModelList.Count);
+            }
+        }
+
+        [Fact]
         public async Task EmptyLogWorkspaceConfigTestAsync() {
 
             IList<ConfigurationModel> configurationModelList = new List<ConfigurationModel>();

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Deployment/DeploymentExecutor.cs
@@ -1053,6 +1053,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Deployment {
             var iiotEnvironment = new IIoTEnvironment(
                 _authConf.AzureEnvironment,
                 _authConf.TenantId,
+                _subscription.SubscriptionId,
+                _resourceGroup.Name,
                 // IoT Hub
                 iotHub,
                 iotHubOwnerConnectionString,

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/IIoTEnvironment.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Azure.IIoT.Deployment {
         // Log Analytics Workspace
         public readonly string PCS_WORKSPACE_ID;
         public readonly string PCS_WORKSPACE_KEY;
+        public readonly string PCS_SUBSCRIPTION_ID;
+        public readonly string PCS_RESOURCE_GROUP;
 
         // Service URLs
         public readonly string PCS_SERVICE_URL;
@@ -106,6 +108,8 @@ namespace Microsoft.Azure.IIoT.Deployment {
         public IIoTEnvironment(
             AzureEnvironment azureEnvironment,
             Guid tenantId,
+            string subscriptionId,
+            string resourceGroupName,
             // IoT Hub
             IotHubDescription iotHub,
             string iotHubOwnerConnectionString,
@@ -178,6 +182,8 @@ namespace Microsoft.Azure.IIoT.Deployment {
             // Log Analytics Workspace
             PCS_WORKSPACE_ID = workspace.Id;
             PCS_WORKSPACE_KEY = workspaceKey;
+            PCS_SUBSCRIPTION_ID = subscriptionId;
+            PCS_RESOURCE_GROUP = resourceGroupName;
 
             // Service URLs
             PCS_SERVICE_URL = serviceURL;
@@ -262,6 +268,8 @@ namespace Microsoft.Azure.IIoT.Deployment {
                 // Log Analytics Workspace
                 { $"{nameof(PCS_WORKSPACE_ID)}", PCS_WORKSPACE_ID },
                 { $"{nameof(PCS_WORKSPACE_KEY)}", PCS_WORKSPACE_KEY },
+                { $"{nameof(PCS_SUBSCRIPTION_ID)}", PCS_SUBSCRIPTION_ID },
+                { $"{nameof(PCS_RESOURCE_GROUP)}", PCS_RESOURCE_GROUP },
 
                 // Service URLs
                 { $"{nameof(PCS_SERVICE_URL)}", PCS_SERVICE_URL },


### PR DESCRIPTION
There are two actually two issues here:

- Both variables - PCS_SUBSCRIPTION_ID and PCS_RESOURCE_GROUP were not available through IIoT Environment file for IAI deployment

- These two variables were used to construct IoTHubResourceId parameter in LogWorkspace config. Moreover, empty check was not available for this parameter in IotHubMetricsCollector deployment file.

Fixed by:

- Adding PCS_SUBSCRIPTION_ID and PCS_RESOURCE_GROUP for IAI deployment

- Adding empty check for IoTHubResourceId parameter so that the deployment fails instead of creating an erroneous deployment


Workitem link is [here](https://dev.azure.com/msazure/One/_boards/board/t/IoT-Industrial-Edge-Data/Backlog%20items/?workitem=12450681).