### PR TITLE
Add non-versioned name to the publisher's DM API as fallback

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Hosting/MethodRouter.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/src/Hosting/MethodRouter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
         /// <param name="target"></param>
         private void AddToCallTable(object target) {
             var versions = target.GetType().GetCustomAttributes<VersionAttribute>(true)
-                .Select(v => "_v" + v.Value)
+                .Select(v => v.Value)
                 .ToList();
             if (versions.Count == 0) {
                 versions.Add(string.Empty);

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Hosting/MethodRouterTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Hosting/MethodRouterTests.cs
@@ -568,7 +568,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
             public byte[] Test { get; set; }
         }
 
-        [Version(1)]
+        [Version("_V1")]
         public class TestControllerV1 : IMethodController {
 
             public Task<TestModel> Test1Async(TestModel request) {
@@ -599,7 +599,7 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
             public bool _noparamcalled;
         }
 
-        [Version(2)]
+        [Version("_V2")]
         public class TestControllerV2 : IMethodController {
 
             public Task<byte[]> Test2Async(byte[] request) {
@@ -618,8 +618,8 @@ namespace Microsoft.Azure.IIoT.Module.Framework.Hosting {
             }
         }
 
-        [Version(1)]
-        [Version(2)]
+        [Version("_V1")]
+        [Version("_V2")]
         public class TestControllerV1And2 : IMethodController {
 
             public Task<byte[]> Test8Async(byte[] request) {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/src/Controllers/DiscoveryMethodsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/src/Controllers/DiscoveryMethodsController.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Azure.IIoT.Modules.Discovery.Controllers {
     /// <summary>
     /// Discovery method controller
     /// </summary>
-    [Version(1)]
-    [Version(2)]
+    [Version("_V1")]
+    [Version("_V2")]
     [ExceptionsFilter]
     public class DiscoveryMethodsController : IMethodController {
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Controller/PublisherMethodsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Controller/PublisherMethodsController.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Controller {
-    using Microsoft.Azure.IIoT.Agent.Framework.Models;
     using Microsoft.Azure.IIoT.Exceptions;
     using Microsoft.Azure.IIoT.Module.Framework;
     using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
@@ -20,7 +19,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Controller {
     /// <summary>
     /// Publisher direct  method controller
     /// </summary>
-    [Version(1)]
+    [Version("_V1")]
+    [Version("")]
     [ExceptionsFilter]
     public class PublisherMethodsController : IMethodController {
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/EndpointMethodsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/EndpointMethodsController.cs
@@ -14,16 +14,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Controllers {
     using Microsoft.Azure.IIoT.OpcUa.Twin;
     using Microsoft.Azure.IIoT.OpcUa.History;
     using Microsoft.Azure.IIoT.Serializers;
+    using Prometheus;
     using System;
     using System.Threading.Tasks;
-    using Prometheus;
-    using Microsoft.Azure.IIoT.Module;
 
     /// <summary>
     /// Endpoint methods controller
     /// </summary>
-    [Version(1)]
-    [Version(2)]
+    [Version("_V1")]
+    [Version("_V2")]
     [ExceptionsFilter]
     public class EndpointMethodsController : IMethodController {
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/SupervisorMethodsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Controllers/SupervisorMethodsController.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Controllers {
     /// <summary>
     /// Supervisor method controller
     /// </summary>
-    [Version(1)]
-    [Version(2)]
+    [Version("_V1")]
+    [Version("_V2")]
     [ExceptionsFilter]
     public class SupervisorMethodsController : IMethodController {
 


### PR DESCRIPTION
The publisher shall respond to the DM names without _V1 as a fallback. The recommended way is still with "_V1" suffix