### PR TITLE
Using IIOT_TEST subscription for deployment of E2E resources. (#1480)

### DIFF
--- a/tools/e2etesting/steps/deployplatform.yml
+++ b/tools/e2etesting/steps/deployplatform.yml
@@ -29,8 +29,8 @@ steps:
   displayName: 'Load secrets from Key Vault as variables by default'
   condition: and(eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
   inputs:
-    azureSubscription: 'IOT-OPC-WALLS-SP'
-    KeyVaultName: 'developerPipelineKV'
+    azureSubscription: '$(AzureSubscription)'
+    KeyVaultName: '$(DevAcrCredentialsKeyVaultName)'
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 
@@ -38,8 +38,8 @@ steps:
   displayName: 'Load secrets from Release Key Vault as variables on Release Branch'
   condition: startsWith(variables['BranchName'], 'release')
   inputs:
-    azureSubscription: 'IOT-OPC-WALLS-SP'
-    KeyVaultName: 'industrialiotKV'
+    azureSubscription: '$(AzureSubscription)'
+    KeyVaultName: '$(ReleaseAcrCredentialsKeyVaultName)'
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -67,8 +67,8 @@ steps:
   displayName: 'Load secrets from Key Vault as variables by default'
   condition: and(eq(variables['ContainerRegistryServer'], ''), eq(variables['ContainerRegistryUsername'], ''), eq(variables['ContainerRegistryPassword'], ''))
   inputs:
-    azureSubscription: 'IOT-OPC-WALLS-SP'
-    KeyVaultName: 'developerPipelineKV'
+    azureSubscription: '$(AzureSubscription)'
+    KeyVaultName: '$(DevAcrCredentialsKeyVaultName)'
     SecretsFilter: 'ContainerRegistryPassword,ContainerRegistryServer,ContainerRegistryUsername'
     RunAsPreJob: true
 

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -1,7 +1,9 @@
 variables:
   BasePath: $(System.DefaultWorkingDirectory)\tools\e2etesting
   ClientCredentialsKeyVaultName: automatedtesting
-  AzureSubscription: IOT-OPC-WALLS-SP # Use Services-Connection with Service-Principal-Authentication as subscription
+  DevAcrCredentialsKeyVaultName: kv-developer-pipeline
+  ReleaseAcrCredentialsKeyVaultName: kv-release-pipeline
+  AzureSubscription: IIOT_TEST-SP # Use Services-Connection with Service-Principal-Authentication as subscription
   AgentPool: Azure-IoT-Manufacturing
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests


### PR DESCRIPTION
This PR applies changes in #1480 on `releases` branch so that scheduled build and test pipelines from this branch use resources in `IIOT_TEST` subscription.

Changes:
* Moved names of hardcoded Key Vaults to tools/e2etesting/steps/variables.yml.
* Changed service connection and Key Vault details to use the ones pointing to IIOT_TEST subscription.

Successful runs of pipelines:
* [Azure.Industrial-IoT-E2ETesting-Orchestrated](https://iotcat.visualstudio.com/Industrial-IoT-E2E-Testing/_build/results?buildId=3116&view=results)
* [Azure.Industrial-IoT-E2ETesting-Standalone](https://iotcat.visualstudio.com/Industrial-IoT-E2E-Testing/_build/results?buildId=3117&view=results)