### PR TITLE
Using latest (2020.0.1) SSH.NET NuGet package in E2E tests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.0-beta1" />
+    <PackageReference Include="SSH.NET" Version="2020.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Changes:
* Using latest `2020.0.1` version of [`SSH.NET` NuGet package](https://www.nuget.org/packages/SSH.NET/) in E2E tests instead of `2020.0.0-beta1`.