### PR TITLE
Renamed LegacyJobOrchestrator to StandaloneJobOrchestrator.

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IStandaloneCliModelProvider.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/IStandaloneCliModelProvider.cs
@@ -7,12 +7,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models;
 
     /// <summary>
-    /// Interface that provides access to the LegacyCliModel passed via command line arguments.
+    /// Interface that provides access to the StandaloneCliModel passed via command line arguments.
     /// </summary>
-    public interface ILegacyCliModelProvider {
+    public interface IStandaloneCliModelProvider {
         /// <summary>
-        /// The instance of the LegacyCliModel that represents the passed command line arguments.
+        /// The instance of the StandaloneCliModel that represents the passed command line arguments.
         /// </summary>
-        LegacyCliModel LegacyCliModel { get; }
+        StandaloneCliModel StandaloneCliModel { get; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/StandaloneCliModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/StandaloneCliModel.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
 
     /// <summary>
     /// Model that represents the command line arguments in the format of the
-    /// legacy OPC Publisher.
+    /// standalone publisher mode.
     /// </summary>
-    public class LegacyCliModel {
+    public class StandaloneCliModel {
 
         /// <summary>
         /// The published nodes file.

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesProvider.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
     /// </summary>
     public class PublishedNodesProvider: IPublishedNodesProvider, IDisposable {
 
-        private readonly LegacyCliModel _legacyCliModel;
+        private readonly StandaloneCliModel _standaloneCliModel;
         private readonly ILogger _logger;
         private readonly SemaphoreSlim _lock;
         private readonly FileSystemWatcher _fileSystemWatcher;
@@ -43,21 +43,21 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
         /// <summary>
         /// Provider of utilities for published nodes file.
         /// </summary>
-        /// <param name="legacyCliModelProvider"> legacyCliModelProvider that will define location of published nodes file. </param>
+        /// <param name="standaloneCliModelProvider"> standaloneCliModelProvider that will define location of published nodes file. </param>
         /// <param name="logger"> Logger </param>
-        public PublishedNodesProvider(ILegacyCliModelProvider legacyCliModelProvider, ILogger logger) {
+        public PublishedNodesProvider(IStandaloneCliModelProvider standaloneCliModelProvider, ILogger logger) {
 
-            _legacyCliModel = legacyCliModelProvider?.LegacyCliModel ??
-                throw new ArgumentNullException(nameof(legacyCliModelProvider));
+            _standaloneCliModel = standaloneCliModelProvider?.StandaloneCliModel ??
+                throw new ArgumentNullException(nameof(standaloneCliModelProvider));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
-            var directory = Path.GetDirectoryName(_legacyCliModel.PublishedNodesFile);
+            var directory = Path.GetDirectoryName(_standaloneCliModel.PublishedNodesFile);
 
             if (string.IsNullOrWhiteSpace(directory)) {
                 directory = Environment.CurrentDirectory;
             }
 
-            var file = Path.GetFileName(_legacyCliModel.PublishedNodesFile);
+            var file = Path.GetFileName(_standaloneCliModel.PublishedNodesFile);
             _fileSystemWatcher = new FileSystemWatcher(directory, file);
             _fileSystemWatcher.Deleted += FileSystemWatcher_Deleted;
             _fileSystemWatcher.Created += FileSystemWatcher_Created;
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
         public DateTime GetLastWriteTime() {
             _lock.Wait();
             try {
-                return File.GetLastWriteTime(_legacyCliModel.PublishedNodesFile);
+                return File.GetLastWriteTime(_standaloneCliModel.PublishedNodesFile);
             }
             finally {
                 _lock.Release();
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
             _lock.Wait();
             try {
                 using (var fileStream = new FileStream(
-                    _legacyCliModel.PublishedNodesFile,
+                    _standaloneCliModel.PublishedNodesFile,
                     FileMode.Open,
                     FileAccess.Read,
                     FileShare.Read
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
             }
             catch (Exception e) {
                 _logger.Error(e, "Failed to read content of published nodes file from \"{path}\"",
-                    _legacyCliModel.PublishedNodesFile);
+                    _standaloneCliModel.PublishedNodesFile);
                 throw;
             }
             finally {
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
 
                 try {
                     using (var fileStream = new FileStream(
-                        _legacyCliModel.PublishedNodesFile,
+                        _standaloneCliModel.PublishedNodesFile,
                         FileMode.Open,
                         FileAccess.Write,
                         // We will require that there is no other process using the file.
@@ -130,12 +130,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
                     _logger.Warning("Failed to update published nodes file at \"{path}\" with restricted share policies. " +
                         "Please close any other application that uses this file. " +
                         "Falling back to opening it with more relaxed share policies.",
-                        _legacyCliModel.PublishedNodesFile);
+                        _standaloneCliModel.PublishedNodesFile);
 
                     // We will fall back to writing with ReadWrite access.
                     try {
                         using (var fileStream = new FileStream(
-                            _legacyCliModel.PublishedNodesFile,
+                            _standaloneCliModel.PublishedNodesFile,
                             FileMode.Open,
                             FileAccess.Write,
                             // Relaxing requirements.
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage {
                     catch (Exception) {
                         // Report and raise original exception if fallback also failed.
                         _logger.Error(e, "Failed to update published nodes file at \"{path}\"",
-                            _legacyCliModel.PublishedNodesFile);
+                            _standaloneCliModel.PublishedNodesFile);
 
                         throw e;
                     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Controller/DmApiPublisherMethodControllerTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Controller/DmApiPublisherMethodControllerTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData("Controller/DmApiPayloadCollection.json")]
         public async Task DmApiPublishUnpublishNodesTest(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var identityMock = new Mock<IIdentity>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
@@ -44,19 +44,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCli = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCli);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData("Controller/DmApiPayloadCollection.json")]
         public async Task DmApiPublishUnpublishAllNodesTest(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var identityMock = new Mock<IIdentity>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
@@ -135,19 +135,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCli = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCli);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData("Controller/DmApiPayloadCollection.json")]
         public async Task DmApiPublishNodesToJobTest(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var identityMock = new Mock<IIdentity>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
@@ -229,19 +229,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCli = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCli);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -514,7 +514,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         /// publish nodes from publishedNodesFile
         /// </summary>
         private async Task<PublisherMethodsController> publishNodeAsync(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var identityMock = new Mock<IIdentity>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
@@ -523,18 +523,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCli = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCli);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -561,7 +561,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [Theory]
         [InlineData("Controller/DmApiPayloadCollection.json")]
         public async Task DmApiGetConfiguredEndpointsTest(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var identityMock = new Mock<IIdentity>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
@@ -570,19 +570,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCli = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCli);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_opc_nodes_empty.json")]
         [InlineData("Engine/pn_opc_nodes_null.json")]
         [InlineData("Engine/pn_opc_nodes_empty_and_null.json")]
-        public async Task Test_InitstandaloneJobOrchestratorFromEmptyOpcNodes(string publishedNodesFile) {
+        public async Task Test_InitStandaloneJobOrchestratorFromEmptyOpcNodes(string publishedNodesFile) {
             Utils.CopyContent(publishedNodesFile, _tempFile);
             InitStandaloneJobOrchestrator();
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandalonePublisherConfigServicesTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandalonePublisherConfigServicesTests.cs
@@ -28,9 +28,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
     using Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Utils;
 
     /// <summary>
-    /// Tests the Direct methods configuration for the LegacyJobOrchestrator class
+    /// Tests the Direct methods configuration for the standaloneJobOrchestrator class
     /// </summary>
-    public class LegacyPublisherConfigServicesTests : TempFileProviderBase {
+    public class StandalonePublisherConfigServicesTests : TempFileProviderBase {
 
         [Theory]
         [InlineData("Engine/publishednodes.json")]
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets.json")]
         [InlineData("Engine/pn_assets_with_optional_fields.json")]
         public async Task PublishNodesOnEmptyConfiguration(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -46,19 +46,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent("Engine/empty_pn.json", _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
 
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets.json", "Engine/pn_assets_with_optional_fields.json")]
         [InlineData("Engine/pn_assets_with_optional_fields.json", "Engine/pn_assets.json")]
         public async Task PublishNodesOnExistingConfiguration(string existingConfig, string newConfig) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -110,18 +110,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent(existingConfig, _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets.json", "Engine/publishednodes.json")]
         [InlineData("Engine/pn_assets_with_optional_fields.json", "Engine/publishednodeswithoptionalfields.json")]
         public async Task PublishNodesOnNewConfiguration(string existingConfig, string newConfig) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -174,18 +174,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent(existingConfig, _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets.json")]
         [InlineData("Engine/pn_assets_with_optional_fields.json")]
         public async Task UnpublishNodesOnExistingConfiguration(string publishedNodesFile) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -237,18 +237,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent(publishedNodesFile, _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets.json", "Engine/publishednodes.json")]
         [InlineData("Engine/pn_assets_with_optional_fields.json", "Engine/publishednodeswithoptionalfields.json")]
         public async Task UnpublishNodesOnNonExistingConfiguration(string existingConfig, string newConfig) {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -292,18 +292,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             var publishedNodesJobConverter = new PublishedNodesJobConverter(logger, newtonSoftJsonSerializer);
 
             Utils.CopyContent(existingConfig, _tempFile);
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
 
         [Fact]
         public async Task PublishNodesStressTest() {
-            var legacyCliModelProviderMock = new Mock<ILegacyCliModelProvider>();
+            var standaloneCliModelProviderMock = new Mock<IStandaloneCliModelProvider>();
             var agentConfigProviderMock = new Mock<IAgentConfigProvider>();
             var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
             var jobSerializer = new PublisherJobSerializer(newtonSoftJsonSerializer);
@@ -355,18 +355,18 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 fileStream.Write(Encoding.UTF8.GetBytes("[]"));
             }
 
-            var legacyCliModel = new LegacyCliModel {
+            var standaloneCliModel = new StandaloneCliModel {
                 PublishedNodesFile = _tempFile,
                 PublishedNodesSchemaFile = "Storage/publishednodesschema.json"
             };
-            legacyCliModelProviderMock.Setup(p => p.LegacyCliModel).Returns(legacyCliModel);
+            standaloneCliModelProviderMock.Setup(p => p.StandaloneCliModel).Returns(standaloneCliModel);
             agentConfigProviderMock.Setup(p => p.Config).Returns(new AgentConfigModel());
 
-            var publishedNodesProvider = new PublishedNodesProvider(legacyCliModelProviderMock.Object, logger);
+            var publishedNodesProvider = new PublishedNodesProvider(standaloneCliModelProviderMock.Object, logger);
 
-            var orchestrator = new LegacyJobOrchestrator(
+            var orchestrator = new StandaloneJobOrchestrator(
                 publishedNodesJobConverter,
-                legacyCliModelProviderMock.Object,
+                standaloneCliModelProviderMock.Object,
                 agentConfigProviderMock.Object,
                 jobSerializer,
                 logger,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -99,9 +99,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
             Assert.Equal("testid", jobs
@@ -130,9 +130,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
             Assert.Equal("1000", jobs
@@ -162,9 +162,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -193,9 +193,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -225,9 +225,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -266,11 +266,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromSeconds(5)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -322,9 +322,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -352,9 +352,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -383,9 +383,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -418,11 +418,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
 
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -449,11 +449,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -479,11 +479,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -511,11 +511,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -542,11 +542,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -573,11 +573,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -603,11 +603,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -635,11 +635,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -666,11 +666,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromMilliseconds(2000)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -697,9 +697,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -734,9 +734,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -771,9 +771,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -805,9 +805,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -836,9 +836,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -871,11 +871,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
 
-            var legacyCli = new LegacyCliModel() {
+            var standaloneCli = new StandaloneCliModel() {
                 DefaultPublishingInterval = TimeSpan.FromSeconds(10)
             };
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -908,9 +908,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -945,9 +945,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -993,9 +993,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
 
             Assert.NotEmpty(jobs);
@@ -1033,9 +1033,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -1093,9 +1093,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             Assert.NotEmpty(jobs);
             Assert.Single(jobs);
@@ -1152,9 +1152,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ";
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             // No jobs
             Assert.NotEmpty(jobs);
@@ -1218,9 +1218,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             // No jobs
             Assert.NotEmpty(jobs);
@@ -1285,9 +1285,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             // No jobs
             Assert.NotEmpty(jobs);
@@ -1350,9 +1350,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn, new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli);
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli);
 
             // No jobs
             Assert.NotEmpty(jobs);
@@ -1393,9 +1393,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ");
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli).ToList();
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             // No jobs
             Assert.NotEmpty(jobs);
@@ -1441,9 +1441,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Storage.Tests {
 ");
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
             var converter = new PublishedNodesJobConverter(TraceLogger.Create(), _serializer);
-            var legacyCli = new LegacyCliModel();
+            var standaloneCli = new StandaloneCliModel();
             var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
-            var jobs = converter.ToWriterGroupJobs(entries, legacyCli).ToList();
+            var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             // No jobs
             Assert.NotEmpty(jobs);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/ModuleProcess.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/ModuleProcess.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
 
             var config = new Config(configuration);
             var builder = new ContainerBuilder();
-            var legacyCliOptions = new LegacyCliOptions(configuration);
+            var standaloneCliOptions = new StandaloneCliOptions(configuration);
 
             // Register configuration interfaces
             builder.RegisterInstance(config)
@@ -204,10 +204,10 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
             builder.RegisterModule<ModuleFramework>();
             builder.RegisterModule<NewtonSoftJsonModule>();
 
-            if (legacyCliOptions.RunInLegacyMode) {
+            if (standaloneCliOptions.RunInStandaloneMode) {
                 builder.AddDiagnostics(config,
-                    legacyCliOptions.ToLoggerConfiguration());
-                builder.RegisterInstance(legacyCliOptions)
+                    standaloneCliOptions.ToLoggerConfiguration());
+                builder.RegisterInstance(standaloneCliOptions)
                     .AsImplementedInterfaces();
 
                 // we overwrite the ModuleHost registration from PerLifetimeScope
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
                 builder.RegisterType<PublishedNodesProvider>()
                     .AsImplementedInterfaces().SingleInstance();
                 // Local orchestrator
-                builder.RegisterType<LegacyJobOrchestrator>()
+                builder.RegisterType<StandaloneJobOrchestrator>()
                     .AsImplementedInterfaces().SingleInstance();
                 // Create jobs from published nodes file
                 builder.RegisterType<PublishedNodesJobConverter>()

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Program.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Program.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher {
                 .AddEnvironmentVariables()
                 .AddEnvironmentVariables(EnvironmentVariableTarget.User)
                 .AddCommandLine(args)
-                .AddLegacyPublisherCommandLine(args) // making sure the Legacy arguments are processed at last so they are not overriden
+                .AddStandalonePublisherCommandLine(args)
+                // making sure the standalone arguments are processed at last so they are not overriden
                 .Build();
 
 #if DEBUG

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliConfigKeys.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliConfigKeys.cs
@@ -8,10 +8,10 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
     using Microsoft.Azure.IIoT.OpcUa.Protocol.Runtime;
 
     /// <summary>
-    /// Static class that contains the default keys for the legacy command line arguments how they will be represented in
-    /// the IConfiguration-instance.
+    /// Static class that contains the default keys for the standalone command line arguments how they
+    /// will be represented in the IConfiguration-instance.
     /// </summary>
-    public static class LegacyCliConfigKeys {
+    public static class StandaloneCliConfigKeys {
         /// <summary>
         /// Key for default published nodes file.
         /// </summary>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliEx.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliEx.cs
@@ -7,16 +7,16 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
     using Microsoft.Extensions.Configuration;
 
     /// <summary>
-    /// Extensions for the Legacy Command Line
+    /// Extensions for the standalone command line
     /// </summary>
-    public static class LegacyCliEx {
+    public static class StandaloneCliEx {
         /// <summary>
         /// Add options
         /// </summary>
         /// <param name="builder"></param>
         /// <param name="args"></param>
-        public static IConfigurationBuilder AddLegacyPublisherCommandLine(this IConfigurationBuilder builder, string[] args) {
-            return builder.AddInMemoryCollection(new LegacyCliOptions(args));
+        public static IConfigurationBuilder AddStandalonePublisherCommandLine(this IConfigurationBuilder builder, string[] args) {
+            return builder.AddInMemoryCollection(new StandaloneCliOptions(args));
         }
     }
 }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public StandaloneCliModel StandaloneCliModel {
             get {
                 if (_standaloneCliModel == null) {
-                    _standaloneCliModel = TostandaloneCliModel();
+                    _standaloneCliModel = ToStandaloneCliModel();
                 }
 
                 return _standaloneCliModel;
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             return loggerConfiguration;
         }
 
-        private StandaloneCliModel TostandaloneCliModel() {
+        private StandaloneCliModel ToStandaloneCliModel() {
             var model = new StandaloneCliModel();
             model.PublishedNodesFile = GetValueOrDefault(StandaloneCliConfigKeys.PublishedNodesConfigurationFilename, StandaloneCliConfigKeys.DefaultPublishedNodesFilename);
             model.PublishedNodesSchemaFile = GetValueOrDefault(StandaloneCliConfigKeys.PublishedNodesConfigurationSchemaFilename, StandaloneCliConfigKeys.DefaultPublishedNodesSchemaFilename);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
     /// <summary>
     /// Class that represents a dictionary with all command line arguments from the legacy version of the OPC Publisher
     /// </summary>
-    public class LegacyCliOptions : Dictionary<string, string>, IAgentConfigProvider,
-        ISettingsController, IEngineConfiguration, ILegacyCliModelProvider {
+    public class StandaloneCliOptions : Dictionary<string, string>, IAgentConfigProvider,
+        ISettingsController, IEngineConfiguration, IStandaloneCliModelProvider {
         /// <summary>
-        /// Creates a new instance of the the legacy CLI options based on existing configuration values.
+        /// Creates a new instance of the the standalone cli options based on existing configuration values.
         /// </summary>
         /// <param name="config"></param>
-        public LegacyCliOptions(IConfiguration config) {
+        public StandaloneCliOptions(IConfiguration config) {
             foreach (var item in config.GetChildren()) {
                 this[item.Key] = item.Value;
             }
@@ -42,122 +42,122 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// Parse arguments and set values in the environment the way the new configuration expects it.
         /// </summary>
         /// <param name="args">The specified command line arguments.</param>
-        public LegacyCliOptions(string[] args) {
+        public StandaloneCliOptions(string[] args) {
 
             // command line options
             var options = new Mono.Options.OptionSet {
                     // Publisher configuration options
                     { "pf|publishfile=", "The filename to configure the nodes to publish.",
-                        s => this[LegacyCliConfigKeys.PublishedNodesConfigurationFilename] = s },
+                        s => this[StandaloneCliConfigKeys.PublishedNodesConfigurationFilename] = s },
                     { "pfs|publishfileschema=", "The validation schema filename for publish file. Disabled by default.",
-                        s => this[LegacyCliConfigKeys.PublishedNodesConfigurationSchemaFilename] = s },
+                        s => this[StandaloneCliConfigKeys.PublishedNodesConfigurationSchemaFilename] = s },
                     { "s|site=", "The site OPC Publisher is working in.",
-                        s => this[LegacyCliConfigKeys.PublisherSite] = s },
+                        s => this[StandaloneCliConfigKeys.PublisherSite] = s },
 
                     { "di|diagnosticsinterval=", "Shows publisher diagnostic info at the specified interval " +
                         "in seconds (need log level info).\n-1 disables remote diagnostic log and diagnostic output",
-                        (int i) => this[LegacyCliConfigKeys.DiagnosticsInterval] = TimeSpan.FromSeconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.DiagnosticsInterval] = TimeSpan.FromSeconds(i).ToString() },
                     { "lf|logfile=", "The filename of the logfile to use.",
-                        s => this[LegacyCliConfigKeys.LogFileName] = s },
+                        s => this[StandaloneCliConfigKeys.LogFileName] = s },
                     { "lt|logflushtimespan=", "The timespan in seconds when the logfile should be flushed.",
-                        (int i) => this[LegacyCliConfigKeys.LogFileFlushTimeSpanSec] = TimeSpan.FromSeconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.LogFileFlushTimeSpanSec] = TimeSpan.FromSeconds(i).ToString() },
                     { "ll|loglevel=", "The loglevel to use (allowed: fatal, error, warn, info, debug, verbose).",
                         (LogEventLevel l) => LogControl.Level.MinimumLevel = l },
                     { "ih|iothubprotocol=", "Protocol to use for communication with the hub. " +
                             $"(allowed values: {string.Join(", ", Enum.GetNames(typeof(TransportOption)))}).",
-                        (TransportOption p) => this[LegacyCliConfigKeys.HubTransport] = p.ToString() },
+                        (TransportOption p) => this[StandaloneCliConfigKeys.HubTransport] = p.ToString() },
                     { "dc|deviceconnectionstring=", "A device or edge module connection string to use.",
-                        dc => this[LegacyCliConfigKeys.EdgeHubConnectionString] = dc },
+                        dc => this[StandaloneCliConfigKeys.EdgeHubConnectionString] = dc },
                     { "ec|edgehubconnectionstring=", "An edge module connection string to use",
-                        dc => this[LegacyCliConfigKeys.EdgeHubConnectionString] = dc },
+                        dc => this[StandaloneCliConfigKeys.EdgeHubConnectionString] = dc },
 
                     { "hb|heartbeatinterval=", "The publisher is using this as default value in seconds " +
                         "for the heartbeat interval setting of nodes without a heartbeat interval setting.",
-                        (int i) => this[LegacyCliConfigKeys.HeartbeatIntervalDefault] = TimeSpan.FromSeconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.HeartbeatIntervalDefault] = TimeSpan.FromSeconds(i).ToString() },
                     { "sf|skipfirstevent=", "The publisher is using this as default value for the skip first " +
                         "event setting of nodes without a skip first event setting.",
-                        (bool b) => this[LegacyCliConfigKeys.SkipFirstDefault] = b.ToString() },
+                        (bool b) => this[StandaloneCliConfigKeys.SkipFirstDefault] = b.ToString() },
 
                     { "fm|fullfeaturedmessage=", "The full featured mode for messages (all fields filled in)." +
                         "Default is 'false' for legacy compatibility.",
-                        (bool b) => this[LegacyCliConfigKeys.FullFeaturedMessage] = b.ToString() },
+                        (bool b) => this[StandaloneCliConfigKeys.FullFeaturedMessage] = b.ToString() },
 
                     // Client settings
                     { "ot|operationtimeout=", "The operation timeout of the publisher OPC UA client in ms.",
-                        (uint i) => this[LegacyCliConfigKeys.OpcOperationTimeout] = TimeSpan.FromMilliseconds(i).ToString() },
+                        (uint i) => this[StandaloneCliConfigKeys.OpcOperationTimeout] = TimeSpan.FromMilliseconds(i).ToString() },
                     { "ol|opcmaxstringlen=", "The max length of a string opc can transmit/receive.",
-                        (uint i) => this[LegacyCliConfigKeys.OpcMaxStringLength] = i.ToString() },
+                        (uint i) => this[StandaloneCliConfigKeys.OpcMaxStringLength] = i.ToString() },
                     { "oi|opcsamplinginterval=", "Default value in milliseconds to request the servers to " +
                         "sample values.",
-                        (int i) => this[LegacyCliConfigKeys.OpcSamplingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.OpcSamplingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
                     { "op|opcpublishinginterval=", "Default value in milliseconds for the publishing interval " +
                         "setting of the subscriptions against the OPC UA server.",
-                        (int i) => this[LegacyCliConfigKeys.OpcPublishingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.OpcPublishingInterval] = TimeSpan.FromMilliseconds(i).ToString() },
                     { "ct|createsessiontimeout=", "Maximum amount of time in seconds that a session should " +
                         "remain open by the OPC server without any activity (session timeout) " +
                         "- to request from the OPC server at session creation.",
-                        (uint u) => this[LegacyCliConfigKeys.OpcSessionCreationTimeout] = TimeSpan.FromSeconds(u).ToString() },
+                        (uint u) => this[StandaloneCliConfigKeys.OpcSessionCreationTimeout] = TimeSpan.FromSeconds(u).ToString() },
                     { "ki|keepaliveinterval=", "The interval in seconds the publisher is sending keep alive messages " +
                         "to the OPC servers on the endpoints it is connected to.",
-                        (int i) => this[LegacyCliConfigKeys.OpcKeepAliveIntervalInSec] = TimeSpan.FromSeconds(i).ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.OpcKeepAliveIntervalInSec] = TimeSpan.FromSeconds(i).ToString() },
                     { "kt|keepalivethreshold=", "Specify the number of keep alive packets a server can miss, " +
                         "before the session is disconneced.",
-                        (uint u) => this[LegacyCliConfigKeys.OpcKeepAliveDisconnectThreshold] = u.ToString() },
+                        (uint u) => this[StandaloneCliConfigKeys.OpcKeepAliveDisconnectThreshold] = u.ToString() },
                     { "fd|fetchdisplayname=", "Fetches the displayname for the monitored items subscribed.",
-                        (bool b) => this[LegacyCliConfigKeys.FetchOpcNodeDisplayName] = b.ToString() },
+                        (bool b) => this[StandaloneCliConfigKeys.FetchOpcNodeDisplayName] = b.ToString() },
                     { "mq|monitoreditemqueuecapacity=", "Default queue size for monitored items.",
-                        (uint u) => this[LegacyCliConfigKeys.DefaultQueueSize] = u.ToString() },
+                        (uint u) => this[StandaloneCliConfigKeys.DefaultQueueSize] = u.ToString() },
 
                     // cert store option
                     { "aa|autoaccept", "The publisher trusts all servers it is establishing a connection to.",
-                          b => this[LegacyCliConfigKeys.AutoAcceptCerts] = (b != null).ToString() },
+                          b => this[StandaloneCliConfigKeys.AutoAcceptCerts] = (b != null).ToString() },
                     { "tm|trustmyself", "The publisher certificate is put into the trusted store automatically.",
-                        t => this[LegacyCliConfigKeys.TrustMyself] = (t != null).ToString() },
+                        t => this[StandaloneCliConfigKeys.TrustMyself] = (t != null).ToString() },
                     { "at|appcertstoretype=", "The own application cert store type (allowed: Directory, X509Store).",
                         s => {
                             if (s.Equals(CertificateStoreType.X509Store, StringComparison.OrdinalIgnoreCase) ||
                                 s.Equals(CertificateStoreType.Directory, StringComparison.OrdinalIgnoreCase)) {
-                                this[LegacyCliConfigKeys.OpcOwnCertStoreType] = s;
+                                this[StandaloneCliConfigKeys.OpcOwnCertStoreType] = s;
                                 return;
                             }
                             throw new OptionException("Bad store type", "at");
                         }
                     },
                     { "ap|appcertstorepath=", "The path where the own application cert should be stored.",
-                        s => this[LegacyCliConfigKeys.OpcOwnCertStorePath] = s },
+                        s => this[StandaloneCliConfigKeys.OpcOwnCertStorePath] = s },
                     { "tp|trustedcertstorepath=", "The path of the trusted cert store.",
-                        s => this[LegacyCliConfigKeys.OpcTrustedCertStorePath] = s },
+                        s => this[StandaloneCliConfigKeys.OpcTrustedCertStorePath] = s },
                     { "sn|appcertsubjectname=", "The subject name for the app cert.",
-                        s => this[LegacyCliConfigKeys.OpcApplicationCertificateSubjectName] = s },
+                        s => this[StandaloneCliConfigKeys.OpcApplicationCertificateSubjectName] = s },
                     { "an|appname=", "The name for the app (used during OPC UA authentication).",
-                        s => this[LegacyCliConfigKeys.OpcApplicationName] = s },
+                        s => this[StandaloneCliConfigKeys.OpcApplicationName] = s },
                     { "tt|trustedcertstoretype=", "Legacy - do not use.", _ => {} },
                     { "rp|rejectedcertstorepath=", "The path of the rejected cert store.",
-                        s => this[LegacyCliConfigKeys.OpcRejectedCertStorePath] = s },
+                        s => this[StandaloneCliConfigKeys.OpcRejectedCertStorePath] = s },
                     { "rt|rejectedcertstoretype=", "Legacy - do not use.", _ => {} },
                     { "ip|issuercertstorepath=", "The path of the trusted issuer cert store.",
-                        s => this[LegacyCliConfigKeys.OpcIssuerCertStorePath] = s },
+                        s => this[StandaloneCliConfigKeys.OpcIssuerCertStorePath] = s },
                     { "it|issuercertstoretype=", "Legacy - do not use.", _ => {} },
                     { "bs|batchsize=", "The size of message batching buffer.",
-                        (int i) => this[LegacyCliConfigKeys.BatchSize] = i.ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.BatchSize] = i.ToString() },
                     { "si|iothubsendinterval=", "The trigger batching interval in seconds.",
-                        (int k) => this[LegacyCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
+                        (int k) => this[StandaloneCliConfigKeys.BatchTriggerInterval] = TimeSpan.FromSeconds(k).ToString() },
                     { "ms|iothubmessagesize=", "The maximum size of the (IoT D2C) message.",
-                        (int i) => this[LegacyCliConfigKeys.IoTHubMaxMessageSize] = i.ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.IoTHubMaxMessageSize] = i.ToString() },
                     { "om|maxoutgressmessages=", "The maximum size of the (IoT D2C) message outgress buffer",
-                        (int i) => this[LegacyCliConfigKeys.MaxOutgressMessages] = i.ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.MaxOutgressMessages] = i.ToString() },
                     { "mm|messagingmode=", "The messaging mode for messages " +
                         $"(allowed values: {string.Join(", ", Enum.GetNames(typeof(MessagingMode)))}).",
-                        (MessagingMode m) => this[LegacyCliConfigKeys.MessagingMode] = m.ToString() },
+                        (MessagingMode m) => this[StandaloneCliConfigKeys.MessagingMode] = m.ToString() },
                     { "me|messageencoding=", "The message encoding for messages " +
                         $"(allowed values: {string.Join(", ", Enum.GetNames(typeof(MessageEncoding)))}).",
-                        (MessageEncoding m) => this[LegacyCliConfigKeys.MessageEncoding] = m.ToString() },
+                        (MessageEncoding m) => this[StandaloneCliConfigKeys.MessageEncoding] = m.ToString() },
 
                     // testing purposes
                     { "sc|scaletestcount=", "The number of monitored item clones in scale tests.",
-                        (int i) => this[LegacyCliConfigKeys.ScaleTestCount] = i.ToString() },
+                        (int i) => this[StandaloneCliConfigKeys.ScaleTestCount] = i.ToString() },
 
-                    // Legacy unsupported
+                    // Legacy: unsupported
                     { "tc|telemetryconfigfile=", "Legacy - do not use.", _ => {} },
                     { "ic|iotcentral=", "Legacy - do not use.", _ => {} },
                     { "ns|noshutdown=", "Legacy - do not use.", _ => {} },
@@ -187,7 +187,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                     { "vc|verboseconsole=", "Legacy - do not use.", _ => {} },
                     { "as|autotrustservercerts=", "Legacy - do not use.", _ => {} }
                 };
-            
             options.Parse(args);
 
             Config = ToAgentConfigModel();
@@ -196,11 +195,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// check if we're running in standalone mode - default publishednodes.json file accessible
         /// </summary>
-        public bool RunInLegacyMode => TryGetValue(LegacyCliConfigKeys.PublishedNodesConfigurationFilename, out _) ||
-             System.IO.File.Exists(LegacyCliConfigKeys.DefaultPublishedNodesFilename);
+        public bool RunInStandaloneMode => TryGetValue(StandaloneCliConfigKeys.PublishedNodesConfigurationFilename, out _) ||
+             System.IO.File.Exists(StandaloneCliConfigKeys.DefaultPublishedNodesFilename);
 
         /// <summary>
-        /// The AgentConfigModel instance that is based on specified legacy command line arguments.
+        /// The AgentConfigModel instance that is based on specified standalone command line arguments.
         /// </summary>
         public AgentConfigModel Config { get; }
 
@@ -215,44 +214,44 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// <summary>
         /// The batch size
         /// </summary>
-        public int? BatchSize => LegacyCliModel.BatchSize;
+        public int? BatchSize => StandaloneCliModel.BatchSize;
 
         /// <summary>
         /// The interval to show diagnostic information in the log.
         /// </summary>
-        public TimeSpan? BatchTriggerInterval => LegacyCliModel.BatchTriggerInterval;
+        public TimeSpan? BatchTriggerInterval => StandaloneCliModel.BatchTriggerInterval;
 
         /// <summary>
         /// The interval to show diagnostic information in the log.
         /// </summary>
-        public TimeSpan? DiagnosticsInterval => LegacyCliModel.DiagnosticsInterval;
+        public TimeSpan? DiagnosticsInterval => StandaloneCliModel.DiagnosticsInterval;
 
         /// <summary>
         /// the Maximum (IoT D2C) message size
         /// </summary>
-        public int? MaxMessageSize => LegacyCliModel.MaxMessageSize;
+        public int? MaxMessageSize => StandaloneCliModel.MaxMessageSize;
 
         /// <summary>
         /// The Maximum (IoT D2C) message buffer size
         /// </summary>
-        public int? MaxOutgressMessages => LegacyCliModel.MaxOutgressMessages;
+        public int? MaxOutgressMessages => StandaloneCliModel.MaxOutgressMessages;
 
         /// <summary>
         /// Maximum number of nodes within a DataSet/Subscription. When more nodes are configured
         /// for a dataSetWriter, they will be added in a different DataSet/Subscription.
         /// </summary>
-        public int? MaxNodesPerDataSet => LegacyCliModel.DefaultMaxNodesPerDataSet;
+        public int? MaxNodesPerDataSet => StandaloneCliModel.DefaultMaxNodesPerDataSet;
 
         /// <summary>
         /// The model of the CLI arguments.
         /// </summary>
-        public LegacyCliModel LegacyCliModel {
+        public StandaloneCliModel StandaloneCliModel {
             get {
-                if (_legacyCliModel == null) {
-                    _legacyCliModel = ToLegacyCliModel();
+                if (_standaloneCliModel == null) {
+                    _standaloneCliModel = TostandaloneCliModel();
                 }
 
-                return _legacyCliModel;
+                return _standaloneCliModel;
             }
         }
 
@@ -263,38 +262,38 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public LoggerConfiguration ToLoggerConfiguration() {
             LoggerConfiguration loggerConfiguration = null;
 
-            if (!string.IsNullOrWhiteSpace(LegacyCliModel.LogFilename)) {
+            if (!string.IsNullOrWhiteSpace(StandaloneCliModel.LogFilename)) {
                 loggerConfiguration ??= new LoggerConfiguration();
                 loggerConfiguration = loggerConfiguration.WriteTo.File(
-                    LegacyCliModel.LogFilename, flushToDiskInterval: LegacyCliModel.LogFileFlushTimeSpan);
+                    StandaloneCliModel.LogFilename, flushToDiskInterval: StandaloneCliModel.LogFileFlushTimeSpan);
             }
 
             return loggerConfiguration;
         }
 
-        private LegacyCliModel ToLegacyCliModel() {
-            var model = new LegacyCliModel();
-            model.PublishedNodesFile = GetValueOrDefault(LegacyCliConfigKeys.PublishedNodesConfigurationFilename, LegacyCliConfigKeys.DefaultPublishedNodesFilename);
-            model.PublishedNodesSchemaFile = GetValueOrDefault(LegacyCliConfigKeys.PublishedNodesConfigurationSchemaFilename, LegacyCliConfigKeys.DefaultPublishedNodesSchemaFilename);
-            model.DefaultHeartbeatInterval = GetValueOrDefault(LegacyCliConfigKeys.HeartbeatIntervalDefault, model.DefaultHeartbeatInterval);
-            model.DefaultSkipFirst = GetValueOrDefault(LegacyCliConfigKeys.SkipFirstDefault, model.DefaultSkipFirst);
-            model.DefaultSamplingInterval = GetValueOrDefault(LegacyCliConfigKeys.OpcSamplingInterval, model.DefaultSamplingInterval);
-            model.DefaultPublishingInterval = GetValueOrDefault(LegacyCliConfigKeys.OpcPublishingInterval, model.DefaultPublishingInterval);
-            model.FetchOpcNodeDisplayName = GetValueOrDefault(LegacyCliConfigKeys.FetchOpcNodeDisplayName, model.FetchOpcNodeDisplayName);
-            model.DefaultQueueSize = GetValueOrDefault(LegacyCliConfigKeys.DefaultQueueSize, model.DefaultQueueSize);
-            model.DiagnosticsInterval = GetValueOrDefault(LegacyCliConfigKeys.DiagnosticsInterval, model.DiagnosticsInterval);
-            model.LogFileFlushTimeSpan = GetValueOrDefault(LegacyCliConfigKeys.LogFileFlushTimeSpanSec, model.LogFileFlushTimeSpan);
-            model.LogFilename = GetValueOrDefault(LegacyCliConfigKeys.LogFileName, model.LogFilename);
-            model.MessagingMode = GetValueOrDefault(LegacyCliConfigKeys.MessagingMode, model.MessagingMode);
-            model.MessageEncoding = GetValueOrDefault(LegacyCliConfigKeys.MessageEncoding, model.MessageEncoding);
-            model.FullFeaturedMessage = GetValueOrDefault(LegacyCliConfigKeys.FullFeaturedMessage, model.FullFeaturedMessage);
-            model.OperationTimeout = GetValueOrDefault(LegacyCliConfigKeys.OpcOperationTimeout, model.OperationTimeout);
-            model.BatchSize = GetValueOrDefault(LegacyCliConfigKeys.BatchSize, model.BatchSize);
-            model.BatchTriggerInterval = GetValueOrDefault(LegacyCliConfigKeys.BatchTriggerInterval, model.BatchTriggerInterval);
-            model.MaxMessageSize = GetValueOrDefault(LegacyCliConfigKeys.IoTHubMaxMessageSize, model.MaxMessageSize);
-            model.ScaleTestCount = GetValueOrDefault(LegacyCliConfigKeys.ScaleTestCount, model.ScaleTestCount);
-            model.MaxOutgressMessages = GetValueOrDefault(LegacyCliConfigKeys.MaxOutgressMessages, model.MaxOutgressMessages);
-            model.DefaultMaxNodesPerDataSet = GetValueOrDefault(LegacyCliConfigKeys.DefaultMaxNodesPerDataSet, model.DefaultMaxNodesPerDataSet);
+        private StandaloneCliModel TostandaloneCliModel() {
+            var model = new StandaloneCliModel();
+            model.PublishedNodesFile = GetValueOrDefault(StandaloneCliConfigKeys.PublishedNodesConfigurationFilename, StandaloneCliConfigKeys.DefaultPublishedNodesFilename);
+            model.PublishedNodesSchemaFile = GetValueOrDefault(StandaloneCliConfigKeys.PublishedNodesConfigurationSchemaFilename, StandaloneCliConfigKeys.DefaultPublishedNodesSchemaFilename);
+            model.DefaultHeartbeatInterval = GetValueOrDefault(StandaloneCliConfigKeys.HeartbeatIntervalDefault, model.DefaultHeartbeatInterval);
+            model.DefaultSkipFirst = GetValueOrDefault(StandaloneCliConfigKeys.SkipFirstDefault, model.DefaultSkipFirst);
+            model.DefaultSamplingInterval = GetValueOrDefault(StandaloneCliConfigKeys.OpcSamplingInterval, model.DefaultSamplingInterval);
+            model.DefaultPublishingInterval = GetValueOrDefault(StandaloneCliConfigKeys.OpcPublishingInterval, model.DefaultPublishingInterval);
+            model.FetchOpcNodeDisplayName = GetValueOrDefault(StandaloneCliConfigKeys.FetchOpcNodeDisplayName, model.FetchOpcNodeDisplayName);
+            model.DefaultQueueSize = GetValueOrDefault(StandaloneCliConfigKeys.DefaultQueueSize, model.DefaultQueueSize);
+            model.DiagnosticsInterval = GetValueOrDefault(StandaloneCliConfigKeys.DiagnosticsInterval, model.DiagnosticsInterval);
+            model.LogFileFlushTimeSpan = GetValueOrDefault(StandaloneCliConfigKeys.LogFileFlushTimeSpanSec, model.LogFileFlushTimeSpan);
+            model.LogFilename = GetValueOrDefault(StandaloneCliConfigKeys.LogFileName, model.LogFilename);
+            model.MessagingMode = GetValueOrDefault(StandaloneCliConfigKeys.MessagingMode, model.MessagingMode);
+            model.MessageEncoding = GetValueOrDefault(StandaloneCliConfigKeys.MessageEncoding, model.MessageEncoding);
+            model.FullFeaturedMessage = GetValueOrDefault(StandaloneCliConfigKeys.FullFeaturedMessage, model.FullFeaturedMessage);
+            model.OperationTimeout = GetValueOrDefault(StandaloneCliConfigKeys.OpcOperationTimeout, model.OperationTimeout);
+            model.BatchSize = GetValueOrDefault(StandaloneCliConfigKeys.BatchSize, model.BatchSize);
+            model.BatchTriggerInterval = GetValueOrDefault(StandaloneCliConfigKeys.BatchTriggerInterval, model.BatchTriggerInterval);
+            model.MaxMessageSize = GetValueOrDefault(StandaloneCliConfigKeys.IoTHubMaxMessageSize, model.MaxMessageSize);
+            model.ScaleTestCount = GetValueOrDefault(StandaloneCliConfigKeys.ScaleTestCount, model.ScaleTestCount);
+            model.MaxOutgressMessages = GetValueOrDefault(StandaloneCliConfigKeys.MaxOutgressMessages, model.MaxOutgressMessages);
+            model.DefaultMaxNodesPerDataSet = GetValueOrDefault(StandaloneCliConfigKeys.DefaultMaxNodesPerDataSet, model.DefaultMaxNodesPerDataSet);
             return model;
         }
 
@@ -302,9 +301,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             return new AgentConfigModel {
                 AgentId = "StandalonePublisher",
                 Capabilities = new Dictionary<string, string>(),
-                HeartbeatInterval = TimeSpan.FromSeconds(30), // heartbeat is needed even though in standalone mode to be notified about config file changes
+                // heartbeat is needed even though in standalone mode to be notified about config file changes
+                HeartbeatInterval = TimeSpan.FromSeconds(30),
                 JobCheckInterval = TimeSpan.FromSeconds(30),
-                JobOrchestratorUrl = "standalone", //we have to set a value so that the (legacy) job orchestrator is called
+                //we have to set a value so that the standalone job orchestrator is called
+                JobOrchestratorUrl = "standalone",
                 MaxWorkers = 1,
             };
         }
@@ -317,6 +318,6 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
             return (T)converter.ConvertFrom(this[key]);
         }
 
-        private LegacyCliModel _legacyCliModel;
+        private StandaloneCliModel _standaloneCliModel;
     }
 }


### PR DESCRIPTION
changes:
 - rename LegacyJobOrchestrator to StandaloneJobOrchestrator
 - replace term legacy with standalone on the when standalone publisher is actually meant
 - add using for SHA256Managed in StandaloneJobOrchestrator