### PR TITLE
Using SSH client to create mount directories for standalone E2E tests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -249,24 +249,12 @@ namespace IIoTPlatform_E2E_Tests {
         /// <returns></returns>
         public static async Task CleanPublishedNodesJsonFilesAsync(IIoTPlatformTestContext context) {
             // Make sure directories exist.
-            var privateKeyFile = GetPrivateSshKey(context);
-            var sftpClient = new SftpClient(context.SshConfig.Host,
-                context.SshConfig.Username,
-                privateKeyFile
-            );
-            sftpClient.Connect();
-
-            void CreateDirectory(SftpClient sftpClient, string directoryPath) {
-                try {
-                    sftpClient.GetAttributes(directoryPath);
-                }
-                catch (SftpPathNotFoundException) {
-                    sftpClient.CreateDirectory(directoryPath);
-                }
+            using (var sshCient = CreateSshClientAndConnect(context)) {
+                sshCient.RunCommand($"[ ! -d { TestConstants.PublishedNodesFolder} ]" +
+                    $" && sudo mkdir -m 777 -p {TestConstants.PublishedNodesFolder}");
+                sshCient.RunCommand($"[ ! -d { TestConstants.PublishedNodesFolderLegacy} ]" +
+                    $" && sudo mkdir -m 777 -p {TestConstants.PublishedNodesFolderLegacy}");
             }
-
-            CreateDirectory(sftpClient, TestConstants.PublishedNodesFolder);
-            CreateDirectory(sftpClient, TestConstants.PublishedNodesFolderLegacy);
 
             await PublishNodesAsync(
                 context,


### PR DESCRIPTION
Using SSH client instead of SFTP client to create mount directories for standalone E2E tests.