### PR TITLE
Increased E2E test time limit to 120 minutes from 90.

### DIFF
--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -78,7 +78,7 @@ stages:
   condition: and(not(canceled()), or(eq(dependencies.deploy.result, 'Succeeded'), eq(dependencies.deploy.result, 'Skipped')))
   jobs:
   - job: runtests
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     displayName: 'Run End 2 End Tests'
     steps:
     - template: steps/runtests.yml

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -94,7 +94,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'Executing xUnit tests (with ${{ parameters.ModeName }}=${{ parameters.ModeValue }})'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   inputs:
     command: test
     projects: '$(TestPath)\IIoTPlatform-E2E-Tests.csproj'


### PR DESCRIPTION
Standalone E2E tests now may last longer than `90` minutes. So this PR increases that limit to `120` minutes.

[Here](https://iotcat.visualstudio.com/Industrial-IoT-E2E-Testing/_build/results?buildId=3589&view=results) is a sample of standalone E2E test run that timed out. One can see that no test failed during this time.