### PR TITLE
Extended multi-endpoint E2E direct method tests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
@@ -49,7 +49,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -187,7 +187,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
@@ -4,10 +4,10 @@
 // ------------------------------------------------------------
 
 namespace IIoTPlatform_E2E_Tests.Standalone {
+
     using IIoTPlatform_E2E_Tests.Deploy;
     using IIoTPlatform_E2E_Tests.TestModels;
     using Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models;
-    using Microsoft.Azure.Devices;
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,7 +16,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
     using Xunit.Abstractions;
     using Microsoft.Azure.IIoT.Hub.Models;
     using Microsoft.Azure.IIoT.Serializers;
-    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
     using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
     using System.Net;
     using System.Collections.Generic;
@@ -28,33 +27,12 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
     [TestCaseOrderer(TestCaseOrderer.FullName, TestConstants.TestAssemblyName)]
     [Collection("IIoT Standalone Direct Methods Test Collection")]
     [Trait(TestConstants.TraitConstants.PublisherModeTraitName, TestConstants.TraitConstants.PublisherModeStandaloneTraitValue)]
-    public class A_PublishSingleNodeStandaloneDirectMethodTestTheory {
-
-        private readonly ITestOutputHelper _output;
-        private readonly IIoTMultipleNodesTestContext _context;
-        private readonly ServiceClient _iotHubClient;
-        private readonly IJsonSerializer _serializer;
-        private string _iotHubConnectionString;
-        private string _iotHubPublisherDeviceName;
-        private string _iotHubPublisherModuleName; 
+    public class A_PublishSingleNodeStandaloneDirectMethodTestTheory : DirectMethodTestBase {
 
         public A_PublishSingleNodeStandaloneDirectMethodTestTheory(
             ITestOutputHelper output,
             IIoTMultipleNodesTestContext context
-        ) {
-            _output = output ?? throw new ArgumentNullException(nameof(output));
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _context.OutputHelper = _output;
-            _iotHubConnectionString = _context.IoTHubConfig.IoTHubConnectionString;
-            _iotHubPublisherDeviceName = _context.DeviceConfig.DeviceId;
-            _serializer = new NewtonSoftJsonSerializer();
-
-            // Initialize DeviceServiceClient from IoT Hub connection string.
-            _iotHubClient = TestHelper.DeviceServiceClient(
-                _iotHubConnectionString,
-                TransportType.Amqp_WebSocket_Only
-            );
-        }
+        ) : base(output, context) { }
 
         [Theory]
         [InlineData(MessagingMode.Samples)]
@@ -63,42 +41,45 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var ioTHubEdgeBaseDeployment = new IoTHubEdgeBaseDeployment(_context);
             var ioTHubPublisherDeployment = new IoTHubPublisherDeployment(_context, messagingMode);
 
-            _iotHubPublisherModuleName = "publisher_standalone";
+            _iotHubPublisherModuleName = ioTHubPublisherDeployment.ModuleName;
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             // Make sure that there is no active monitoring.
-            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
 
             // Create base edge deployment.
-            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _output.WriteLine("Created/Updated new edge base deployment.");
 
             // Create layered edge deployment.
-            var layeredDeploymentResult = await ioTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var layeredDeploymentResult = await ioTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(layeredDeploymentResult, "Failed to create/update layered deployment for publisher module.");
             _output.WriteLine("Created/Updated layered deployment for publisher module.");
 
-            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token);
+            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token).ConfigureAwait(false);
 
-            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
                 _context.DeviceConfig.DeviceId,
                 cts.Token,
-                new string[] { "publisher_standalone" }
+                new string[] { ioTHubPublisherDeployment.ModuleName }
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
             //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
-            var responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             var configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
@@ -107,29 +88,36 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var request = model.ToApiModel();
 
             //Call Publish direct method
-            var response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case).
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             //Create request for GetConfiguredNodesOnEndpoint method call
-            var nodesOnEndpoint = new PublishedNodesEntryModel();
-            nodesOnEndpoint.EndpointUrl = request.EndpointUrl;
+            var nodesOnEndpoint = new PublishedNodesEntryModel {
+                EndpointUrl = request.EndpointUrl,
+            };
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
@@ -137,10 +125,13 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse[0], request);
 
             //Call GetConfiguredNodesOnEndpoint direct method
-            var responseGetConfiguredNodesOnEndpoint = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredNodesOnEndpoint,
-                JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredNodesOnEndpoint,
+                    JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredNodesOnEndpoint.Status);
             var jsonResponse = _serializer.Deserialize<List<PublishedNodeApiModel>>(responseGetConfiguredNodesOnEndpoint.JsonPayload);
@@ -148,7 +139,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(jsonResponse[0].Id, "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1");
 
             // Stop monitoring and get the result.
-            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)publishingMonitoringResultJson.totalValueChangesCount > 0, "No messages received at IoT Hub");
             Assert.True((uint)publishingMonitoringResultJson.droppedValueCount == 0,
                 $"Dropped messages detected: {(uint)publishingMonitoringResultJson.droppedValueCount}");
@@ -156,25 +147,28 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 $"Duplicate values detected: {(uint)publishingMonitoringResultJson.duplicateValueCount}");
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case).
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
-            var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)unpublishingMonitoringResultJson.totalValueChangesCount == 0,
                 $"Messages received at IoT Hub: {(int)unpublishingMonitoringResultJson.totalValueChangesCount}");
         }
@@ -184,43 +178,46 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
         async Task SubscribeUnsubscribeDirectMethodLegacyPublisherTest() {
             var ioTHubEdgeBaseDeployment = new IoTHubEdgeBaseDeployment(_context);
             var ioTHubLegacyPublisherDeployment = new IoTHubLegacyPublisherDeployments(_context);
-            
-            _iotHubPublisherModuleName = "publisher_standalone_legacy";
+
+            _iotHubPublisherModuleName = ioTHubLegacyPublisherDeployment.ModuleName;
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             // Make sure that there is no active monitoring.
-            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
 
             // Create base edge deployment.
-            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _output.WriteLine("Created/Updated new edge base deployment.");
 
             // Create layered edge deployment.
-            var layeredDeploymentResult1 = await ioTHubLegacyPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var layeredDeploymentResult1 = await ioTHubLegacyPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(layeredDeploymentResult1, "Failed to create/update layered deployment for legacy publisher module.");
             _output.WriteLine("Created/Updated layered deployment for legacy publisher module.");
 
-            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token);
+            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token).ConfigureAwait(false);
 
-            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
                 _context.DeviceConfig.DeviceId,
                 cts.Token,
-                new string[] { "publisher_standalone_legacy" }
+                new string[] { ioTHubLegacyPublisherDeployment.ModuleName }
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
             //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
-            var responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             var epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
@@ -231,24 +228,30 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var request = model.ToApiModel();
 
             //Call Publish direct method
-            var response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case).
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
@@ -258,15 +261,19 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse[0], request);
 
             //Create request for GetConfiguredNodesOnEndpoint method call
-            var nodesOnEndpoint = new PublishedNodesEntryModel();
-            nodesOnEndpoint.EndpointUrl = request.EndpointUrl;
+            var nodesOnEndpoint = new PublishedNodesEntryModel {
+                EndpointUrl = request.EndpointUrl,
+            };
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
             //Call GetConfiguredNodesOnEndpoint direct method
-            var responseGetConfiguredNodesOnEndpoint = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredNodesOnEndpoint,
-                JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredNodesOnEndpoint,
+                    JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredNodesOnEndpoint.Status);
 
@@ -277,7 +284,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(jsonResponse[0].Id, "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1");
 
             // Stop monitoring and get the result.
-            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)publishingMonitoringResultJson.totalValueChangesCount > 0, "No messages received at IoT Hub");
             Assert.True((uint)publishingMonitoringResultJson.droppedValueCount == 0,
                 $"Dropped messages detected: {(uint)publishingMonitoringResultJson.droppedValueCount}");
@@ -285,22 +292,25 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 $"Duplicate values detected: {(uint)publishingMonitoringResultJson.duplicateValueCount}");
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case).
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -49,7 +49,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -187,7 +187,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
@@ -48,7 +48,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -48,7 +48,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
@@ -62,7 +62,12 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token);
 
-            await TestHelper.PublishNodesAsync(new[] { model }, _context);
+            await TestHelper.PublishNodesAsync(
+                _context,
+                TestConstants.PublishedNodesFullName,
+                new[] { model }
+            ).ConfigureAwait(false);
+
             await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
 
             // Wait some time till the updated pn.json is reflected.
@@ -92,7 +97,11 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 $"Duplicate values detected: {(uint)publishingMonitoringResultJson.duplicateValueCount}");
 
             // Stop publishing nodes.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(
+                _context,
+                TestConstants.PublishedNodesFullName,
+                Array.Empty<PublishedNodesEntryModel>()
+            ).ConfigureAwait(false);
             await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
 
             // Wait till the publishing has stopped.

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -53,7 +53,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -202,7 +202,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -53,7 +53,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -202,7 +202,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
@@ -51,7 +51,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
@@ -51,7 +51,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
@@ -65,7 +65,11 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token);
 
-            TestHelper.PublishNodesAsync(new[] { nodesToPublish }, _context).GetAwaiter().GetResult();
+            await TestHelper.PublishNodesAsync(
+                _context,
+                TestConstants.PublishedNodesFullName,
+                new[] { nodesToPublish }
+            ).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
@@ -109,7 +113,11 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             }
 
             // Stop publishing nodes.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(
+                _context,
+                TestConstants.PublishedNodesFullName,
+                Array.Empty<PublishedNodesEntryModel>()
+            ).ConfigureAwait(false);
             await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
 
             // Wait till the publishing has stopped.

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -4,10 +4,10 @@
 // ------------------------------------------------------------
 
 namespace IIoTPlatform_E2E_Tests.Standalone {
+
     using IIoTPlatform_E2E_Tests.Deploy;
     using IIoTPlatform_E2E_Tests.TestModels;
     using Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models;
-    using Microsoft.Azure.Devices;
     using System;
     using System.Threading;
     using System.Threading.Tasks;
@@ -16,7 +16,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
     using Xunit.Abstractions;
     using Microsoft.Azure.IIoT.Hub.Models;
     using Microsoft.Azure.IIoT.Serializers;
-    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
     using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
     using System.Net;
     using System.Linq;
@@ -29,33 +28,12 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
     [TestCaseOrderer(TestCaseOrderer.FullName, TestConstants.TestAssemblyName)]
     [Collection("IIoT Standalone Direct Methods Test Collection")]
     [Trait(TestConstants.TraitConstants.PublisherModeTraitName, TestConstants.TraitConstants.PublisherModeStandaloneTraitValue)]
-    public class C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory {
-
-        private readonly ITestOutputHelper _output;
-        private readonly IIoTMultipleNodesTestContext _context;
-        private readonly ServiceClient _iotHubClient;
-        private readonly IJsonSerializer _serializer;
-        private string _iotHubConnectionString;
-        private string _iotHubPublisherDeviceName;
-        private string _iotHubPublisherModuleName;
+    public class C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory : DirectMethodTestBase {
 
         public C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory(
             ITestOutputHelper output,
             IIoTMultipleNodesTestContext context
-        ) {
-            _output = output ?? throw new ArgumentNullException(nameof(output));
-            _context = context ?? throw new ArgumentNullException(nameof(context));
-            _context.OutputHelper = _output;
-            _iotHubConnectionString = _context.IoTHubConfig.IoTHubConnectionString;
-            _iotHubPublisherDeviceName = _context.DeviceConfig.DeviceId;
-            _serializer = new NewtonSoftJsonSerializer();
-
-            // Initialize DeviceServiceClient from IoT Hub connection string.
-            _iotHubClient = TestHelper.DeviceServiceClient(
-                _iotHubConnectionString,
-                TransportType.Amqp_WebSocket_Only
-            );
-        }
+        ) : base(output, context) {}
 
         [Theory]
         [InlineData(MessagingMode.Samples)]
@@ -64,7 +42,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var ioTHubEdgeBaseDeployment = new IoTHubEdgeBaseDeployment(_context);
             var ioTHubPublisherDeployment = new IoTHubPublisherDeployment(_context, messagingMode);
 
-            _iotHubPublisherModuleName = "publisher_standalone";
+            _iotHubPublisherModuleName = ioTHubPublisherDeployment.ModuleName;
 
             // Clear context.
             _context.Reset();
@@ -72,35 +50,38 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             // Make sure that there is no active monitoring.
-            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
 
             // Create base edge deployment.
-            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _output.WriteLine("Created/Updated new edge base deployment.");
 
             // Create layered edge deployment.
-            var layeredDeploymentResult = await ioTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var layeredDeploymentResult = await ioTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(layeredDeploymentResult, "Failed to create/update layered deployment for publisher module.");
             _output.WriteLine("Created/Updated layered deployment for publisher module.");
 
-            var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token);
+            var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
                 _context.DeviceConfig.DeviceId,
                 cts.Token,
-                new string[] { "publisher_standalone" }
+                new string[] { ioTHubPublisherDeployment.ModuleName }
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
             //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
-            var responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             var configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
@@ -109,36 +90,45 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var request = nodesToPublish.ToApiModel();
 
             //Call Publish direct method
-            var response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //publish nodes on a different enpoint
-            nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token, 5, 100);
+            nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token, 5, 100).ConfigureAwait(false);
             var request1 = nodesToPublish.ToApiModel();
 
             //Call Publish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request1)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request1)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case)
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
@@ -152,17 +142,20 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
             //Call GetConfiguredNodesOnEndpoint direct method
-            var responseGetConfiguredNodesOnEndpoint = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredNodesOnEndpoint,
-                JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredNodesOnEndpoint,
+                    JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredNodesOnEndpoint.Status);
             var jsonResponse = _serializer.Deserialize<List<PublishedNodeApiModel>>(responseGetConfiguredNodesOnEndpoint.JsonPayload);
             Assert.Equal(jsonResponse.Count, 100);
 
             // Stop monitoring and get the result.
-            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)publishingMonitoringResultJson.totalValueChangesCount > 0, "No messages received at IoT Hub");
 
             // Check that every published node is sending data.
@@ -181,39 +174,48 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             }
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request1)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request1)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
             Assert.Equal(configuredEndpointsResponse.Count, 0);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case)
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
@@ -227,18 +229,18 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var ioTHubEdgeBaseDeployment = new IoTHubEdgeBaseDeployment(_context);
             var ioTHubLegacyPublisherDeployment = new IoTHubLegacyPublisherDeployments(_context);
 
-            _iotHubPublisherModuleName = "publisher_standalone_legacy";
+            _iotHubPublisherModuleName = ioTHubLegacyPublisherDeployment.ModuleName;
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             // Make sure that there is no active monitoring.
-            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context);
+            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
 
             // Create base edge deployment.
-            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token);
+            var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _output.WriteLine("Created/Updated new edge base deployment.");
 
@@ -247,20 +249,23 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.True(layeredDeploymentResult1, "Failed to create/update layered deployment for legacy publisher module.");
             _output.WriteLine("Created/Updated layered deployment for legacy publisher module.");
 
-            var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token);
+            var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
                 _context.DeviceConfig.DeviceId,
                 cts.Token,
-                new string[] { "publisher_standalone_legacy" }
+                new string[] { ioTHubLegacyPublisherDeployment.ModuleName }
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
             //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
-            var responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             var epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
@@ -271,36 +276,45 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var request = nodesToPublish.ToApiModel();
 
             //Call Publish direct method
-            var response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //publish nodes on a different enpoint
-            nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token, 5, 100);
+            nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token, 5, 100).ConfigureAwait(false);
             var request1 = nodesToPublish.ToApiModel();
 
             //Call Publish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
-                JsonPayload = _serializer.SerializeToString(request1)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request1)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case)
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
@@ -316,10 +330,13 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
             //Call GetConfiguredNodesOnEndpoint direct method
-            var responseGetConfiguredNodesOnEndpoint = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredNodesOnEndpoint,
-                JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
-            }, _context, cts.Token).ConfigureAwait(false);
+            var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredNodesOnEndpoint,
+                    JsonPayload = _serializer.SerializeToString(requestGetConfiguredNodesOnEndpoint)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredNodesOnEndpoint.Status);
 
@@ -329,9 +346,9 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(jsonResponse.Count, 100);
 
             // Stop monitoring and get the result.
-            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)publishingMonitoringResultJson.totalValueChangesCount > 0, "No messages received at IoT Hub");
-            
+
             // Check that every published node is sending data.
             if (_context.ConsumedOpcUaNodes != null) {
                 var expectedNodes = _context.ConsumedOpcUaNodes.First().Value.OpcNodes.Select(n => n.Id).ToList();
@@ -348,25 +365,34 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             }
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //Call Unpublish direct method
-            response = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
-                JsonPayload = _serializer.SerializeToString(request1)
-            }, _context, cts.Token).ConfigureAwait(false);
+            response = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.UnPublishNodes,
+                    JsonPayload = _serializer.SerializeToString(request1)
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             //Call GetConfiguredEndpoints direct method
-            responseGetConfiguredEndpoints = await TestHelper.CallMethodAsync(_iotHubClient, _iotHubPublisherDeviceName, _iotHubPublisherModuleName, new MethodParameterModel {
-                Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
-            }, _context, cts.Token).ConfigureAwait(false);
+            responseGetConfiguredEndpoints = await CallMethodAsync(
+                new MethodParameterModel {
+                    Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
+                },
+                cts.Token
+            ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
@@ -375,17 +401,17 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(configuredEndpointsResponse.Count, 0);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case)
-            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token);
+            await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);
+            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
-            var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
+            var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
             Assert.True((int)unpublishingMonitoringResultJson.totalValueChangesCount == 0,
                 $"Messages received at IoT Hub: {(int)unpublishingMonitoringResultJson.totalValueChangesCount}");
         }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -53,7 +53,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -283,7 +283,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFilesAsync(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -207,7 +207,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 foreach (dynamic property in publishingMonitoringResultJson.valueChangesByNodeId) {
                     var propertyName = (string)property.Name;
                     var nodeId = propertyName.Split('#').Last();
-
                     var expected = expectedNodes.FirstOrDefault(n => n.EndsWith(nodeId));
                     Assert.True(expected != null, $"Publishing from unexpected node: {propertyName}");
                     expectedNodes.Remove(expected);
@@ -447,7 +446,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 foreach (dynamic property in publishingMonitoringResultJson.valueChangesByNodeId) {
                     var propertyName = (string)property.Name;
                     var nodeId = propertyName.Split('#').Last();
-
                     var expected = expectedNodes.FirstOrDefault(n => n.EndsWith(nodeId));
                     Assert.True(expected != null, $"Publishing from unexpected node: {propertyName}");
                     expectedNodes.Remove(expected);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -53,7 +53,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
@@ -277,7 +277,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Clean publishednodes.json.
-            await TestHelper.PublishNodesAsync(Array.Empty<PublishedNodesEntryModel>(), _context).ConfigureAwait(false);
+            await TestHelper.CleanPublishedNodesJsonFiles(_context).ConfigureAwait(false);
 
             // Create base edge deployment.
             var baseDeploymentResult = await ioTHubEdgeBaseDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DirectMethodTestBase.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DirectMethodTestBase.cs
@@ -69,7 +69,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
         /// <inheritdoc/>
         public void Dispose() {
-            _context?.Dispose();
             _iotHubClient?.Dispose();
         }
     }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DirectMethodTestBase.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/DirectMethodTestBase.cs
@@ -1,0 +1,76 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Standalone {
+
+    using IIoTPlatform_E2E_Tests.TestExtensions;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Azure.IIoT.Hub.Models;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// Base class for test suites that validate functionality of direct method calls.
+    /// </summary>
+    public class DirectMethodTestBase : IDisposable {
+
+        protected readonly ITestOutputHelper _output;
+        protected readonly IIoTMultipleNodesTestContext _context;
+        protected readonly ServiceClient _iotHubClient;
+        protected readonly IJsonSerializer _serializer;
+        protected string _iotHubPublisherDeviceName;
+        protected string _iotHubPublisherModuleName;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        public DirectMethodTestBase(
+            ITestOutputHelper output,
+            IIoTMultipleNodesTestContext context
+        ) {
+            _output = output ?? throw new ArgumentNullException(nameof(output));
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _context.OutputHelper = _output;
+            _iotHubPublisherDeviceName = _context.DeviceConfig.DeviceId;
+            _serializer = new NewtonSoftJsonSerializer();
+
+            // Initialize DeviceServiceClient from IoT Hub connection string.
+            _iotHubClient = TestHelper.DeviceServiceClient(
+                _context.IoTHubConfig.IoTHubConnectionString,
+                TransportType.Amqp_WebSocket_Only
+            );
+        }
+
+        /// <summary>
+        /// Perform direct method call.
+        /// </summary>
+        /// <param name="parameters"> Direct method parameters. </param>
+        /// <param name="ct"> Cancellation token. </param>
+        /// <returns></returns>
+        public async Task<MethodResultModel> CallMethodAsync(
+            MethodParameterModel parameters,
+            CancellationToken ct
+        ) {
+            return await TestHelper.CallMethodAsync(
+                _iotHubClient,
+                _iotHubPublisherDeviceName,
+                _iotHubPublisherModuleName,
+                parameters,
+                _context,
+                ct
+            ).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose() {
+            _context?.Dispose();
+            _iotHubClient?.Dispose();
+        }
+    }
+}

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Publisher.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Publisher.cs
@@ -20,7 +20,7 @@ namespace IIoTPlatform_E2E_Tests {
                 Assert.Equal(expected.DataSetPublishingInterval, actual.DataSetPublishingInterval);
                 Assert.Equal(expected.DataSetWriterGroup, actual.DataSetWriterGroup);
                 Assert.Equal(expected.DataSetWriterId, actual.DataSetWriterId);
-                Assert.Equal(expected.EndpointUrl, actual.EndpointUrl + '/');
+                Assert.Equal(expected.EndpointUrl.TrimEnd('/'), actual.EndpointUrl.TrimEnd('/'));
                 Assert.Equal(expected.OpcAuthenticationMode, actual.OpcAuthenticationMode);
                 Assert.Equal(expected.UserName, actual.UserName);
                 Assert.Equal(expected.UseSecurity, actual.UseSecurity);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -604,7 +604,12 @@ namespace IIoTPlatform_E2E_Tests {
         /// </summary>
         /// <param name="IIoTMultipleNodesTestContext">context</param>
         /// <param name="CancellationTokenSource">cancellation token</param>
-        public static async Task<PublishedNodesEntryModel> CreateMultipleNodesModelAsync(IIoTMultipleNodesTestContext context, CancellationToken ct, int endpointIndex = 2, int numberOfNodes = 250) {
+        public static async Task<PublishedNodesEntryModel> CreateMultipleNodesModelAsync(
+            IIoTMultipleNodesTestContext context,
+            CancellationToken ct,
+            int endpointIndex = 2,
+            int numberOfNodes = 250) {
+
             await context.LoadSimulatedPublishedNodes(ct);
 
             PublishedNodesEntryModel nodesToPublish;

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -212,8 +212,9 @@ namespace IIoTPlatform_E2E_Tests {
         /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
         /// <param name="ct">Cancellation token</param>
         public static async Task PublishNodesAsync(
-            IEnumerable<PublishedNodesEntryModel> entries,
-            IIoTPlatformTestContext context
+            IIoTPlatformTestContext context,
+            string publishedNodesFullPath,
+            IEnumerable<PublishedNodesEntryModel> entries
         ) {
             var json = JsonConvert.SerializeObject(entries, Formatting.Indented);
             context.OutputHelper?.WriteLine("Write published_nodes.json to IoT Edge");
@@ -221,21 +222,42 @@ namespace IIoTPlatform_E2E_Tests {
             CreateFolderOnEdgeVM(TestConstants.PublishedNodesFolder, context);
             using var scpClient = CreateScpClientAndConnect(context);
             await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
-            scpClient.Upload(stream, TestConstants.PublishedNodesFullName);
+
+            scpClient.Upload(stream, publishedNodesFullPath);
 
             if (context.IoTEdgeConfig.NestedEdgeFlag == "Enable") {
                 using var sshCient = CreateSshClientAndConnect(context);
                 foreach (var edge in context.IoTEdgeConfig.NestedEdgeSshConnections) {
                     if (edge != string.Empty) {
                         // Copy file to the edge vm
-                        var command = $"scp -oStrictHostKeyChecking=no {TestConstants.PublishedNodesFullName} {edge}:{TestConstants.PublishedNodesFilename}";
+                        var command = $"scp -oStrictHostKeyChecking=no {publishedNodesFullPath} {edge}:{TestConstants.PublishedNodesFilename}";
                         sshCient.RunCommand(command);
+
                         // Move file to the target folder with sudo permissions
-                        command = $"ssh -oStrictHostKeyChecking=no {edge} 'sudo mv {TestConstants.PublishedNodesFilename} {TestConstants.PublishedNodesFullName}'";
+                        command = $"ssh -oStrictHostKeyChecking=no {edge} 'sudo mv {TestConstants.PublishedNodesFilename} {publishedNodesFullPath}'";
                         sshCient.RunCommand(command);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Clean published nodes JSON files for both legacy (2.5) and current (2.8) versions.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public static async Task CleanPublishedNodesJsonFiles(IIoTPlatformTestContext context) {
+            await PublishNodesAsync(
+                context,
+                TestConstants.PublishedNodesFullName,
+                Array.Empty<PublishedNodesEntryModel>()
+            ).ConfigureAwait(false);
+
+            await PublishNodesAsync(
+                context,
+                TestConstants.PublishedNodesFullNameLegacy,
+                Array.Empty<PublishedNodesEntryModel>()
+            ).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -246,7 +246,7 @@ namespace IIoTPlatform_E2E_Tests {
         /// </summary>
         /// <param name="context"></param>
         /// <returns></returns>
-        public static async Task CleanPublishedNodesJsonFiles(IIoTPlatformTestContext context) {
+        public static async Task CleanPublishedNodesJsonFilesAsync(IIoTPlatformTestContext context) {
             await PublishNodesAsync(
                 context,
                 TestConstants.PublishedNodesFullName,

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PublisherExtensions.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PublisherExtensions.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
                 return null;
             }
             return new PublishNodesEndpointApiModel {
-
                 DataSetWriterGroup = model.DataSetWriterGroup,
                 DataSetWriterId = model.DataSetWriterId,
                 DataSetPublishingInterval = model.DataSetPublishingInterval,
@@ -30,7 +29,9 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
                 UseSecurity = model.UseSecurity,
                 Password = model.OpcAuthenticationPassword,
                 UserName = model.OpcAuthenticationUsername,
-                OpcNodes = model.OpcNodes != null ? model.OpcNodes.Select(n => n.ToApiModel()).ToList() : null,
+                OpcNodes = model.OpcNodes != null
+                    ? model.OpcNodes.Select(n => n.ToApiModel()).ToList()
+                    : null,
             };
         }
 
@@ -54,5 +55,4 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
             };
         }
     }
-    
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubLegacyPublisherDeployments.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubLegacyPublisherDeployments.cs
@@ -9,7 +9,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
     using Newtonsoft.Json;
     using TestExtensions;
 
-    public sealed class IoTHubLegacyPublisherDeployments : DeploymentConfiguration {
+    public sealed class IoTHubLegacyPublisherDeployments : ModuleDeploymentConfiguration {
 
         /// <summary>
         /// Create deployment
@@ -24,7 +24,11 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
         /// <inheritdoc />
         protected override string DeploymentName => kDeploymentName + $"{DateTime.UtcNow.Ticks}";
 
+        /// <inheritdoc />
         protected override string TargetCondition => kTargetCondition;
+
+        /// <inheritdoc />
+        public override string ModuleName => kModuleName;
 
         /// <inheritdoc />
         protected override IDictionary<string, IDictionary<string, object>> CreateDeploymentModules() {
@@ -32,7 +36,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
 
             // Configure create options per os specified
             var createOptions = JsonConvert.SerializeObject(new {
-                Hostname = kModuleName,
+                Hostname = ModuleName,
                 Cmd = new[] {
                 "PkiRootPath=" + TestConstants.PublishedNodesFolderLegacy + "/pki",
                 "--aa",
@@ -54,7 +58,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
             {
                 ""$edgeAgent"": {
                     " + registryCredentials + @"
-                    ""properties.desired.modules." + kModuleName + @""": {
+                    ""properties.desired.modules." + ModuleName + @""": {
                         ""settings"": {
                             ""image"": """ + image + @""",
                             ""createOptions"": """ + createOptions + @"""
@@ -66,14 +70,14 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
                     }
                 },
                 ""$edgeHub"": {
-                    ""properties.desired.routes." + kModuleName + @"ToUpstream"": ""FROM /messages/modules/" + kModuleName + @"/* INTO $upstream"",
+                    ""properties.desired.routes." + ModuleName + @"ToUpstream"": ""FROM /messages/modules/" + ModuleName + @"/* INTO $upstream"",
                     ""properties.desired.routes.leafToUpstream"": ""FROM /messages/* WHERE NOT IS_DEFINED($connectionModuleId) INTO $upstream""
                 }
             }";
             return JsonConvert.DeserializeObject<IDictionary<string, IDictionary<string, object>>>(content);
         }
 
-        private const string kVersion = "2.5.5";
+        private const string kVersion = "2.5";
         private const string kModuleName = "publisher_standalone_legacy";
         private const string kDeploymentName = "__default-opcpublisher-standalone-legacy";
         private const string kTargetCondition = "(tags.__type__ = 'iiotedge' AND IS_DEFINED(tags.unmanaged))";

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
@@ -9,7 +9,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
     using Newtonsoft.Json;
     using TestExtensions;
 
-    public sealed class IoTHubPublisherDeployment : DeploymentConfiguration {
+    public sealed class IoTHubPublisherDeployment : ModuleDeploymentConfiguration {
 
         /// <summary>
         /// MessagingMode that will be used for configuration of OPC Publisher.
@@ -33,6 +33,9 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
         protected override string TargetCondition => kTargetCondition;
 
         /// <inheritdoc />
+        public override string ModuleName => kModuleName;
+
+        /// <inheritdoc />
         protected override IDictionary<string, IDictionary<string, object>> CreateDeploymentModules() {
             var registryCredentials = "";
 
@@ -53,7 +56,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
 
             // Configure create options per os specified
             var createOptions = JsonConvert.SerializeObject(new {
-                Hostname = kModuleName,
+                Hostname = ModuleName,
                 Cmd = new[] {
                 "PkiRootPath=" + TestConstants.PublishedNodesFolder + "/pki",
                 "--aa",
@@ -83,7 +86,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
             {
                 ""$edgeAgent"": {
                     " + registryCredentials + @"
-                    ""properties.desired.modules." + kModuleName + @""": {
+                    ""properties.desired.modules." + ModuleName + @""": {
                         ""settings"": {
                             ""image"": """ + image + @""",
                             ""createOptions"": """ + createOptions + @"""
@@ -95,7 +98,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
                     }
                 },
                 ""$edgeHub"": {
-                    ""properties.desired.routes." + kModuleName + @"ToUpstream"": ""FROM /messages/modules/" + kModuleName + @"/* INTO $upstream"",
+                    ""properties.desired.routes." + ModuleName + @"ToUpstream"": ""FROM /messages/modules/" + ModuleName + @"/* INTO $upstream"",
                     ""properties.desired.routes.leafToUpstream"": ""FROM /messages/* WHERE NOT IS_DEFINED($connectionModuleId) INTO $upstream""
                 }
             }";

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/ModuleDeploymentConfiguration.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/ModuleDeploymentConfiguration.cs
@@ -1,0 +1,28 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace IIoTPlatform_E2E_Tests.Deploy {
+
+    using IIoTPlatform_E2E_Tests.Deploy;
+    using IIoTPlatform_E2E_Tests.TestExtensions;
+
+    /// <summary>
+    /// Configuration that corresponds to a module deployment.
+    /// </summary>
+    public abstract class ModuleDeploymentConfiguration : DeploymentConfiguration {
+
+        /// <summary>
+        /// Name of the module that is being deployed by this configuration.
+        /// </summary>
+        public abstract string ModuleName { get; }
+
+        /// <summary>
+        /// Constructor that delegates to the base DeploymentConfiguration.
+        /// </summary>
+        /// <param name="context"></param>
+        public ModuleDeploymentConfiguration(IIoTPlatformTestContext context)
+            : base (context) {}
+    }
+}


### PR DESCRIPTION
Changes:
* In `LegacyJobOrchestrator` :
  * Added call to `TriggerAgentConfigUpdate()` in the end of `AddOrUpdateEndpointsAsync()` method to quickly notify workers of configuration changes.
  * Added logging of execution time to `GetConfiguredEndpointsAsync()` method.
* Some refactoring of direct method tests:
  * Added `DirectMethodTestBase` which (1) does the initialization of required objects for the test classes which was previously done similarly in the test constructors and (2) adds a wrapper method for calling direct methods.
  * Added `ModuleDeploymentConfiguration` base class for modern and legacy OPC Publisher deployments. The class now holds the name of the module that is deployed. Now we can use the value for the module name from the class itself instead of hardcoding it in tests.
* Extended multi-endpoint test to check for all nodes. Now the two endpoints are monitoring different nodes. So with `TestEventProcessor` we can see if values from both are coming. This is required as `TestEventProcessor` is not yet able to differentiate source endpoints of nodes and report accordingly.
* Changed cleanup to update published nodes JSON files of both versions of OPC Publisher. Added `CleanPublishedNodesJsonFilesAsync()` method to do that.
* Fixed expected node generation.
* Fixed multi-endpoint tests for legacy OPC Publisher.
