### PR TITLE
Add DeviceAuthentication login option for Connect-AzAccount

### DIFF
--- a/deploy/scripts/aad-register.ps1
+++ b/deploy/scripts/aad-register.ps1
@@ -88,7 +88,6 @@ Function Select-Context() {
             # for the case where prompting web browser is not applicable, we will prompt for DeviceAuthentication login.
             $azProfile = Connect-AzAccount `
             -UseDeviceAuthentication `
-            -TenantId $script:tenantId `
             -Environment $environmentName @tenantIdArg `
             -ErrorAction Stop
 


### PR DESCRIPTION
When the user's environment cannot prompting web browser for Connect-AzAccount login, the original code not able to catch that, no error popup but the output will be null.
An improvement here is to change line 75 -ErrorAction to -WarningAction to catch this case, and provide DeviceAuthentication login option for the user.