### PR TITLE
IAI: Upgraded Kubernetes version in AKS from 1.19.11 to 1.20.13.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/Extensions/RegionTypeExtension.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/Extensions/RegionTypeExtension.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration.Extension {
                 RegionType.CentralUS => Region.USCentral,
                 RegionType.NorthEurope => Region.EuropeNorth,
                 RegionType.WestEurope => Region.EuropeWest,
-                RegionType.SothEastAsia => Region.AsiaSouthEast,
+                RegionType.SouthEastAsia => Region.AsiaSouthEast,
                 RegionType.EastAustralia => Region.AustraliaEast,
                 _ => throw new Exception($"Unrecognized RegionType: {region}")
             };

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/RegionType.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/RegionType.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration {
         CentralUS,
         NorthEurope,
         WestEurope,
-        SothEastAsia,
+        SouthEastAsia,
         EastAustralia
     }
 }

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION_FALLBACK = "1.19.11";
-        public const string KUBERNETES_VERSION_MAJ_MIN = "1.19";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.20.13";
+        public const string KUBERNETES_VERSION_MAJ_MIN = "1.20";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;
 


### PR DESCRIPTION
Changes:
* Upgraded Kubernetes version in AKS from `1.19.11` to `1.20.13` as [Kubernetes `1.19` will be removed on 2022-01-31](https://github.com/Azure/AKS/releases/tag/2022-01-13).