### PR TITLE
Fixed expected values for MonitoredOpcNodesSucceededCount according to publishing requests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
@@ -61,8 +61,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.True(layeredDeploymentResult, "Failed to create/update layered deployment for publisher module.");
             _output.WriteLine("Created/Updated layered deployment for publisher module.");
 
-            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token).ConfigureAwait(false);
-
             await TestHelper.SwitchToStandaloneModeAsync(_context, cts.Token).ConfigureAwait(false);
 
             // We will wait for module to be deployed.
@@ -85,6 +83,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
             Assert.Equal(0, configuredEndpointsResponse.Count);
 
+            var model = await TestHelper.CreateSingleNodeModelAsync(_context, cts.Token).ConfigureAwait(false);
             var request = model.ToApiModel();
 
             //Call Publish direct method
@@ -153,7 +152,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.True(diagInfoList[0].IngressValueChanges > 0);
             Assert.True(diagInfoList[0].IngressDataChanges > 0);
             Assert.Equal(0, diagInfoList[0].MonitoredOpcNodesFailedCount);
-            Assert.Equal(10, diagInfoList[0].MonitoredOpcNodesSucceededCount);
+            Assert.Equal(1, diagInfoList[0].MonitoredOpcNodesSucceededCount);
             Assert.True(diagInfoList[0].OpcEndpointConnected);
             Assert.True(diagInfoList[0].OutgressIoTMessageCount > 0);
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -173,7 +173,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.True(diagInfoList[0].IngressValueChanges > 0);
             Assert.True(diagInfoList[0].IngressDataChanges > 0);
             Assert.Equal(0, diagInfoList[0].MonitoredOpcNodesFailedCount);
-            Assert.Equal(10, diagInfoList[0].MonitoredOpcNodesSucceededCount);
+            Assert.Equal(250, diagInfoList[0].MonitoredOpcNodesSucceededCount);
             Assert.True(diagInfoList[0].OpcEndpointConnected);
             Assert.True(diagInfoList[0].OutgressIoTMessageCount > 0);
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -241,7 +241,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 Assert.True(diagInfo.IngressValueChanges > 0);
                 Assert.True(diagInfo.IngressDataChanges > 0);
                 Assert.Equal(0, diagInfo.MonitoredOpcNodesFailedCount);
-                Assert.Equal(10, diagInfo.MonitoredOpcNodesSucceededCount);
+                Assert.Equal(125, diagInfo.MonitoredOpcNodesSucceededCount);
                 Assert.True(diagInfo.OpcEndpointConnected);
                 Assert.True(diagInfo.OutgressIoTMessageCount > 0);
 


### PR DESCRIPTION
Changes:
* Fixed expected values for `MonitoredOpcNodesSucceededCount` according to publishing requests. The values are `1` for `A` test suite, `250` for `B` test suite and `125` for `C` test suite.