### PR TITLE
Fixing removal of diagnostics info in AddOrUpdateEndpointsAsync().

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
@@ -1023,7 +1023,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                             foreach (var assignedJob in _assignedJobs) {
                                 if (entryJobId == assignedJob.Value.Job.Id) {
                                     jobFound = _assignedJobs.Remove(assignedJob.Key);
-                                    _publisherDiagnosticInfo.Remove(assignedJob.Key);
+                                    _publisherDiagnosticInfo.Remove(assignedJob.Value.Job.Id);
                                     break;
                                 }
                             }


### PR DESCRIPTION
Aligning diagnostics info removal logic in `AddOrUpdateEndpointsAsync()` with that of `UnpublishNodesAsync()` and `UnpublishAllNodesAsync()`.