### PR TITLE
Fixed bug with expected order of diagnostic info entries in response.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/A_PublishSingleNodeStandaloneDirectMethodTestTheory.cs
@@ -148,18 +148,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal((int)HttpStatusCode.OK, responseGetDiagnosticInfo.Status);
             var diagInfoList = _serializer.Deserialize<List<DiagnosticInfoApiModel>>(responseGetDiagnosticInfo.JsonPayload);
             Assert.Equal(diagInfoList.Count, 1);
-            
-            TestHelper.Publisher.AssertEndpointInfoModel(diagInfoList[0].EndpointInfo, request);
-            Assert.True(diagInfoList[0].IngressValueChanges > 0);
-            Assert.True(diagInfoList[0].IngressDataChanges > 0);
-            Assert.Equal(0, diagInfoList[0].MonitoredOpcNodesFailedCount);
-            Assert.Equal(1, diagInfoList[0].MonitoredOpcNodesSucceededCount);
-            Assert.True(diagInfoList[0].OpcEndpointConnected);
-            Assert.True(diagInfoList[0].OutgressIoTMessageCount > 0);
 
-            // Check that we are not dropping anything.
-            Assert.Equal((uint)0, diagInfoList[0].EncoderNotificationsDropped);
-            Assert.Equal((ulong)0, diagInfoList[0].OutgressInputBufferDropped);
+            TestHelper.Publisher.AssertEndpointDiagnosticInfoModel(request, diagInfoList[0]);
 
             // Stop monitoring and get the result.
             var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -170,17 +170,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var diagInfoList = _serializer.Deserialize<List<DiagnosticInfoApiModel>>(responseGetDiagnosticInfo.JsonPayload);
             Assert.Equal(diagInfoList.Count, 1);
 
-            TestHelper.Publisher.AssertEndpointInfoModel(diagInfoList[0].EndpointInfo, request);
-            Assert.True(diagInfoList[0].IngressValueChanges > 0);
-            Assert.True(diagInfoList[0].IngressDataChanges > 0);
-            Assert.Equal(0, diagInfoList[0].MonitoredOpcNodesFailedCount);
-            Assert.Equal(250, diagInfoList[0].MonitoredOpcNodesSucceededCount);
-            Assert.True(diagInfoList[0].OpcEndpointConnected);
-            Assert.True(diagInfoList[0].OutgressIoTMessageCount > 0);
-
-            // Check that we are not dropping anything.
-            Assert.Equal((uint)0, diagInfoList[0].EncoderNotificationsDropped);
-            Assert.Equal((ulong)0, diagInfoList[0].OutgressInputBufferDropped);
+            TestHelper.Publisher.AssertEndpointDiagnosticInfoModel(request, diagInfoList[0]);
 
             // Stop monitoring and get the result.
             var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -965,7 +965,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
             endpoints = _serializer.SerializeToString(epObj["Endpoints"]);
             configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(endpoints);
-            Assert.Equal(configuredEndpointsResponse.Count, 0);
+            Assert.Equal(0, configuredEndpointsResponse.Count);
 
             // Wait till the publishing has stopped.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Publisher.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Publisher.cs
@@ -27,14 +27,32 @@ namespace IIoTPlatform_E2E_Tests {
             }
 
             /// <summary>
-            /// Compare PublishNodesEndpointApiModel with PublishedNodeApiModel returned from diagnosticInfo
+            /// Compare PublishNodesEndpointApiModel of requst with DiagnosticInfoApiModel returned
+            /// from GetDiagnosticInfo direct method call.
             /// </summary>
-            public static void AssertEndpointInfoModel(PublishNodesEndpointApiModel expected, PublishNodesEndpointApiModel actual) {
+            public static void AssertEndpointDiagnosticInfoModel(
+                PublishNodesEndpointApiModel expected,
+                DiagnosticInfoApiModel diagnosticInfo) {
+
+                var actual = diagnosticInfo.EndpointInfo;
+
                 Assert.Equal(expected.DataSetWriterGroup, actual.DataSetWriterGroup);
                 Assert.Equal(expected.EndpointUrl.TrimEnd('/'), actual.EndpointUrl.TrimEnd('/'));
                 Assert.Equal(expected.OpcAuthenticationMode, actual.OpcAuthenticationMode);
                 Assert.Equal(expected.UserName, actual.UserName);
                 Assert.Equal(expected.UseSecurity, actual.UseSecurity);
+
+                // Check validity of diagnosticInfo
+                Assert.True(diagnosticInfo.IngressValueChanges > 0);
+                Assert.True(diagnosticInfo.IngressDataChanges > 0);
+                Assert.Equal(0, diagnosticInfo.MonitoredOpcNodesFailedCount);
+                Assert.Equal(expected.OpcNodes.Count, diagnosticInfo.MonitoredOpcNodesSucceededCount);
+                Assert.True(diagnosticInfo.OpcEndpointConnected);
+                Assert.True(diagnosticInfo.OutgressIoTMessageCount > 0);
+
+                // Check that we are not dropping anything.
+                Assert.Equal((uint)0, diagnosticInfo.EncoderNotificationsDropped);
+                Assert.Equal((ulong)0, diagnosticInfo.OutgressInputBufferDropped);
             }
         }
     }


### PR DESCRIPTION
Accounting for the fact that order of diagnostic info entries in response might not be the same as requests order.