### PR TITLE
fix removing of diagnosticInfo after an unpublish direct method call

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
@@ -746,7 +746,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         foreach (var assignedJob in _assignedJobs) {
                             if (entryJobId == assignedJob.Value.Job.Id) {
                                 found = _assignedJobs.Remove(assignedJob.Key, out _);
-                                _publisherDiagnosticInfo.Remove(assignedJob.Key, out _);
+                                _publisherDiagnosticInfo.Remove(assignedJob.Value.Job.Id, out _);
                                 break;
                             }
                         }
@@ -846,6 +846,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         foreach (var assignedJob in _assignedJobs) {
                             if (entryJobId == assignedJob.Value.Job.Id) {
                                 found = _assignedJobs.Remove(assignedJob.Key, out _);
+                                _publisherDiagnosticInfo.Remove(assignedJob.Value.Job.Id, out _);
                                 break;
                             }
                         }


### PR DESCRIPTION
diagnosticInfo was still present after unpublishing using direct method. 