### PR TITLE
Fix publisher heartbeat interval inconsistent handling

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishedNodeApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishedNodeApiModel.cs
@@ -73,12 +73,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
         /// </summary>
         [DataMember(Name = "heartbeatInterval", Order = 8,
             EmitDefaultValue = false)]
-        public int? HeartbeatInterval {
-            get => HeartbeatIntervalTimespan.HasValue ?
-                (int)HeartbeatIntervalTimespan.Value.TotalSeconds : (int?)null;
-            set => HeartbeatIntervalTimespan = value.HasValue ?
-                TimeSpan.FromSeconds(value.Value) : (TimeSpan?)null;
-        }
+        public int? HeartbeatInterval { get; set; }
 
         /// <summary> Heartbeat </summary>
         [DataMember(Name = "heartbeatIntervalTimespan", Order = 9,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -128,11 +128,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                     PublishedVariableDisplayName = node.Item2.DisplayName,
                                     SamplingInterval = node.Item2.OpcSamplingIntervalTimespan ??
                                         standaloneCliModel.DefaultSamplingInterval,
-                                    HeartbeatInterval = node.Item2.HeartbeatIntervalTimespan.HasValue
-                                        ? node.Item2.HeartbeatIntervalTimespan.Value
-                                        : node.Item2.HeartbeatInterval.HasValue
-                                            ? TimeSpan.FromSeconds(node.Item2.HeartbeatInterval.Value)
-                                            : standaloneCliModel.DefaultHeartbeatInterval,
+                                    HeartbeatInterval = node.Item2.HeartbeatIntervalTimespan
+                                        .GetTimeSpanFromSeconds(node.Item2.HeartbeatInterval) ??
+                                            standaloneCliModel.DefaultHeartbeatInterval,
                                     QueueSize = node.Item2.QueueSize ?? standaloneCliModel.DefaultQueueSize,
                                     SkipFirst = node.Item2.SkipFirst ?? standaloneCliModel.DefaultSkipFirst,
                                 }).ToList()

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -128,9 +128,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                     PublishedVariableDisplayName = node.Item2.DisplayName,
                                     SamplingInterval = node.Item2.OpcSamplingIntervalTimespan ??
                                         standaloneCliModel.DefaultSamplingInterval,
-                                    HeartbeatInterval = node.Item2.HeartbeatIntervalTimespan.HasValue ?
-                                        node.Item2.HeartbeatIntervalTimespan.Value :
-                                        standaloneCliModel.DefaultHeartbeatInterval,
+                                    HeartbeatInterval = node.Item2.HeartbeatIntervalTimespan.HasValue
+                                        ? node.Item2.HeartbeatIntervalTimespan.Value
+                                        : node.Item2.HeartbeatInterval.HasValue
+                                            ? TimeSpan.FromSeconds(node.Item2.HeartbeatInterval.Value)
+                                            : standaloneCliModel.DefaultHeartbeatInterval,
                                     QueueSize = node.Item2.QueueSize ?? standaloneCliModel.DefaultQueueSize,
                                     SkipFirst = node.Item2.SkipFirst ?? standaloneCliModel.DefaultSkipFirst,
                                 }).ToList()
@@ -306,6 +308,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                             DataSetFieldId = node.DataSetFieldId,
                             ExpandedNodeId = node.ExpandedNodeId,
                             HeartbeatIntervalTimespan = node.HeartbeatIntervalTimespan,
+                            HeartbeatInterval = node.HeartbeatInterval,
                             OpcPublishingInterval = item.DataSetPublishingInterval.GetValueOrDefault(
                                      node.OpcPublishingInterval.GetValueOrDefault(
                                          (int)standaloneCliModel.DefaultPublishingInterval.GetValueOrDefault().TotalMilliseconds)),
@@ -326,6 +329,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                 DataSetFieldId = node.DataSetFieldId,
                                 ExpandedNodeId = node.ExpandedNodeId,
                                 HeartbeatIntervalTimespan = node.HeartbeatIntervalTimespan,
+                                HeartbeatInterval = node.HeartbeatInterval,
                                 OpcPublishingInterval = item.DataSetPublishingInterval.GetValueOrDefault(
                                     node.OpcPublishingInterval.GetValueOrDefault(
                                         (int)standaloneCliModel.DefaultPublishingInterval.GetValueOrDefault().TotalMilliseconds)),

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
@@ -58,7 +58,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
                 return false;
             }
 
-            if (model.HeartbeatInterval != that.HeartbeatInterval) {
+            var modelHeartbeatInterval = model.HeartbeatIntervalTimespan.HasValue
+                ? model.HeartbeatIntervalTimespan
+                : model.HeartbeatInterval.HasValue
+                    ? TimeSpan.FromSeconds(model.HeartbeatInterval.Value)
+                    : (TimeSpan?)null;
+
+            var thatHeartbeatInterval = that.HeartbeatIntervalTimespan.HasValue
+                ? that.HeartbeatIntervalTimespan
+                : that.HeartbeatInterval.HasValue
+                    ? TimeSpan.FromSeconds(that.HeartbeatInterval.Value)
+                    : (TimeSpan?)null;
+
+            if (modelHeartbeatInterval != thatHeartbeatInterval) {
                 return false;
             }
 
@@ -76,17 +88,20 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
         /// <summary>
         /// Returns the hashcode for a node
         /// </summary>
-        public static int GetHashCode(this OpcNodeModel model, int? defaultPublishing = null) {
+        public static int GetHashCode(this OpcNodeModel model) {
             var hash = new HashCode();
             hash.Add(model.Id);
             hash.Add(model.DisplayName);
             hash.Add(model.DataSetFieldId);
             hash.Add(model.ExpandedNodeId);
-            hash.Add(defaultPublishing.HasValue
-                ? model.OpcPublishingInterval.GetValueOrDefault(defaultPublishing.Value)
-                : model.OpcPublishingInterval);
+            hash.Add(model.OpcPublishingInterval);
             hash.Add(model.OpcSamplingInterval);
-            hash.Add(model.HeartbeatInterval);
+            var heartbeatInterval = model.HeartbeatIntervalTimespan.HasValue
+                ? model.HeartbeatIntervalTimespan
+                : model.HeartbeatInterval.HasValue
+                    ? TimeSpan.FromSeconds(model.HeartbeatInterval.Value)
+                    : (TimeSpan?)null;
+            hash.Add(heartbeatInterval);
             hash.Add(model.SkipFirst);
             hash.Add(model.QueueSize);
             return hash.ToHashCode();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
@@ -58,19 +58,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
                 return false;
             }
 
-            var modelHeartbeatInterval = model.HeartbeatIntervalTimespan.HasValue
-                ? model.HeartbeatIntervalTimespan
-                : model.HeartbeatInterval.HasValue
-                    ? TimeSpan.FromSeconds(model.HeartbeatInterval.Value)
-                    : (TimeSpan?)null;
-
-            var thatHeartbeatInterval = that.HeartbeatIntervalTimespan.HasValue
-                ? that.HeartbeatIntervalTimespan
-                : that.HeartbeatInterval.HasValue
-                    ? TimeSpan.FromSeconds(that.HeartbeatInterval.Value)
-                    : (TimeSpan?)null;
-
-            if (modelHeartbeatInterval != thatHeartbeatInterval) {
+            if (model.HeartbeatIntervalTimespan.GetTimeSpanFromSeconds(model.HeartbeatInterval) !=
+                that.HeartbeatIntervalTimespan.GetTimeSpanFromSeconds(that.HeartbeatInterval)) {
                 return false;
             }
 
@@ -96,15 +85,23 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
             hash.Add(model.ExpandedNodeId);
             hash.Add(model.OpcPublishingInterval);
             hash.Add(model.OpcSamplingInterval);
-            var heartbeatInterval = model.HeartbeatIntervalTimespan.HasValue
-                ? model.HeartbeatIntervalTimespan
-                : model.HeartbeatInterval.HasValue
-                    ? TimeSpan.FromSeconds(model.HeartbeatInterval.Value)
-                    : (TimeSpan?)null;
-            hash.Add(heartbeatInterval);
+            hash.Add(model.HeartbeatIntervalTimespan.GetTimeSpanFromSeconds(model.HeartbeatInterval));
             hash.Add(model.SkipFirst);
             hash.Add(model.QueueSize);
             return hash.ToHashCode();
+        }
+
+        /// <summary>
+        /// Returns a the timespan value from the timespan repsecively integer rperesenting seconds
+        /// The Timespan value wins when provided
+        /// </summary>
+        public static TimeSpan?  GetTimeSpanFromSeconds(this TimeSpan? timespan, int? seconds) {
+
+            return timespan.HasValue
+                ? timespan
+                : seconds.HasValue
+                    ? TimeSpan.FromSeconds(seconds.Value)
+                    : (TimeSpan?)null;
         }
 
         /// <summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcNodeModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/OpcNodeModel.cs
@@ -61,14 +61,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
 
         /// <summary> Heartbeat interval in seconds </summary>
         [DataMember(EmitDefaultValue = false, IsRequired = false)]
-        public int? HeartbeatInterval {
-            get => HeartbeatIntervalTimespan.HasValue
-                ? (int)HeartbeatIntervalTimespan.Value.TotalSeconds
-                : default;
-            set => HeartbeatIntervalTimespan = value.HasValue
-                ? TimeSpan.FromSeconds(value.Value)
-                : default;
-        }
+        public int? HeartbeatInterval { get; set; }
 
         /// <summary> Heartbeat interval as TimeSpan. </summary>
         [DataMember(EmitDefaultValue = false, IsRequired = false)]

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
@@ -56,6 +56,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
                 OpcPublishingInterval = model.OpcPublishingInterval,
                 OpcSamplingInterval = model.OpcSamplingInterval,
                 HeartbeatIntervalTimespan = model.HeartbeatIntervalTimespan,
+                // only fill the HeartbeatInterval if the HeartbeatIntervalTimespan
+                // was not provided.
+                HeartbeatInterval = !model.HeartbeatIntervalTimespan.HasValue
+                    ? model.HeartbeatInterval
+                    : null,
                 SkipFirst = model.SkipFirst,
                 QueueSize = model.QueueSize,
             };
@@ -119,7 +124,10 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
                 OpcPublishingInterval = model.OpcPublishingInterval,
                 DataSetFieldId = model.DataSetFieldId,
                 DisplayName = model.DisplayName,
-                HeartbeatInterval = model.HeartbeatInterval,
+                HeartbeatIntervalTimespan = model.HeartbeatIntervalTimespan,
+                HeartbeatInterval = !model.HeartbeatIntervalTimespan.HasValue
+                    ? model.HeartbeatInterval
+                    : null,
                 SkipFirst = model.SkipFirst,
                 QueueSize = model.QueueSize,
             };


### PR DESCRIPTION
* make sure the default values for `HeartbeatInterval` respective `HeartbeatIntervalTimespan` are **not** persisted it in the pn.json.
* make sure only one of the `HeartbeatInterval` respectivelty `HeartbeatIntervalTimespan` (this wins when both values provided) is consistently used in job definitions. Timespan variant wins when both values are provided.
* report consistently the `HeartbeatInterval`, as originally configured in `GetConfiguredNodesOnEndpoint_V1` DM.