### PR TITLE
Allowing for some time between unpublishing and getting diagnostic info.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -913,6 +913,10 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
+            // Cleanup of sessions is an operation that happens in parallel to unpublishing. So getting diagnostic info immediately
+            // after unpublishing might not yet show the cleaned up state. So we will wait for some time to allow for that to happen.
+            await Task.Delay(TestConstants.DefaultDelayMilliseconds, cts.Token).ConfigureAwait(false);
+
             //Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
                 new MethodParameterModel {


### PR DESCRIPTION
This change adds `5` seconds of delay in `C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.SubscribeUnsubscribeDirectMethodLegacyPublisherTest()` test between node unpublishing and getting diagnostic info. This is needed as in OPC Publisher `2.5` cleanup of unused sessions is not triggered directly by unpublishing but happen in parallel from a housekeeping loop in `OpcSession.cs`. So we can encounter situations where fast call to `GetDiagnosticInfo` would still return state before cleanup of unused sessions.