### PR TITLE
Diagnostic connection counters

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
@@ -27,20 +27,17 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         public string Id => _writerGroup.WriterGroupId;
 
         /// <inheritdoc/>
-        public int NumberOfConnectionRetries => _subscriptions?.FirstOrDefault()?.
-            Subscription?.NumberOfConnectionRetries ?? 0;
+        public int NumberOfConnectionRetries => _subscriptions?.Sum(x => x.Subscription?.NumberOfConnectionRetries) ?? 0;
 
         /// <inheritdoc/>
-        public bool IsConnectionOk => _subscriptions?.FirstOrDefault()?.
-            Subscription?.IsConnectionOk ?? false;
+        public bool IsConnectionOk => (_subscriptions?.Count == 0 || 
+            _subscriptions?.Where(x => x.Subscription?.IsConnectionOk == true).Count() < _subscriptions?.Count) ? false : true;
 
         /// <inheritdoc/>
-        public int NumberOfGoodNodes => _subscriptions?.FirstOrDefault()?.
-            Subscription?.NumberOfGoodNodes ?? 0;
+        public int NumberOfGoodNodes => _subscriptions?.Sum(x => x.Subscription?.NumberOfGoodNodes) ?? 0;
 
         /// <inheritdoc/>
-        public int NumberOfBadNodes => _subscriptions?.FirstOrDefault()?.
-            Subscription?.NumberOfBadNodes ?? 0;
+        public int NumberOfBadNodes => _subscriptions?.Sum(x => x.Subscription?.NumberOfBadNodes) ?? 0;
 
         /// <inheritdoc/>
         public ulong ValueChangesCountLastMinute {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
@@ -3,8 +3,7 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
-{
+namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
     using Microsoft.Azure.IIoT.OpcUa.Protocol;
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Models;
@@ -23,8 +22,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
     /// <summary>
     /// Triggers dataset writer messages on subscription changes
     /// </summary>
-    public class WriterGroupMessageTrigger : IMessageTrigger, IDisposable
-    {
+    public class WriterGroupMessageTrigger : IMessageTrigger, IDisposable {
         /// <inheritdoc/>
         public string Id => _writerGroup.WriterGroupId;
 
@@ -45,18 +43,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             Subscription?.NumberOfBadNodes ?? 0;
 
         /// <inheritdoc/>
-        public ulong ValueChangesCountLastMinute
-        {
+        public ulong ValueChangesCountLastMinute {
             get => CalculateSumForRingBuffer(_valueChangesBuffer, ref _lastPointerValueChanges, _bucketWidth, _lastWriteTimeValueChange);
             private set => IncreaseRingBuffer(_valueChangesBuffer, ref _lastPointerValueChanges, _bucketWidth, value, ref _lastWriteTimeValueChange);
         }
 
         /// <inheritdoc/>
-        public ulong ValueChangesCount
-        {
+        public ulong ValueChangesCount {
             get { return _valueChangesCount; }
-            private set
-            {
+            private set {
                 var difference = value - _valueChangesCount;
                 _valueChangesCount = value;
                 ValueChangesCountLastMinute = difference;
@@ -64,21 +59,17 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         }
 
         /// <inheritdoc/>
-        public ulong DataChangesCountLastMinute
-        {
+        public ulong DataChangesCountLastMinute {
             get => CalculateSumForRingBuffer(_dataChangesBuffer, ref _lastPointerDataChanges, _bucketWidth, _lastWriteTimeDataChange);
             private set => IncreaseRingBuffer(_dataChangesBuffer, ref _lastPointerDataChanges, _bucketWidth, value, ref _lastWriteTimeDataChange);
         }
 
         /// <inheritdoc/>
-        public ulong DataChangesCount
-        {
-            get
-            {
+        public ulong DataChangesCount {
+            get {
                 return _dataChangesCount;
             }
-            private set
-            {
+            private set {
                 var difference = value - _dataChangesCount;
                 _dataChangesCount = value;
                 DataChangesCountLastMinute = difference;
@@ -88,15 +79,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// <summary>
         /// Iterates the array and add up all values
         /// </summary>
-        private static ulong CalculateSumForRingBuffer(ulong[] array, ref int lastPointer, int bucketWidth, DateTime lastWriteTime)
-        {
+        private static ulong CalculateSumForRingBuffer(ulong[] array, ref int lastPointer, int bucketWidth, DateTime lastWriteTime) {
             // if IncreaseRingBuffer wasn't called for some time, maybe some stale values are included
             UpdateRingBufferBuckets(array, ref lastPointer, bucketWidth, ref lastWriteTime);
 
             // with cleaned buffer, we can just accumulate all buckets
             ulong sum = 0;
-            for (int index = 0; index < array.Length; index++)
-            {
+            for (int index = 0; index < array.Length; index++) {
                 sum += array[index];
             }
             return sum;
@@ -105,8 +94,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// <summary>
         /// Helper function to distribute values over array based on time
         /// </summary>
-        private static void IncreaseRingBuffer(ulong[] array, ref int lastPointer, int bucketWidth, ulong difference, ref DateTime lastWriteTime)
-        {
+        private static void IncreaseRingBuffer(ulong[] array, ref int lastPointer, int bucketWidth, ulong difference, ref DateTime lastWriteTime) {
             var indexPointer = UpdateRingBufferBuckets(array, ref lastPointer, bucketWidth, ref lastWriteTime);
 
             array[indexPointer] += difference;
@@ -115,25 +103,21 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// <summary>
         /// Empty the ring buffer buckets if necessary
         /// </summary>
-        private static int UpdateRingBufferBuckets(ulong[] array, ref int lastPointer, int bucketWidth, ref DateTime lastWriteTime)
-        {
+        private static int UpdateRingBufferBuckets(ulong[] array, ref int lastPointer, int bucketWidth, ref DateTime lastWriteTime) {
             var now = DateTime.UtcNow;
             var indexPointer = now.Second % bucketWidth;
 
             // if last update was > bucketsize seconds in the past delete whole array
-            if (lastWriteTime != DateTime.MinValue)
-            {
+            if (lastWriteTime != DateTime.MinValue) {
                 var deleteWholeArray = (now - lastWriteTime).TotalSeconds >= bucketWidth;
-                if (deleteWholeArray)
-                {
+                if (deleteWholeArray) {
                     Array.Clear(array, 0, array.Length);
                     lastPointer = indexPointer;
                 }
             }
 
             // reset all buckets, between last write and now
-            while (lastPointer != indexPointer)
-            {
+            while (lastPointer != indexPointer) {
                 lastPointer = (lastPointer + 1) % bucketWidth;
                 array[lastPointer] = 0;
             }
@@ -149,8 +133,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// <inheritdoc/>
         public event EventHandler<EventArgs> OnCounterReset;
 
-        private void FireOnCounterResetEvent()
-        {
+        private void FireOnCounterResetEvent() {
             OnCounterReset?.Invoke(this, EventArgs.Empty);
         }
 
@@ -158,8 +141,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// Create trigger from writer group
         /// </summary>
         public WriterGroupMessageTrigger(IWriterGroupConfig writerGroupConfig,
-            ISubscriptionManager subscriptionManager, ILogger logger)
-        {
+            ISubscriptionManager subscriptionManager, ILogger logger) {
 
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _subscriptionManager = subscriptionManager ??
@@ -173,24 +155,20 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         }
 
         /// <inheritdoc/>
-        public async Task RunAsync(CancellationToken ct)
-        {
+        public async Task RunAsync(CancellationToken ct) {
 
             _subscriptions.ForEach(sc => sc.OpenAsync().Wait());
             _subscriptions.ForEach(sc => sc.ActivateAsync(ct).Wait());
-            try
-            {
+            try {
                 await Task.Delay(-1, ct).ConfigureAwait(false);
             }
-            finally
-            {
+            finally {
                 _subscriptions.ForEach(sc => sc.DeactivateAsync().Wait());
             }
         }
 
         /// <inheritdoc/>
-        public void Dispose()
-        {
+        public void Dispose() {
             _subscriptions.ForEach(sc => sc.Dispose());
             _subscriptions.Clear();
         }
@@ -198,8 +176,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
         /// <summary>
         /// Helper to manage subscriptions
         /// </summary>
-        private sealed class DataSetWriterSubscription : IDisposable
-        {
+        private sealed class DataSetWriterSubscription : IDisposable {
 
             /// <summary>
             /// Active subscription
@@ -212,8 +189,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// <param name="outer"></param>
             /// <param name="dataSetWriter"></param>
             public DataSetWriterSubscription(WriterGroupMessageTrigger outer,
-                DataSetWriterModel dataSetWriter)
-            {
+                DataSetWriterModel dataSetWriter) {
 
                 _outer = outer ?? throw new ArgumentNullException(nameof(outer));
                 _dataSetWriter = dataSetWriter.Clone() ??
@@ -221,20 +197,17 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
                 _subscriptionInfo = _dataSetWriter.ToSubscriptionModel();
 
                 if (dataSetWriter.KeyFrameInterval.HasValue &&
-                   dataSetWriter.KeyFrameInterval.Value > TimeSpan.Zero)
-                {
+                   dataSetWriter.KeyFrameInterval.Value > TimeSpan.Zero) {
                     _keyframeTimer = new Timer(
                         dataSetWriter.KeyFrameInterval.Value.TotalMilliseconds);
                     _keyframeTimer.Elapsed += KeyframeTimerElapsedAsync;
                 }
-                else
-                {
+                else {
                     _keyFrameCount = dataSetWriter.KeyFrameCount;
                 }
 
                 if (dataSetWriter.DataSetMetaDataSendInterval.HasValue &&
-                    dataSetWriter.DataSetMetaDataSendInterval.Value > TimeSpan.Zero)
-                {
+                    dataSetWriter.DataSetMetaDataSendInterval.Value > TimeSpan.Zero) {
                     _metaData = dataSetWriter.DataSet?.DataSetMetaData ??
                         throw new ArgumentNullException(nameof(dataSetWriter.DataSet));
 
@@ -248,10 +221,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// Open subscription
             /// </summary>
             /// <returns></returns>
-            public async Task OpenAsync()
-            {
-                if (Subscription != null)
-                {
+            public async Task OpenAsync() {
+                if (Subscription != null) {
                     _outer._logger.Warning("Subscription already exists");
                     return;
                 }
@@ -269,28 +240,23 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// </summary>
             /// <param name="ct"></param>
             /// <returns></returns>
-            public async Task ActivateAsync(CancellationToken ct)
-            {
-                if (Subscription == null)
-                {
+            public async Task ActivateAsync(CancellationToken ct) {
+                if (Subscription == null) {
                     _outer._logger.Warning("Subscription not registered");
                     return;
                 }
                 // only try to activate if already enabled. Otherwise the activation
                 // will be handled by the session's keep alive mechanism
-                if (Subscription.Enabled)
-                {
+                if (Subscription.Enabled) {
                     await Subscription.ActivateAsync(null).ConfigureAwait(false);
                 }
 
-                if (_keyframeTimer != null)
-                {
+                if (_keyframeTimer != null) {
                     ct.Register(() => _keyframeTimer.Stop());
                     _keyframeTimer.Start();
                 }
 
-                if (_metadataTimer != null)
-                {
+                if (_metadataTimer != null) {
                     ct.Register(() => _metadataTimer.Stop());
                     _metadataTimer.Start();
                 }
@@ -300,34 +266,28 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// deactivate a subscription
             /// </summary>
             /// <returns></returns>
-            public async Task DeactivateAsync()
-            {
+            public async Task DeactivateAsync() {
 
-                if (Subscription == null)
-                {
+                if (Subscription == null) {
                     _outer._logger.Warning("Subscription not registered");
                     return;
                 }
 
                 await Subscription.CloseAsync().ConfigureAwait(false);
 
-                if (_keyframeTimer != null)
-                {
+                if (_keyframeTimer != null) {
                     _keyframeTimer.Stop();
                 }
 
-                if (_metadataTimer != null)
-                {
+                if (_metadataTimer != null) {
                     _metadataTimer.Stop();
                 }
             }
 
 
             /// <inheritdoc/>
-            public void Dispose()
-            {
-                if (Subscription != null)
-                {
+            public void Dispose() {
+                if (Subscription != null) {
                     Subscription.OnSubscriptionChange -= OnSubscriptionChangedAsync;
                     Subscription.Dispose();
                 }
@@ -341,26 +301,21 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// </summary>
             /// <param name="sender"></param>
             /// <param name="e"></param>
-            private async void KeyframeTimerElapsedAsync(object sender, ElapsedEventArgs e)
-            {
-                try
-                {
+            private async void KeyframeTimerElapsedAsync(object sender, ElapsedEventArgs e) {
+                try {
                     _keyframeTimer.Enabled = false;
 
                     _outer._logger.Debug("Insert keyframe message...");
                     var sequenceNumber = (uint)Interlocked.Increment(ref _currentSequenceNumber);
                     var snapshot = await Subscription.GetSnapshotAsync().ConfigureAwait(false);
-                    if (snapshot != null)
-                    {
+                    if (snapshot != null) {
                         CallMessageReceiverDelegates(this, sequenceNumber, snapshot);
                     }
                 }
-                catch (Exception ex)
-                {
+                catch (Exception ex) {
                     _outer._logger.Information(ex, "Failed to send keyframe.");
                 }
-                finally
-                {
+                finally {
                     _keyframeTimer.Enabled = true;
                 }
             }
@@ -370,8 +325,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// </summary>
             /// <param name="sender"></param>
             /// <param name="e"></param>
-            private void MetadataTimerElapsed(object sender, ElapsedEventArgs e)
-            {
+            private void MetadataTimerElapsed(object sender, ElapsedEventArgs e) {
                 // Send(_metaData)
             }
 
@@ -381,15 +335,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// <param name="sender"></param>
             /// <param name="notification"></param>
             private async void OnSubscriptionChangedAsync(object sender,
-                SubscriptionNotificationModel notification)
-            {
+                SubscriptionNotificationModel notification) {
                 var sequenceNumber = (uint)Interlocked.Increment(ref _currentSequenceNumber);
                 if (_keyFrameCount.HasValue && _keyFrameCount.Value != 0 &&
-                    (sequenceNumber % _keyFrameCount.Value) == 0)
-                {
+                    (sequenceNumber % _keyFrameCount.Value) == 0) {
                     var snapshot = await Try.Async(() => Subscription.GetSnapshotAsync()).ConfigureAwait(false);
-                    if (snapshot != null)
-                    {
+                    if (snapshot != null) {
                         notification = snapshot;
                     }
                 }
@@ -403,12 +354,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
             /// <param name="sequenceNumber"></param>
             /// <param name="notification"></param>
             private void CallMessageReceiverDelegates(object sender, uint sequenceNumber,
-                SubscriptionNotificationModel notification)
-            {
-                try
-                {
-                    var message = new DataSetMessageModel
-                    {
+                SubscriptionNotificationModel notification) {
+                try {
+                    var message = new DataSetMessageModel {
                         // TODO: Filter changes on the monitored items contained in the template
                         Notifications = notification.Notifications.ToList(),
                         ServiceMessageContext = notification.ServiceMessageContext,
@@ -421,11 +369,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
                         Writer = _dataSetWriter,
                         WriterGroup = _outer._writerGroup
                     };
-                    lock (_lock)
-                    {
+                    lock (_lock) {
                         if (_outer.DataChangesCount >= kNumberOfInvokedMessagesResetThreshold ||
-                            _outer.ValueChangesCount >= kNumberOfInvokedMessagesResetThreshold)
-                        {
+                            _outer.ValueChangesCount >= kNumberOfInvokedMessagesResetThreshold) {
                             // reset both
                             _outer._logger.Information("Notifications counter has been reset to prevent overflow. " +
                                 "So far, {DataChangesCount} data changes and {ValueChangesCount}" +
@@ -441,8 +387,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine
                         _outer.OnMessage?.Invoke(sender, message);
                     }
                 }
-                catch (Exception ex)
-                {
+                catch (Exception ex) {
                     _outer._logger.Debug(ex, "Failed to produce message");
                 }
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/IMessageTrigger.cs
@@ -25,6 +25,21 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher {
         int NumberOfConnectionRetries { get; }
 
         /// <summary>
+        /// Is connection ok?
+        /// </summary>
+        bool IsConnectionOk { get; }
+
+        /// <summary>
+        /// Number of nodes currently connected and returning data
+        /// </summary>
+        int NumberOfGoodNodes { get; }
+
+        /// <summary>
+        /// Number of nodes currently not connected
+        /// </summary>
+        int NumberOfBadNodes { get; }
+
+        /// <summary>
         /// The number of all monitored items value changes
         /// that have been invoked by this message source.
         /// </summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISessionManager.cs
@@ -19,11 +19,32 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol {
         int SessionCount { get; }
 
         /// <summary>
-        /// gets the number of retiries for a speciffic session
+        /// gets the number of retiries for a specific session
         /// </summary>
         /// <param name="connection"></param>
         /// <returns></returns>
         int GetNumberOfConnectionRetries(ConnectionModel connection);
+
+        /// <summary>
+        /// Returns whether the connection is up and running or not
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        public bool IsConnectionOk(ConnectionModel connection);
+
+        /// <summary>
+        /// Gets the number nodes connected and receiving data
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        int GetNumberOfGoodNodes(ConnectionModel connection);
+
+        /// <summary>
+        /// Gets the number nodes disconnected
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <returns></returns>
+        int GetNumberOfBadNodes(ConnectionModel connection);
 
         /// <summary>
         /// Get or create session for subscription

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISessionManager.cs
@@ -33,20 +33,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol {
         public bool IsConnectionOk(ConnectionModel connection);
 
         /// <summary>
-        /// Gets the number nodes connected and receiving data
-        /// </summary>
-        /// <param name="connection"></param>
-        /// <returns></returns>
-        int GetNumberOfGoodNodes(ConnectionModel connection);
-
-        /// <summary>
-        /// Gets the number nodes disconnected
-        /// </summary>
-        /// <param name="connection"></param>
-        /// <returns></returns>
-        int GetNumberOfBadNodes(ConnectionModel connection);
-
-        /// <summary>
         /// Get or create session for subscription
         /// </summary>
         /// <param name="connection"></param>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISubscription.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/ISubscription.cs
@@ -52,6 +52,21 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol {
         int NumberOfConnectionRetries { get; }
 
         /// <summary>
+        /// IsConnectionOk
+        /// </summary>
+        bool IsConnectionOk { get; }
+
+        /// <summary>
+        /// Number of nodes connected and receiving data
+        /// </summary>
+        int NumberOfGoodNodes { get; }
+
+        /// <summary>
+        /// Number of nodes disconnected
+        /// </summary>
+        int NumberOfBadNodes { get; }
+
+        /// <summary>
         /// Create snapshot
         /// </summary>
         /// <returns></returns>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
@@ -79,36 +79,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
         }
 
         /// <inheritdoc/>
-        public int GetNumberOfGoodNodes(ConnectionModel connection) {
-            var key = new ConnectionIdentifier(connection);
-            _lock.Wait();
-            try {
-                if (!_sessions.TryGetValue(key, out var wrapper)) {
-                    return 0;
-                }
-                return wrapper._subscriptions.Sum(x => x.Value.NumberOfGoodNodes);
-            }
-            finally {
-                _lock.Release();
-            }
-        }
-
-        /// <inheritdoc/>
-        public int GetNumberOfBadNodes(ConnectionModel connection) {
-            var key = new ConnectionIdentifier(connection);
-            _lock.Wait();
-            try {
-                if (!_sessions.TryGetValue(key, out var wrapper)) {
-                    return 0;
-                }
-                return wrapper._subscriptions.Sum(x => x.Value.NumberOfBadNodes);
-            }
-            finally {
-                _lock.Release();
-            }
-        }
-
-        /// <inheritdoc/>
         public Session GetOrCreateSession(ConnectionModel connection,
             bool createIfNotExists) {
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
 
         /// <inheritdoc/>
         public int GetNumberOfConnectionRetries(ConnectionModel connection) {
-
             var key = new ConnectionIdentifier(connection);
             _lock.Wait();
             try {
@@ -58,6 +57,51 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                     return 0;
                 }
                 return wrapper.NumberOfConnectRetries;
+            }
+            finally {
+                _lock.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool IsConnectionOk(ConnectionModel connection) {
+            var key = new ConnectionIdentifier(connection);
+            _lock.Wait();
+            try {
+                if (!_sessions.TryGetValue(key, out var wrapper)) {
+                    return false;
+                }
+                return wrapper.State == SessionState.Running;
+            }
+            finally {
+                _lock.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public int GetNumberOfGoodNodes(ConnectionModel connection) {
+            var key = new ConnectionIdentifier(connection);
+            _lock.Wait();
+            try {
+                if (!_sessions.TryGetValue(key, out var wrapper)) {
+                    return 0;
+                }
+                return wrapper._subscriptions.Sum(x => x.Value.NumberOfGoodNodes);
+            }
+            finally {
+                _lock.Release();
+            }
+        }
+
+        /// <inheritdoc/>
+        public int GetNumberOfBadNodes(ConnectionModel connection) {
+            var key = new ConnectionIdentifier(connection);
+            _lock.Wait();
+            try {
+                if (!_sessions.TryGetValue(key, out var wrapper)) {
+                    return 0;
+                }
+                return wrapper._subscriptions.Sum(x => x.Value.NumberOfBadNodes);
             }
             finally {
                 _lock.Release();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -80,6 +80,31 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 _outer._sessionManager.GetNumberOfConnectionRetries(_subscription.Connection);
 
             /// <inheritdoc/>
+            public bool IsConnectionOk =>
+                _outer._sessionManager.IsConnectionOk(_subscription.Connection);
+
+            /// <inheritdoc/>
+            public int NumberOfGoodNodes {
+                get {
+                    return (IsConnectionOk && _currentlyMonitored != null) ?
+                        _currentlyMonitored
+                            .Where(x => x.Item.Status.MonitoringMode == Opc.Ua.MonitoringMode.Reporting ||
+                                    x.Item.Status.MonitoringMode == Opc.Ua.MonitoringMode.Sampling)
+                            .Count() : 0;
+                }
+            }
+
+            /// <inheritdoc/>
+            public int NumberOfBadNodes {
+                get {
+                    return (IsConnectionOk && _currentlyMonitored != null) ?
+                        _currentlyMonitored
+                            .Where(x => x.Item.Status.MonitoringMode == Opc.Ua.MonitoringMode.Disabled)
+                            .Count() : 0;
+                }
+            }
+
+            /// <inheritdoc/>
             public ConnectionModel Connection => _subscription.Connection;
 
             /// <inheritdoc/>
@@ -853,7 +878,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             /// <summary>
             /// Last published time
             /// </summary>
-            public DateTime NextHeartbeat {get; private set; }
+            public DateTime NextHeartbeat { get; private set; }
 
             /// <summary>
             /// validates if a heartbeat is required.

--- a/docs/manual/readme.md
+++ b/docs/manual/readme.md
@@ -1531,6 +1531,9 @@ Several metrics are provided by default to give an overview of the health of the
 | iiot_edge_publisher_encoded_message_size_average      | deviceid, module, triggerid                      | Encoded IoT message body size average                                                   | gauge     |
 | iiot_edge_publisher_chunk_size_average                 | deviceid, module, triggerid                      | IoT Hub chunk size average                                                              | gauge     |
 | iiot_edge_publisher_estimated_message_chunks_per_day | deviceid, module, triggerid                      | Estimated IoT Hub chunks charged per day                                                | gauge     |
+| iiot_edge_publisher_is_connection_ok                 | deviceid, module, triggerid                      | Is the endpoint connection ok?                                                          | gauge     |
+| iiot_edge_publisher_good_nodes                       | deviceid, module, triggerid                      | How many nodes are receiving data for this endpoint?                                    | gauge     |
+| iiot_edge_publisher_bad_nodes                        | deviceid, module, triggerid                      | How many nodes are misconfigured for this endpoint?                                     | gauge     |
 
 Cloud Microservices Metrics are described below:
 


### PR DESCRIPTION
This PR adds three diagnostic counters per endpoint:
* Is the endpoint connection up and running?
* How many nodes have successfully connected and are receiving data?
* How many nodes have misconfiguration causing them to not connect?

Example of diagnostic output can be seen here:
![image](https://user-images.githubusercontent.com/5628905/142489742-59a21cbf-93b6-4609-beea-bd5c02a0ea86.png)
