### PR TITLE
Fixing standalone E2E tests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneTestTheory.cs
@@ -68,7 +68,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 new[] { model }
             ).ConfigureAwait(false);
 
-            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             // Wait some time till the updated pn.json is reflected.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds);
@@ -102,7 +102,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 TestConstants.PublishedNodesFullName,
                 Array.Empty<PublishedNodesEntryModel>()
             ).ConfigureAwait(false);
-            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
 
             // Wait till the publishing has stopped.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -65,6 +65,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.True(layeredDeploymentResult, "Failed to create/update layered deployment for publisher module.");
             _output.WriteLine("Created/Updated layered deployment for publisher module.");
 
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
+
             var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
@@ -213,6 +215,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var layeredDeploymentResult1 = await ioTHubLegacyPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(layeredDeploymentResult1, "Failed to create/update layered deployment for legacy publisher module.");
             _output.WriteLine("Created/Updated layered deployment for legacy publisher module.");
+
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token).ConfigureAwait(false);
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneTestTheory.cs
@@ -71,6 +71,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 new[] { nodesToPublish }
             ).ConfigureAwait(false);
 
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
+
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(
                 _context.DeviceConfig.DeviceId,
@@ -118,7 +120,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 TestConstants.PublishedNodesFullName,
                 Array.Empty<PublishedNodesEntryModel>()
             ).ConfigureAwait(false);
-            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token);
 
             // Wait till the publishing has stopped.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -279,6 +279,9 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             _iotHubPublisherModuleName = ioTHubLegacyPublisherDeployment.ModuleName;
 
+            // Clear context.
+            _context.Reset();
+
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
 
             // Make sure that there is no active monitoring.

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -64,6 +64,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var layeredDeploymentResult = await ioTHubPublisherDeployment.CreateOrUpdateLayeredDeploymentAsync(cts.Token).ConfigureAwait(false);
             Assert.True(layeredDeploymentResult, "Failed to create/update layered deployment for publisher module.");
             _output.WriteLine("Created/Updated layered deployment for publisher module.");
+
+            await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
             var exception = Record.Exception(() => _context.RegistryHelper.WaitForIIoTModulesConnectedAsync(

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
@@ -43,12 +43,12 @@ namespace IIoTPlatform_E2E_Tests {
         /// <summary>
         /// Folder to store published_nodes.json file
         /// </summary>
-        public const string PublishedNodesFolder = "/mount";
+        public const string PublishedNodesFolder = "/mount/opc_publisher";
 
         /// <summary>
         /// Folder to store published_nodes.json file for legacy publisher
         /// </summary>
-        public const string PublishedNodesFolderLegacy = "/mountLegacy";
+        public const string PublishedNodesFolderLegacy = "/mount/opc_publisher_2.5";
 
         /// <summary>
         /// The full name of the publishednodes.json on the Edge

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -27,6 +27,7 @@ namespace IIoTPlatform_E2E_Tests {
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.IIoT.Hub.Models;
     using Microsoft.Azure.IIoT.OpcUa.Api.Publisher;
+    using Renci.SshNet.Common;
 
     internal static partial class TestHelper {
 
@@ -247,6 +248,26 @@ namespace IIoTPlatform_E2E_Tests {
         /// <param name="context"></param>
         /// <returns></returns>
         public static async Task CleanPublishedNodesJsonFilesAsync(IIoTPlatformTestContext context) {
+            // Make sure directories exist.
+            var privateKeyFile = GetPrivateSshKey(context);
+            var sftpClient = new SftpClient(context.SshConfig.Host,
+                context.SshConfig.Username,
+                privateKeyFile
+            );
+            sftpClient.Connect();
+
+            void CreateDirectory(SftpClient sftpClient, string directoryPath) {
+                try {
+                    sftpClient.GetAttributes(directoryPath);
+                }
+                catch (SftpPathNotFoundException) {
+                    sftpClient.CreateDirectory(directoryPath);
+                }
+            }
+
+            CreateDirectory(sftpClient, TestConstants.PublishedNodesFolder);
+            CreateDirectory(sftpClient, TestConstants.PublishedNodesFolderLegacy);
+
             await PublishNodesAsync(
                 context,
                 TestConstants.PublishedNodesFullName,

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubLegacyPublisherDeployments.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubLegacyPublisherDeployments.cs
@@ -44,7 +44,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
             },
                 HostConfig = new {
                     Binds = new[] {
-                    TestConstants.PublishedNodesFolderLegacy + "/:" + TestConstants.PublishedNodesFolderLegacy
+                        TestConstants.PublishedNodesFolderLegacy + "/:" + TestConstants.PublishedNodesFolderLegacy
                     }
                 }
             }).Replace("\"", "\\\"");

--- a/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
@@ -65,7 +65,7 @@ namespace IIoTPlatform_E2E_Tests.Deploy {
             },
                 HostConfig = new {
                     Binds = new[] {
-                    TestConstants.PublishedNodesFolder + "/:" + TestConstants.PublishedNodesFolder
+                        TestConstants.PublishedNodesFolder + "/:" + TestConstants.PublishedNodesFolder
                     },
                     CapDrop = new[] {
                         "CHOWN",


### PR DESCRIPTION
Changes:
* Changed mount directories for both versions of OPC Publisher to use subdirectories in `/mount`. This allows us to make sure that the directories exist before writing to `published_nodes.json` files.
* Making sure that we are in standalone mode before waiting for OPC Publisher module to be deployed.