### PR TITLE
backwards compatibility fixes

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredEndpointsResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredEndpointsResponseApiModel.cs
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
+    using System.Runtime.Serialization;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Result of GetConfiguredEndpoints method call
+    /// </summary>
+    [DataContract]
+    public class GetConfiguredEndpointsResponseApiModel {
+
+        /// <summary>
+        /// Service result in case of error
+        /// </summary>
+        [DataMember(Name = "endpoints", Order = 0,
+            EmitDefaultValue = false)]
+        public List<PublishNodesEndpointApiModel> Endpoints { get; set; }
+    }
+}

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredEndpointsResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredEndpointsResponseApiModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
     public class GetConfiguredEndpointsResponseApiModel {
 
         /// <summary>
-        /// Service result in case of error
+        /// Collection of Endpoints in the configuration
         /// </summary>
         [DataMember(Name = "endpoints", Order = 0,
             EmitDefaultValue = false)]

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredNodesOnEndpointResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredNodesOnEndpointResponseApiModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
     public class GetConfiguredNodesOnEndpointResponseApiModel {
 
         /// <summary>
-        /// Service result in case of error
+        /// Collection of Nodes configured for a particular endpoint
         /// </summary>
         [DataMember(Name = "opcNodes", Order = 0,
             EmitDefaultValue = false)]

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredNodesOnEndpointResponseApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/src/Models/GetConfiguredNodesOnEndpointResponseApiModel.cs
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
+    using System.Runtime.Serialization;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Result of GetConfiguredNodesOnEndpoint method call
+    /// </summary>
+    [DataContract]
+    public class GetConfiguredNodesOnEndpointResponseApiModel {
+
+        /// <summary>
+        /// Service result in case of error
+        /// </summary>
+        [DataMember(Name = "opcNodes", Order = 0,
+            EmitDefaultValue = false)]
+        public List<PublishedNodeApiModel> OpcNodes { get; set; }
+    }
+}

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
@@ -786,82 +786,100 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
             CancellationToken ct) {
             _logger.Information("{nameof} method triggered", nameof(UnpublishAllNodesAsync));
             var sw = Stopwatch.StartNew();
+            // when no endpoint is specified remove all the configuration
+            var purge = null == request.EndpointUrl;
             await _lockConfig.WaitAsync(ct).ConfigureAwait(false);
             try {
-
-                var found = false;
-                // Perform pass to determine existing groups
-                var matchingGroups = new List<PublishedNodesEntryModel>();
-                foreach (var entry in _publishedNodesEntries) {
-                    if (entry.HasSameGroup(request)) {
-                        // We may have several entries with the same DataSetGroup definition,
-                        // so we will remove nodes only if the whole DataSet definition matches.
-                        if (entry.HasSameDataSet(request)) {
-                            entry.OpcNodes.Clear();
-                            found = true;
-                        }
-                        matchingGroups.Add(entry);
-                    }
-                }
-
-                // Report error if there were entries that did not have any nodes
-                if (!found) {
-                    throw new MethodCallStatusException((int)HttpStatusCode.NotFound, $"Endpoint or node not found: {request.EndpointUrl}");
-                }
-
-                // Remove entries without nodes.
-                _publishedNodesEntries.RemoveAll(entry => (entry.OpcNodes == null || entry.OpcNodes.Count == 0));
-
-                PersistPublishedNodes();
-
-                found = false;
-                var jobs = _publishedNodesJobConverter.ToWriterGroupJobs(matchingGroups, _standaloneCliModel);
-
-                await _lockJobs.WaitAsync(ct).ConfigureAwait(false);
-                try {
-                    if (jobs.Any()) {
-                        foreach (var job in jobs) {
-                            var newJob = ToJobProcessingInstructionModel(job);
-                            if (string.IsNullOrEmpty(newJob?.Job?.Id)) {
-                                continue;
+                if (!purge) {
+                    var found = false;
+                    // Perform pass to determine existing groups
+                    var matchingGroups = new List<PublishedNodesEntryModel>();
+                    foreach (var entry in _publishedNodesEntries) {
+                        if (entry.HasSameGroup(request)) {
+                            // We may have several entries with the same DataSetGroup definition,
+                            // so we will remove nodes only if the whole DataSet definition matches.
+                            if (entry.HasSameDataSet(request)) {
+                                entry.OpcNodes.Clear();
+                                found = true;
                             }
+                            matchingGroups.Add(entry);
+                        }
+                    }
 
-                            foreach (var assignedJob in _assignedJobs) {
-                                if (newJob.Job.Id == assignedJob.Value.Job.Id) {
-                                    _assignedJobs[assignedJob.Key] = newJob;
+                    // Report error if there were entries that did not have any nodes
+                    if (!found) {
+                        throw new MethodCallStatusException((int)HttpStatusCode.NotFound, $"Endpoint or node not found: {request.EndpointUrl}");
+                    }
+
+                    // Remove entries without nodes.
+                    _publishedNodesEntries.RemoveAll(entry => (entry.OpcNodes == null || entry.OpcNodes.Count == 0));
+
+                    PersistPublishedNodes();
+
+                    found = false;
+                    var jobs = _publishedNodesJobConverter.ToWriterGroupJobs(matchingGroups, _standaloneCliModel);
+
+                    await _lockJobs.WaitAsync(ct).ConfigureAwait(false);
+                    try {
+                        if (jobs.Any()) {
+                            foreach (var job in jobs) {
+                                var newJob = ToJobProcessingInstructionModel(job);
+                                if (string.IsNullOrEmpty(newJob?.Job?.Id)) {
+                                    continue;
+                                }
+
+                                foreach (var assignedJob in _assignedJobs) {
+                                    if (newJob.Job.Id == assignedJob.Value.Job.Id) {
+                                        _assignedJobs[assignedJob.Key] = newJob;
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                if (!found && _availableJobs.ContainsKey(newJob.Job.Id)) {
+                                    _availableJobs[newJob.Job.Id] = newJob;
                                     found = true;
+                                }
+                            }
+                        }
+
+                        if (!found) {
+                            var entryJobId = _publishedNodesJobConverter.
+                                ToConnectionModel(request, _standaloneCliModel).CreateConnectionId();
+                            foreach (var assignedJob in _assignedJobs) {
+                                if (entryJobId == assignedJob.Value.Job.Id) {
+                                    found = _assignedJobs.Remove(assignedJob.Key, out _);
+                                    _publisherDiagnosticInfo.Remove(assignedJob.Value.Job.Id, out _);
                                     break;
                                 }
                             }
-                            if (!found && _availableJobs.ContainsKey(newJob.Job.Id)) {
-                                _availableJobs[newJob.Job.Id] = newJob;
-                                found = true;
+                            if (!found) {
+                                found = _availableJobs.Remove(entryJobId, out _);
                             }
                         }
+                    }
+                    finally {
+                        _lockJobs.Release();
                     }
 
                     if (!found) {
-                        var entryJobId = _publishedNodesJobConverter.
-                            ToConnectionModel(request, _standaloneCliModel).CreateConnectionId();
-                        foreach (var assignedJob in _assignedJobs) {
-                            if (entryJobId == assignedJob.Value.Job.Id) {
-                                found = _assignedJobs.Remove(assignedJob.Key, out _);
-                                _publisherDiagnosticInfo.Remove(assignedJob.Value.Job.Id, out _);
-                                break;
-                            }
-                        }
-                        if (!found) {
-                            found = _availableJobs.Remove(entryJobId, out _);
-                        }
+                        throw new MethodCallStatusException((int)HttpStatusCode.NotFound,
+                            $"Endpoint not found: {request.EndpointUrl}");
                     }
                 }
-                finally {
-                    _lockJobs.Release();
-                }
+                else {
 
-                if (!found) {
-                    throw new MethodCallStatusException((int)HttpStatusCode.NotFound,
-                        $"Endpoint not found: {request.EndpointUrl}");
+                    // Remove all entries
+                    _publishedNodesEntries.Clear();
+                    PersistPublishedNodes();
+                    await _lockJobs.WaitAsync(ct).ConfigureAwait(false);
+                    try {
+                        _assignedJobs.Clear();
+                        _availableJobs.Clear();
+                        _publisherDiagnosticInfo.Clear();
+                    }
+                    finally {
+                        _lockJobs.Release();
+                    }
                 }
 
                 // fire config update so that the worker supervisor pickes up the changes ASAP
@@ -1090,8 +1108,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// <inheritdoc/>
         public async Task<List<OpcNodeModel>> GetConfiguredNodesOnEndpointAsync(
             PublishedNodesEntryModel request,
-            CancellationToken ct = default
-        ) {
+            CancellationToken ct = default) {
+
             _logger.Information("{nameof} method triggered", nameof(GetConfiguredNodesOnEndpointAsync));
             var sw = Stopwatch.StartNew();
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
         }
 
         /// <summary>
-        /// transforms a published nodes model connection header to a Connection Model object
+        /// Transforms a published nodes model connection header to a Connection Model object
         /// </summary>
         public ConnectionModel ToConnectionModel(PublishedNodesEntryModel model,
             StandaloneCliModel standaloneCliModel) {
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                 Group = model.DataSetWriterGroup,
                 // Exclude the DataSetWriterId since it is not part of the connection model
                 Endpoint = new EndpointModel {
-                    Url = model.EndpointUrl.OriginalString,
+                    Url = model.EndpointUrl?.OriginalString,
                     SecurityMode = model.UseSecurity.GetValueOrDefault(false) ?
                                  SecurityMode.Best : SecurityMode.None,
                 },

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Controller/DmApiPublisherMethodControllerTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Controller/DmApiPublisherMethodControllerTests.cs
@@ -322,13 +322,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                     .NotThrowAsync()
                     .ConfigureAwait(false);
 
-            response.Subject.Count()
+            response.Subject.OpcNodes.Count()
                 .Should()
                 .Be(2);
-            response.Subject.First().Id
+            response.Subject.OpcNodes.First().Id
                 .Should()
                 .Be("ns=2;s=FastUInt1");
-            response.Subject[1].Id
+            response.Subject.OpcNodes[1].Id
                 .Should()
                 .Be("ns=2;s=FastUInt2");
         }
@@ -361,10 +361,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                     .NotThrowAsync()
                     .ConfigureAwait(false);
 
-            response.Subject.Count()
+            response.Subject.OpcNodes.Count()
                 .Should()
                 .Be(1);
-            response.Subject.First().Id
+            response.Subject.OpcNodes.First().Id
                 .Should()
                 .Be("ns=2;s=SlowUInt1");
         }
@@ -404,10 +404,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                         .NotThrowAsync()
                         .ConfigureAwait(false);
 
-                response.Subject.Count
+                response.Subject.OpcNodes.Count
                     .Should()
                     .Be(i + 1);
-                response.Subject.Last().Id
+                response.Subject.OpcNodes.Last().Id
                     .Should()
                     .Be($"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt{i}");
             }
@@ -433,10 +433,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                     .NotThrowAsync()
                     .ConfigureAwait(false);
 
-            response.Subject.Count()
+            response.Subject.OpcNodes.Count()
                 .Should()
                 .Be(1);
-            response.Subject.First().Id
+            response.Subject.OpcNodes.First().Id
                 .Should()
                 .Be("ns=2;s=SlowUInt3");
         }
@@ -467,10 +467,10 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                     .NotThrowAsync()
                     .ConfigureAwait(false);
 
-            response.Subject.Count()
+            response.Subject.OpcNodes.Count()
                 .Should()
                 .Be(1);
-            response.Subject.First().Id
+            response.Subject.OpcNodes.First().Id
                 .Should()
                 .Be("ns=2;s=SlowUInt2");
         }
@@ -499,13 +499,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                     .NotThrowAsync()
                     .ConfigureAwait(false);
 
-            response.Subject.Count()
+            response.Subject.OpcNodes.Count()
                 .Should()
                 .Be(2);
-            response.Subject.First().Id
+            response.Subject.OpcNodes.First().Id
                 .Should()
                 .Be("ns=2;s=FastUInt3");
-            response.Subject[1].Id
+            response.Subject.OpcNodes[1].Id
                 .Should()
                 .Be("ns=2;s=FastUInt4");
         }
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 .NotThrowAsync()
                 .ConfigureAwait(false);
 
-            endpoints.Subject.Count.Should().Be(0);
+            endpoints.Subject.Endpoints.Count.Should().Be(0);
 
             // Publish nodes
             foreach (var request in publishNodesRequests) {
@@ -624,8 +624,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 .NotThrowAsync()
                 .ConfigureAwait(false);
 
-            endpoints.Subject.Count.Should().Be(5);
-            var endpointsHash = endpoints.Subject.Select(e => e.GetHashCode()).ToList();
+            endpoints.Subject.Endpoints.Count.Should().Be(5);
+            var endpointsHash = endpoints.Subject.Endpoints.Select(e => e.GetHashCode()).ToList();
             Assert.True(endpointsHash.Distinct().Count() == endpointsHash.Count());
         }
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Extensions/ConnectionModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Core/Extensions/ConnectionModelEx.cs
@@ -79,11 +79,11 @@ namespace Microsoft.Azure.IIoT.OpcUa.Core.Models {
         }
 
         /// <summary>
-        /// Returns a string that uniquiely identifies the connection based on 
+        /// Returns a string that uniquiely identifies the connection based on
         /// endpoint url, hash and associated group
         /// </summary>
         public static string CreateConnectionId(this ConnectionModel model) {
-            if (model == null) {
+            if (string.IsNullOrEmpty(model?.Endpoint?.Url)) {
                 return null;
             }
             return !string.IsNullOrEmpty(model.Group) ?

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublishedNodesEntryModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublishedNodesEntryModelEx.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models {
                 return false;
             }
 
-            if (string.Compare(model.EndpointUrl.OriginalString, that.EndpointUrl.OriginalString, StringComparison.OrdinalIgnoreCase) != 0) {
+            if (model.EndpointUrl != that.EndpointUrl) {
                 return false;
             }
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -4,23 +4,21 @@
 // ------------------------------------------------------------
 
 namespace IIoTPlatform_E2E_Tests.Standalone {
-
     using IIoTPlatform_E2E_Tests.Deploy;
     using IIoTPlatform_E2E_Tests.TestModels;
+    using Microsoft.Azure.IIoT.Hub.Models;
+    using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
     using Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models;
-    using System;
+    using Microsoft.Azure.IIoT.Serializers;
+    using Newtonsoft.Json.Linq;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using TestExtensions;
     using Xunit;
     using Xunit.Abstractions;
-    using Microsoft.Azure.IIoT.Hub.Models;
-    using Microsoft.Azure.IIoT.Serializers;
-    using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
-    using System.Net;
-    using System.Linq;
-    using System.Collections.Generic;
-    using Newtonsoft.Json.Linq;
 
     /// <summary>
     /// The test theory using different (ordered) test cases to go thru all required steps of publishing OPC UA node
@@ -80,7 +78,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
-            //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
+            // Call GetConfiguredEndpoints direct method, initially there should be no endpoints
             var responseGetConfiguredEndpoints = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
@@ -89,16 +87,16 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
-            var configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
-            Assert.Equal(configuredEndpointsResponse.Count, 0);
+            var configuredEndpointsResponse = _serializer.Deserialize<GetConfiguredEndpointsResponseApiModel>(responseGetConfiguredEndpoints.JsonPayload);
+            Assert.Equal(configuredEndpointsResponse.Endpoints.Count, 0);
 
             var nodesToPublish = await TestHelper.CreateMultipleNodesModelAsync(_context, cts.Token).ConfigureAwait(false);
             var request = nodesToPublish.ToApiModel();
             MethodResultModel response = null;
 
-            //Publish nodes for the endpoint
+            // Publish nodes for the endpoint
             if (useAddOrUpdate) {
-                //Call AddOrUpdateEndpoints direct method
+                // Call AddOrUpdateEndpoints direct method
                 response = await CallMethodAsync(
                     new MethodParameterModel {
                         Name = TestConstants.DirectMethodNames.AddOrUpdateEndpoints,
@@ -108,7 +106,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 ).ConfigureAwait(false);
             }
             else {
-                //Call PublishNodes direct method
+                // Call PublishNodes direct method
                 response = await CallMethodAsync(
                     new MethodParameterModel {
                         Name = TestConstants.DirectMethodNames.PublishNodes,
@@ -127,7 +125,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             // Wait some time to generate events to process.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
-            //Call GetConfiguredEndpoints direct method
+            // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
@@ -136,16 +134,16 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
-            configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(responseGetConfiguredEndpoints.JsonPayload);
-            Assert.Equal(1, configuredEndpointsResponse.Count);
-            TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse[0], request);
+            configuredEndpointsResponse = _serializer.Deserialize<GetConfiguredEndpointsResponseApiModel>(responseGetConfiguredEndpoints.JsonPayload);
+            Assert.Equal(1, configuredEndpointsResponse.Endpoints.Count);
+            TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse.Endpoints[0], request);
 
-            //Create request for GetConfiguredNodesOnEndpoint method call
+            // Create request for GetConfiguredNodesOnEndpoint method call
             var nodesOnEndpoint = new PublishedNodesEntryModel();
             nodesOnEndpoint.EndpointUrl = request.EndpointUrl;
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
-            //Call GetConfiguredNodesOnEndpoint direct method
+            // Call GetConfiguredNodesOnEndpoint direct method
             var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodNames.GetConfiguredNodesOnEndpoint,
@@ -155,10 +153,10 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             ).ConfigureAwait(false);
 
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredNodesOnEndpoint.Status);
-            var jsonResponse = _serializer.Deserialize<List<PublishedNodeApiModel>>(responseGetConfiguredNodesOnEndpoint.JsonPayload);
-            Assert.Equal(jsonResponse.Count, 250);
+            var jsonResponse = _serializer.Deserialize<GetConfiguredNodesOnEndpointResponseApiModel>(responseGetConfiguredNodesOnEndpoint.JsonPayload);
+            Assert.Equal(jsonResponse.OpcNodes.Count, 250);
 
-            //Call GetDiagnosticInfo direct method
+            // Call GetDiagnosticInfo direct method
             var responseGetDiagnosticInfo = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodNames.GetDiagnosticInfo,
@@ -196,9 +194,9 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 Assert.Empty(expectedNodes);
             }
 
-            //Unpublish all nodes for the endpoint
+            // Unpublish all nodes for the endpoint
             if (useAddOrUpdate) {
-                //Call AddOrUpdateEndpoints direct method
+                // Call AddOrUpdateEndpoints direct method
                 request.OpcNodes = null;
                 response = await CallMethodAsync(
                     new MethodParameterModel {
@@ -209,7 +207,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 ).ConfigureAwait(false);
             }
             else {
-                //Call UnPublishNodes direct method
+                // Call UnPublishNodes direct method
                 response = await CallMethodAsync(
                     new MethodParameterModel {
                         Name = TestConstants.DirectMethodNames.UnpublishNodes,
@@ -224,7 +222,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             // Wait till the publishing has stopped.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
-            //Call GetDiagnosticInfo direct method
+            // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodNames.GetDiagnosticInfo,
@@ -286,7 +284,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             ).GetAwaiter().GetResult());
             Assert.Null(exception);
 
-            //Call GetConfiguredEndpoints direct method, initially there should be no endpoints
+            // Call GetConfiguredEndpoints direct method, initially there should be no endpoints
             var responseGetConfiguredEndpoints = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
@@ -297,12 +295,12 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             var epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
             var endpoints = _serializer.SerializeToString(epObj["Endpoints"]);
-            var configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(endpoints);
-            Assert.Equal(configuredEndpointsResponse.Count, 0);
+            var configuredEndpointsResponse = _serializer.Deserialize<GetConfiguredEndpointsResponseApiModel>(endpoints);
+            Assert.Equal(configuredEndpointsResponse.Endpoints.Count, 0);
 
             var request = nodesToPublish.ToApiModel();
 
-            //Call Publish direct method
+            // Call Publish direct method
             var response = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.PublishNodes,
@@ -320,7 +318,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             // Wait some time to generate events to process.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
-            //Call GetConfiguredEndpoints direct method
+            // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.GetConfiguredEndpoints
@@ -331,16 +329,16 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal((int)HttpStatusCode.OK, responseGetConfiguredEndpoints.Status);
             epObj = JObject.Parse(responseGetConfiguredEndpoints.JsonPayload);
             endpoints = _serializer.SerializeToString(epObj["Endpoints"]);
-            configuredEndpointsResponse = _serializer.Deserialize<List<PublishNodesEndpointApiModel>>(endpoints);
-            Assert.Equal(1, configuredEndpointsResponse.Count);
-            TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse[0], request);
+            configuredEndpointsResponse = _serializer.Deserialize<GetConfiguredEndpointsResponseApiModel>(endpoints);
+            Assert.Equal(1, configuredEndpointsResponse.Endpoints.Count);
+            TestHelper.Publisher.AssertEndpointModel(configuredEndpointsResponse.Endpoints[0], request);
 
-            //Create request for GetConfiguredNodesOnEndpoint method call
+            // Create request for GetConfiguredNodesOnEndpoint method call
             var nodesOnEndpoint = new PublishedNodesEntryModel();
             nodesOnEndpoint.EndpointUrl = request.EndpointUrl;
             var requestGetConfiguredNodesOnEndpoint = nodesOnEndpoint.ToApiModel();
 
-            //Call GetConfiguredNodesOnEndpoint direct method
+            // Call GetConfiguredNodesOnEndpoint direct method
             var responseGetConfiguredNodesOnEndpoint = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.GetConfiguredNodesOnEndpoint,
@@ -356,7 +354,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var jsonResponse = _serializer.Deserialize<List<PublishedNodeApiModel>>(opcNodes);
             Assert.Equal(jsonResponse.Count, 250);
 
-            //Call GetDiagnosticInfo direct method
+            // Call GetDiagnosticInfo direct method
             var responseGetDiagnosticInfo = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.GetDiagnosticInfo,
@@ -399,7 +397,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
                 Assert.Empty(expectedNodes);
             }
 
-            //Call Unpublish direct method
+            // Call Unpublish direct method
             response = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.UnpublishNodes,
@@ -413,7 +411,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             // Wait till the publishing has stopped.
             await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
 
-            //Call GetDiagnosticInfo direct method
+            // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
                 new MethodParameterModel {
                     Name = TestConstants.DirectMethodLegacyNames.GetDiagnosticInfo,

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Controller/PublisherMethodsController.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Controller/PublisherMethodsController.cs
@@ -74,17 +74,21 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Controller {
         /// <summary>
         /// Handler for GetConfiguredEndpoints direct method
         /// </summary>
-        public async Task<List<PublishNodesEndpointApiModel>> GetConfiguredEndpointsAsync() {
+        public async Task<GetConfiguredEndpointsResponseApiModel> GetConfiguredEndpointsAsync() {
             var response = await _configServices.GetConfiguredEndpointsAsync().ConfigureAwait(false);
-            return response.ToApiModel();
+            return new GetConfiguredEndpointsResponseApiModel() {
+                Endpoints = response.ToApiModel(),
+            };
         }
 
         /// <summary>
         /// Handler for GetConfiguredNodesOnEndpoint direct method
         /// </summary>
-        public async Task<List<PublishedNodeApiModel>> GetConfiguredNodesOnEndpointAsync(PublishNodesEndpointApiModel request) {
+        public async Task<GetConfiguredNodesOnEndpointResponseApiModel> GetConfiguredNodesOnEndpointAsync(PublishNodesEndpointApiModel request) {
             var response = await _configServices.GetConfiguredNodesOnEndpointAsync(request.ToServiceModel()).ConfigureAwait(false);
-            return response.ToApiModel();
+            return new GetConfiguredNodesOnEndpointResponseApiModel() {
+                OpcNodes = response.ToApiModel(),
+            };
         }
 
         /// <summary>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Models/PublisherExtensions.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
             }
 
             return new PublishedNodesEntryModel {
-                EndpointUrl = new Uri(model.EndpointUrl),
+                EndpointUrl = !string.IsNullOrEmpty(model.EndpointUrl)
+                    ? new Uri(model.EndpointUrl)
+                    : null,
                 UseSecurity = model.UseSecurity,
                 OpcAuthenticationMode = (OpcAuthenticationMode)model.OpcAuthenticationMode,
                 OpcAuthenticationPassword = model.Password,
@@ -106,7 +108,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
             }
 
             return new PublishNodesEndpointApiModel {
-                EndpointUrl = endpoint.EndpointUrl.AbsoluteUri,
+                EndpointUrl = endpoint.EndpointUrl.OriginalString,
                 UseSecurity = endpoint.UseSecurity.GetValueOrDefault(false),
                 OpcAuthenticationMode = (AuthenticationMode)endpoint.OpcAuthenticationMode,
                 UserName = endpoint.OpcAuthenticationUsername,
@@ -173,7 +175,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
             }
 
             return new PublishNodesEndpointApiModel {
-                EndpointUrl = endpoint.EndpointUrl.AbsoluteUri,
+                EndpointUrl = endpoint.EndpointUrl.OriginalString,
                 UseSecurity = endpoint.UseSecurity.GetValueOrDefault(false),
                 OpcAuthenticationMode = (AuthenticationMode)endpoint.OpcAuthenticationMode,
                 UserName = endpoint.OpcAuthenticationUsername,


### PR DESCRIPTION
**Changes:**
* GetConfiguredEndpoints result payload contains "endpoints" object 
* GetConfiguredNodesOnEndpoints - result payload contains now "opcNodes" object
* UnpublishAllNodes - not providing an endpoint results into removing completely the configuration
* E2E tests adapted accordingly

*Note*: Documentation will be updated in a separate PR