### PR TITLE
Migrating storage account for IAI binaries to IIOT_TEST subscription.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,11 @@ trigger:
     - releases
     - dev/*
     - release/*
+
+variables:
+  iaiStorageAccount: azureiiotbak
+  iaiStorageAccountSubscription: azureiiotbak-storage
+
 stages:
 - stage: build
   displayName: 'Build and Test Code'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ trigger:
     - release/*
 
 variables:
-  iaiStorageAccount: azureiiotbak
+  iaiStorageAccount: azureiiot
   iaiStorageAccountSubscription: azureiiotbak-storage
 
 stages:

--- a/tools/templates/iiot_deployment_linux.yml
+++ b/tools/templates/iiot_deployment_linux.yml
@@ -30,14 +30,14 @@ jobs:
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
     inputs:
-      azureSubscription: azureiiot-storage
+      azureSubscription: '$(iaiStorageAccountSubscription)'
       scriptType: pscore
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_mac.yml
+++ b/tools/templates/iiot_deployment_mac.yml
@@ -30,14 +30,14 @@ jobs:
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
     inputs:
-      azureSubscription: azureiiot-storage
+      azureSubscription: '$(iaiStorageAccountSubscription)'
       scriptType: pscore
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment     --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5

--- a/tools/templates/iiot_deployment_win.yml
+++ b/tools/templates/iiot_deployment_win.yml
@@ -98,14 +98,14 @@ jobs:
     displayName: 'Copy to Blob'
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/heads/'))
     inputs:
-      azureSubscription: azureiiot-storage
+      azureSubscription: '$(iaiStorageAccountSubscription)'
       scriptType: pscore
       workingDirectory: $(Build.ArtifactStagingDirectory)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment
       scriptLocation: inlineScript
       inlineScript: |
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
-        az storage blob upload --account-name azureiiot --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/$(setVersionInfo.Version_Prefix)$(setVersionInfo.Version_Prerelease)/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.exe --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.exe
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.pdb --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.pdb
+        az storage blob upload --account-name $(iaiStorageAccount) --container-name binaries -f Microsoft.Azure.IIoT.Deployment.md5 --name ${{ replace(variables['Build.SourceBranch'], 'refs/heads/', '') }}/preview/${{ parameters.runtime }}/Microsoft.Azure.IIoT.Deployment.md5


### PR DESCRIPTION
Changes:
* Storing storage account and service connection names as variables.
* Using `azureiiot` storage account in `IIOT_TEST` subscription.