### PR TITLE
Adding two additional error codes as possible results of the call of the service ActivateSession (BadInvalidState and BadRequestTimeout), which do not have to result in cleanup, disposing and recreation of the current session

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
@@ -344,8 +344,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                         case StatusCodes.BadSessionNotActivated:
                         case StatusCodes.BadServerHalted:
                         case StatusCodes.BadServerNotConnected:
-                            _logger.Warning("Failed to reconnect session '{id}', " +
-                                "will retry later", id);
+                        case StatusCodes.BadInvalidState:
+                        case StatusCodes.BadRequestTimeout:
+                            _logger.Warning("Failed to reconnect session '{id}' due to {exception}, " +
+                                "will retry later", id, e.Message);
                             if (wrapper.MissedKeepAlives < wrapper.MaxKeepAlives) {
                                 // retry later
                                 return;

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliConfigKeys.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public const string OpcMaxStringLength = TransportQuotaConfig.MaxStringLengthKey;
 
         /// <summary>
-        /// Key for the OPC Session creation timeout in seconds.
+        /// Key for the default OPC Session timeout in seconds - to request from the OPC server at session creation.
         /// </summary>
         public const string OpcSessionCreationTimeout = ClientServicesConfig.DefaultSessionTimeoutKey;
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -95,12 +95,14 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                         "sample values.",
                         (int i) => this[LegacyCliConfigKeys.OpcSamplingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
                     { "op|opcpublishinginterval=", "Default value in milliseconds for the publishing interval " +
-                            "setting of the subscriptions against the OPC UA server.",
+                        "setting of the subscriptions against the OPC UA server.",
                         (int i) => this[LegacyCliConfigKeys.OpcPublishingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
-                    { "ct|createsessiontimeout=", "Maximum amount of time that a session should remain open by the OPC server without any activity (session timeout) - to request from the OPC server at session creation.",
+                    { "ct|createsessiontimeout=", "Maximum amount of time in seconds that a session should " +
+                        "remain open by the OPC server without any activity (session timeout) " +
+                        "- to request from the OPC server at session creation.",
                         (uint u) => this[LegacyCliConfigKeys.OpcSessionCreationTimeout] = TimeSpan.FromSeconds(u).ToString() },
                     { "ki|keepaliveinterval=", "The interval in seconds the publisher is sending keep alive messages " +
-                            "to the OPC servers on the endpoints it is connected to.",
+                        "to the OPC servers on the endpoints it is connected to.",
                         (int i) => this[LegacyCliConfigKeys.OpcKeepAliveIntervalInSec] = TimeSpan.FromSeconds(i).ToString() },
                     { "kt|keepalivethreshold=", "Specify the number of keep alive packets a server can miss, " +
                         "before the session is disconneced.",

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/LegacyCliOptions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                     { "op|opcpublishinginterval=", "Default value in milliseconds for the publishing interval " +
                             "setting of the subscriptions against the OPC UA server.",
                         (int i) => this[LegacyCliConfigKeys.OpcPublishingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
-                    { "ct|createsessiontimeout=", "The timeout in seconds used when creating a session to an endpoint.",
+                    { "ct|createsessiontimeout=", "Maximum amount of time that a session should remain open by the OPC server without any activity (session timeout) - to request from the OPC server at session creation.",
                         (uint u) => this[LegacyCliConfigKeys.OpcSessionCreationTimeout] = TimeSpan.FromSeconds(u).ToString() },
                     { "ki|keepaliveinterval=", "The interval in seconds the publisher is sending keep alive messages " +
                             "to the OPC servers on the endpoints it is connected to.",


### PR DESCRIPTION
In some cases in our setup (publisher in standalone mode / pn.json), when there are a bit longer as normal disconnections between the publisher and our OPC UA Servers (e.g. 2-3 min) we experience data loss (even though SessionTimeout is set to 20 min and the QueueSizes of monitorerd items are sufficient). The reason for the data loss is - for some error codes returned at (re)ActivateSession, session cleanup, disposing and session recreation are performed, although the session could be reactivated and existing queues republished in the next refresh cycle without any problems.

These are the following error codes:
1) BadRequestTimeout - when connection loss lasts longer than configured request timeout (example attached)
2) BadInvalidState - the cause is unclear - doesn't occur always (example attached)

Both error codes were added to the error codes after which it must be tried again to make a reconnect in the next Retry cycle. 
After adding there were no more data losses in given cases and everything worked as expected. 
In addition, the description for the cli key ct|createsessiontimeout was adjusted cause it was not quite correct and understandable imho.

[publisher-log-sample-BadRequestTimeout.txt](https://github.com/Azure/Industrial-IoT/files/7946181/publisher-log-sample-BadRequestTimeout.txt)
[publisher-log-sample-BadInvalidState.txt](https://github.com/Azure/Industrial-IoT/files/7946182/publisher-log-sample-BadInvalidState.txt)

