### PR TITLE
Making sure UseSecurity and OpcAuthenticationMode fields are always present in serialized form.

### DIFF
--- a/Industrial-IoT.sln
+++ b/Industrial-IoT.sln
@@ -234,6 +234,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.Valida
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.OpcUa.Tests", "components\opc-ua\src\Microsoft.Azure.IIoT.OpcUa\tests\Microsoft.Azure.IIoT.OpcUa.Tests.csproj", "{74076B01-7597-49FB-9A50-579C92CEFE66}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests", "api\src\Microsoft.Azure.IIoT.OpcUa.Api.Publisher\tests\Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj", "{B27F0CAE-FE68-4789-9EA5-77838DA27C48}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -962,6 +964,14 @@ Global
 		{74076B01-7597-49FB-9A50-579C92CEFE66}.Release|Any CPU.Build.0 = Release|Any CPU
 		{74076B01-7597-49FB-9A50-579C92CEFE66}.Release|x64.ActiveCfg = Release|Any CPU
 		{74076B01-7597-49FB-9A50-579C92CEFE66}.Release|x64.Build.0 = Release|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Debug|x64.Build.0 = Debug|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Release|x64.ActiveCfg = Release|Any CPU
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1075,6 +1085,7 @@ Global
 		{019C942B-5FC7-4417-BE1D-40E7E6869D1B} = {FEE95825-2E34-45AF-BDED-52F9C7412BF5}
 		{1C45566A-D8AC-4EAE-9735-39663784D2DF} = {BBEE26AC-8733-469B-B816-0A54EA99FC59}
 		{74076B01-7597-49FB-9A50-579C92CEFE66} = {1266F300-8BD2-4F1E-BA88-911F5F3AC36C}
+		{B27F0CAE-FE68-4789-9EA5-77838DA27C48} = {85888E57-3801-4986-97E2-11A25B7D1C58}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F09EFCEA-59F6-4A16-9CB6-7E865A3F62D8}

--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -1,24 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Serializers.MessagePack\src\Microsoft.Azure.IIoT.Serializers.MessagePack.csproj" />

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishNodesEndpointApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/PublishNodesEndpointApiModel.cs
@@ -42,12 +42,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
 
         /// <summary> Use a secured channel for the opc ua communication </summary>
         [DataMember(Name = "useSecurity", Order = 5,
-            EmitDefaultValue = false)]
+            EmitDefaultValue = true)]
         public bool UseSecurity { get; set; }
 
         /// <summary> endpoint authentication mode </summary>
         [DataMember(Name = "opcAuthenticationMode", Order = 6,
-            EmitDefaultValue = false)]
+            EmitDefaultValue = true)]
         public AuthenticationMode OpcAuthenticationMode { get; set; }
 
         /// <summary> Endpoint's username </summary>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj" />
+    <ProjectReference Include="..\src\Microsoft.Azure.IIoT.OpcUa.Api.Publisher.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Models/PublishNodesEndpointApiModelTests.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Models/PublishNodesEndpointApiModelTests.cs
@@ -1,0 +1,189 @@
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+
+namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.Models {
+
+    using Xunit;
+    using System.Collections.Generic;
+    using System;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
+    using Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models;
+
+    public class PublishNodesEndpointApiModelTests {
+
+        [Fact]
+        public void UseSecurityDeserializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            var model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.False(model.UseSecurity);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""UseSecurity"": false,
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.False(model.UseSecurity);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""UseSecurity"": true,
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.True(model.UseSecurity);
+        }
+
+        [Fact]
+        public void UseSecuritySerializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            var modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"useSecurity\":false", modeJson);
+
+            model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                UseSecurity = false,
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"useSecurity\":false", modeJson);
+
+            model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                UseSecurity = true,
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"useSecurity\":true", modeJson);
+        }
+
+        [Fact]
+        public void OpcAuthenticationModeDeserializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
+}
+";
+
+            var model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.Equal(AuthenticationMode.Anonymous, model.OpcAuthenticationMode);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""OpcAuthenticationMode"": ""anonymous"",
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.Equal(AuthenticationMode.Anonymous, model.OpcAuthenticationMode);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""OpcAuthenticationMode"": ""usernamePassword"",
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishNodesEndpointApiModel>(modelJson);
+            Assert.Equal(AuthenticationMode.UsernamePassword, model.OpcAuthenticationMode);
+        }
+
+        [Fact]
+        public void OpcAuthenticationModeSerializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            var modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"opcAuthenticationMode\":\"anonymous\"", modeJson);
+
+            model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                OpcAuthenticationMode = AuthenticationMode.Anonymous,
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"opcAuthenticationMode\":\"anonymous\"", modeJson);
+
+            model = new PublishNodesEndpointApiModel {
+                EndpointUrl = "opc.tcp://localhost:50000",
+                OpcAuthenticationMode = AuthenticationMode.UsernamePassword,
+                OpcNodes = new List<PublishedNodeApiModel> {
+                    new PublishedNodeApiModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"opcAuthenticationMode\":\"usernamePassword\"", modeJson);
+        }
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -251,8 +251,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                 // Exclude the DataSetWriterId since it is not part of the connection model
                 Endpoint = new EndpointModel {
                     Url = model.EndpointUrl.OriginalString,
-                    SecurityMode = model.UseSecurity.GetValueOrDefault(false) ?
-                                 SecurityMode.Best : SecurityMode.None,
+                    SecurityMode = model.UseSecurity
+                        ? SecurityMode.Best
+                        : SecurityMode.None,
                 },
                 User = model.OpcAuthenticationMode != OpcAuthenticationMode.UsernamePassword ?
                             null : ToUserNamePasswordCredentialAsync(model).GetAwaiter().GetResult(),

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedNodesEntryModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/PublishedNodesEntryModel.cs
@@ -35,15 +35,15 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
         public Uri EndpointUrl { get; set; }
 
         /// <summary> Secure transport should be used to connect to the opc server.</summary>
-        [DataMember(EmitDefaultValue = false, IsRequired = false)]
-        public bool? UseSecurity { get; set; }
+        [DataMember(EmitDefaultValue = true, IsRequired = false)]
+        public bool UseSecurity { get; set; }
 
         /// <summary> The node to monitor in "ns=" syntax. </summary>
         [DataMember(EmitDefaultValue = false, IsRequired = false)]
         public NodeIdModel NodeId { get; set; }
 
         /// <summary> authentication mode </summary>
-        [DataMember(EmitDefaultValue = false, IsRequired = false)]
+        [DataMember(EmitDefaultValue = true, IsRequired = false)]
         public OpcAuthenticationMode OpcAuthenticationMode { get; set; }
 
         /// <summary> encrypted username </summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\common\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj" />
     <ProjectReference Include="..\src\Microsoft.Azure.IIoT.OpcUa.csproj" />
   </ItemGroup>
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Publisher/Models/PublishedNodesEntryModelTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Publisher/Models/PublishedNodesEntryModelTests.cs
@@ -6,11 +6,11 @@
 namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
 
     using Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models;
-    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
     using Microsoft.Azure.IIoT.Serializers;
-    using Xunit;
-    using System.Collections.Generic;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
     using System;
+    using System.Collections.Generic;
+    using Xunit;
 
     public class PublishedNodesEntryModelTests {
 
@@ -21,9 +21,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
             var modelJson = @"
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 
@@ -34,9 +34,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
     ""UseSecurity"": false,
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 
@@ -47,9 +47,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
     ""UseSecurity"": true,
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 
@@ -107,9 +107,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
             var modelJson = @"
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 
@@ -120,9 +120,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
     ""OpcAuthenticationMode"": ""anonymous"",
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 
@@ -133,9 +133,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
 {
     ""EndpointUrl"": ""opc.tcp://localhost:50002"",
     ""OpcAuthenticationMode"": ""usernamePassword"",
-    ""NodeId"": {
-        ""Identifier"": ""ns=0;i=2261""
-    }
+    ""OpcNodes"": [
+        { ""Identifier"": ""ns=0;i=2261"" }
+    ]
 }
 ";
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Publisher/Models/PublishedNodesEntryModelTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Publisher/Models/PublishedNodesEntryModelTests.cs
@@ -1,0 +1,189 @@
+﻿// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Tests.Publisher.Config.Models {
+
+    using Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models;
+    using Microsoft.Azure.IIoT.Serializers.NewtonSoft;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Xunit;
+    using System.Collections.Generic;
+    using System;
+
+    public class PublishedNodesEntryModelTests {
+
+        [Fact]
+        public void UseSecurityDeserializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            var model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.False(model.UseSecurity);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""UseSecurity"": false,
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.False(model.UseSecurity);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""UseSecurity"": true,
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.True(model.UseSecurity);
+        }
+
+        [Fact]
+        public void UseSecuritySerializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            var modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"UseSecurity\":false", modeJson);
+
+            model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                UseSecurity = false,
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"UseSecurity\":false", modeJson);
+
+            model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                UseSecurity = true,
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"UseSecurity\":true", modeJson);
+        }
+
+        [Fact]
+        public void OpcAuthenticationModeDeserializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            var model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.Equal(OpcAuthenticationMode.Anonymous, model.OpcAuthenticationMode);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""OpcAuthenticationMode"": ""anonymous"",
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.Equal(OpcAuthenticationMode.Anonymous, model.OpcAuthenticationMode);
+
+            modelJson = @"
+{
+    ""EndpointUrl"": ""opc.tcp://localhost:50002"",
+    ""OpcAuthenticationMode"": ""usernamePassword"",
+    ""NodeId"": {
+        ""Identifier"": ""ns=0;i=2261""
+    }
+}
+";
+
+            model = newtonSoftJsonSerializer.Deserialize<PublishedNodesEntryModel>(modelJson);
+            Assert.Equal(OpcAuthenticationMode.UsernamePassword, model.OpcAuthenticationMode);
+        }
+
+        [Fact]
+        public void OpcAuthenticationModeSerializationTest() {
+            var newtonSoftJsonSerializer = new NewtonSoftJsonSerializer();
+
+            var model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            var modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"OpcAuthenticationMode\":\"anonymous\"", modeJson);
+
+            model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                OpcAuthenticationMode = OpcAuthenticationMode.Anonymous,
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"OpcAuthenticationMode\":\"anonymous\"", modeJson);
+
+            model = new PublishedNodesEntryModel {
+                EndpointUrl = new Uri("opc.tcp://localhost:50000"),
+                OpcAuthenticationMode = OpcAuthenticationMode.UsernamePassword,
+                OpcNodes = new List<OpcNodeModel> {
+                    new OpcNodeModel {
+                        Id = "i=2258"
+                    }
+                }
+            };
+
+            modeJson = newtonSoftJsonSerializer.SerializeToString(model);
+            Assert.Contains("\"OpcAuthenticationMode\":\"usernamePassword\"", modeJson);
+        }
+    }
+}

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
 
             return new PublishNodesEndpointApiModel {
                 EndpointUrl = endpoint.EndpointUrl.AbsoluteUri,
-                UseSecurity = endpoint.UseSecurity.GetValueOrDefault(false),
+                UseSecurity = endpoint.UseSecurity,
                 OpcAuthenticationMode = (AuthenticationMode)endpoint.OpcAuthenticationMode,
                 UserName = endpoint.OpcAuthenticationUsername,
                 DataSetWriterGroup = endpoint.DataSetWriterGroup,


### PR DESCRIPTION
Changes:
- Made `UseSecurity` non-nullable in `PublishedNodesEntryModel`. Changed `EmitDefaultValue` to `true` for `UseSecurity` and `OpcAuthenticationMode` fields in `PublishedNodesEntryModel`. Making sure they are always present in serialized form.
- Changed `EmitDefaultValue` to `true` for `UseSecurity` and `OpcAuthenticationMode` fields in `PublishNodesEndpointApiModel`. Making sure they are always present in serialized form.
- Added serialization and deserialization tests for those fields in `PublishedNodesEntryModel` and `PublishNodesEndpointApiModel`