### PR TITLE
Docs update with the backwards compatibility fixes

### DIFF
--- a/docs/modules/publisher-directmethods.md
+++ b/docs/modules/publisher-directmethods.md
@@ -65,18 +65,19 @@ The `_V1` direct methods  uses the  payload schema as described below:
 
 Method call's request attributes are as follows:
 
-| Attribute                   | Mandatory | Type    | Default                   | Description                                                  |
-| --------------------------- | --------- | ------- | ------------------------- | ------------------------------------------------------------ |
-| `EndpointUrl`               | yes       | String  | N/A                       | The OPC UA Server’s endpoint URL                             |
-| `UseSecurity`               | no        | Boolean | false                     | Desired opc session security mode                            |
-| `OpcAuthenticationMode`     | no        | Enum    | Anonymous                 | Enum to specify the session authentication.<br>Options: Anonymous, UserName |
-| `UserName`                  | no        | String  | null                      | The username for the session authentication<br>Mandatory if OpcAuthentication mode is UserName |
-| `Password`                  | no        | String  | null                      | The password for the session authentication<br>Mandatory if OpcAuthentication mode is UserName |
-| `DataSetWriterGroup`        | no        | String  | EndpointUrl               | The writer group collecting datasets defined for a certain <br>endpoint uniquely identified by the above attributes. <br>This is used to identify the session opened into the <br>server. The default value consists of the EndpointUrl string, <br>followed by a deterministic hash composed of the <br>EndpointUrl, security and authentication attributes. |
-| `DataSetWriterId`           | no        | String  | DataSetPublishingInterval | The unique identifier for a data set writer used to collect <br>opc nodes to be semantically grouped and published with <br>a same publishing interval. <br>When not specified a string representing the common <br>publishing interval of the nodes in the data set collection. <br>This the DataSetWriterId  uniquely identifies a data set <br>within a DataSetGroup. The unicity is determined <br>using the provided DataSetWriterId and the publishing <br>interval of the grouped OpcNodes.  An individual <br>subscription is created for each DataSetWriterId |
-| `DataSetPublishingInterval` | no        | Integer | false                     | The publishing interval used for a grouped set of nodes <br>under a certain DataSetWriter. When defined it <br>overrides the OpcPublishingInterval value in the OpcNodes <br>if grouped underneath a DataSetWriter. |
-| `Tag`                       | no        | String  | empty                     | TODO                                                         |
-| `OpcNodes`                  | yes       | OpcNode | empty                     | The DataSet collection grouping the nodes to be published for <br>the specific DataSetWriter defined above. |
+| Attribute                           | Mandatory | Type    | Default                   | Description                                                  |
+| ----------------------------------- | --------- | ------- | ------------------------- | ------------------------------------------------------------ |
+| `EndpointUrl`                       | yes       | String  | N/A                       | The OPC UA Server’s endpoint URL                             |
+| `UseSecurity`                       | no        | Boolean | false                     | Desired opc session security mode                            |
+| `OpcAuthenticationMode`             | no        | Enum    | Anonymous                 | Enum to specify the session authentication.<br>Options: Anonymous, UserName |
+| `UserName`                          | no        | String  | null                      | The username for the session authentication<br>Mandatory if OpcAuthentication mode is UserName |
+| `Password`                          | no        | String  | null                      | The password for the session authentication<br>Mandatory if OpcAuthentication mode is UserName |
+| `DataSetWriterGroup`                | no        | String  | EndpointUrl               | The writer group collecting datasets defined for a certain <br>endpoint uniquely identified by the above attributes. <br>This is used to identify the session opened into the <br>server. The default value consists of the EndpointUrl string, <br>followed by a deterministic hash composed of the <br>EndpointUrl, security and authentication attributes. |
+| `DataSetWriterId`                   | no        | String  | DataSetPublishingInterval | The unique identifier for a data set writer used to collect <br>opc nodes to be semantically grouped and published with <br>a same publishing interval. <br>When not specified a string representing the common <br>publishing interval of the nodes in the data set collection. <br>This the DataSetWriterId  uniquely identifies a data set <br>within a DataSetGroup. The unicity is determined <br>using the provided DataSetWriterId and the publishing <br>interval of the grouped OpcNodes.  An individual <br>subscription is created for each DataSetWriterId |
+| `DataSetPublishingInterval`         | no        | Integer | null                      | The publishing interval used for a grouped set of nodes <br>under a certain DataSetWriter. When defined it <br>overrides the OpcPublishingInterval value in the OpcNodes <br>if grouped underneath a DataSetWriter. <br>_Note:_ the DataSetPublishingInterval is overwritten if an<br> OpcPublishingInterval is set at the node level |
+| `DataSetPublishingIntervalTimespan` | no        | Integer | null                      | The publishing interval used for a grouped set of nodes <br> expressed as a Timespan string ({d.hh:mm:dd.fff}).<br>When both Intervals are specified, the <br> Timespan will win and be used for the configuration. <br>_Note:_ the DataSetPublishingInterval is overwritten if an<br> OpcPublishingInterval is set at the node level |
+| `Tag`                               | no        | String  | empty                     | TODO                                                         |
+| `OpcNodes`                          | yes       | OpcNode | empty                     | The DataSet collection grouping the nodes to be published for <br>the specific DataSetWriter defined above. |
 
 _Note_: __OpcNodes__ field is mandatory for PublishNodes_V1, UnpublishNodes_V1 and AddOrUpdateEndpoints_V1. It should not be specified for the rest of the direct methods.
 
@@ -101,8 +102,6 @@ _Note_: __Id__ field may be omitted when ExpandedNodeIdId is present.
 
 Now let's dive into each direct method request and response payloads with examples.
 
-**TODO**: Update the responses in 2.8.2 after backwards compatibility fixes.
-
 ## PublishNodes_V1
 
 PublishNodes enables a client to add a set of nodes to be published for a specific [`DataSetWriter`](publisher-directmethods.md#terminologies). When a `DataSetWriter` already exists, the nodes are incrementally added to the very same [`dataset`](publisher-directmethods.md#terminologies). When it does not already exist, a new `DataSetWriter` is created with the initial set of nodes contained in the request.
@@ -121,13 +120,13 @@ PublishNodes enables a client to add a set of nodes to be published for a specif
   >
   > ```json
   > {
-  >    "EndpointUrl":"opc.tcp://opcplc:50000/",
-  >    "DataSetWriterGroup":"Asset0",
-  >    "DataSetWriterId":"DataFlow0",
-  >    "DataSetPublishingInterval":5000,
-  >    "OpcNodes":[
+  >    "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >    "DataSetWriterGroup": "Asset0",
+  >    "DataSetWriterId": "DataFlow0",
+  >    "DataSetPublishingInterval": 5000,
+  >    "OpcNodes": [
   >       {
-  >          "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt0"
+  >          "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt0"
   >       }
   >    ]
   > }
@@ -137,10 +136,9 @@ PublishNodes enables a client to add a set of nodes to be published for a specif
   >
   > ```json
   > {
-  >    "status":200,
-  >      "payload":{
-  >      }    
-  >    }
+  >    "status": 200,
+  >    "payload": {}
+  > }
   > ```
 
 ## UnpublishNodes_V1
@@ -167,33 +165,34 @@ _Note_: If all the nodes from a DataSet are to be unpublished, the DataSetWriter
   >
   > ```json
   > {
-  >      "EndpointUrl":"opc.tcp://opcplc:50000/",
-  >      "DataSetWriterGroup":"Asset0",
-  >      "DataSetWriterId":"DataFlow0",
-  >      "DataSetPublishingInterval":5000,
-  >      "OpcNodes":[
-  >         {
-  >             "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt0"
-  >          }
-  >       ]
-  >   }
+  >    "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >    "DataSetWriterGroup": "Asset0",
+  >    "DataSetWriterId": "DataFlow0",
+  >    "DataSetPublishingInterval": 5000,
+  >    "OpcNodes": [
+  >       {
+  >          "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt0"
+  >       }
+  >    ]
+  > }
   > ```
   >
   >_Response_:
   >
   >```json
   > {
-  >    "status":200,
-  >      "payload":{
-  >      }    
-  >    }
+  >    "status": 200,
+  >    "payload": {}
+  > }
   > ```
 
 ## UnpublishAllNodes_V1
 
-UnpublishAllNodes method enables a client to remove all the nodes from a previously configured DataSetWriter. The DataSetWriter entity will be completely removed from the configuration storage.
+UnpublishAllNodes method enables a client to remove all the nodes from a previously configured DataSetWriter.
+The DataSetWriter entity will be completely removed from the configuration storage.
+When an empty payload is set or the endpoint in payload is null, the complete configuration of the publisher will be purged.
 
-  _Request_: follows strictly the request payload schema, the OpcNodes attribute should be excluded.
+  _Request_: follows strictly the request payload schema, the OpcNodes attribute should be excluded.  
 
   _Response_: when successful - Status 200 and an empty json (`{}`) as Payload
 
@@ -211,10 +210,10 @@ UnpublishAllNodes method enables a client to remove all the nodes from a previou
   >
   > ```json
   > {
-  >   "EndpointUrl":"opc.tcp://opcplc:50000",
-  >   "DataSetWriterGroup":"Server0",
-  >   "DataSetWriterId":"Device0",
-  >   "DataSetPublishingInterval":5000
+  >    "EndpointUrl": "opc.tcp://opcplc:50000",
+  >    "DataSetWriterGroup": "Asset1",
+  >    "DataSetWriterId": "DataFlow1",
+  >    "DataSetPublishingInterval": 5000
   > }
   > ```
   >
@@ -222,9 +221,8 @@ UnpublishAllNodes method enables a client to remove all the nodes from a previou
   >
   > ```json
   > {
-  >    "status":200,
-  >    "payload":{
-  >    }
+  >    "status": 200,
+  >    "payload": {}
   > }
   > ```
 
@@ -232,7 +230,7 @@ UnpublishAllNodes method enables a client to remove all the nodes from a previou
 
 Returns the configured endpoints (Datasets)
 
-  _Request_: {}
+  _Request_: empty json (`{}`)
 
   _Response_: list of Endpoints configured (and optional parameters).
 
@@ -246,19 +244,21 @@ Returns the configured endpoints (Datasets)
   >
   > ```json
   > {
-  >      "status":200,
-  >      "payload":[
-  >         {
-  >             "EndpointUrl":"opc.tcp://opcplc:50000/",
-  >             "DataSetWriterGroup":"Server0",
-  >             "DataSetWriterId":"Device0",
-  >             "DataSetPublishingInterval":5000
-  >          },
+  >    "status": 200,
+  >    "payload": [
+  >       "endpoints": [
   >          {
-  >             "EndpointUrl":"opc.tcp://opcplc:50001/"
-  >          }
-  >       ]
-  >   }
+  >             "endpointUrl": "opc.tcp://opcplc:50000",
+  >             "dataSetWriterGroup": "Asset1",
+  >             "dataSetWriterId": "DataFlow1",
+  >             "dataSetPublishingInterval": 5000
+  >           },
+  >           {
+  >              "endpointUrl": "opc.tcp://opcplc:50001"
+  >           }
+  >       ]  
+  >    ]
+  > }
   > ```
 
 ## GetConfiguredNodesOnEndpoint_V1
@@ -279,7 +279,7 @@ Returns the nodes configured for one Endpoint (Dataset)
   >
   > ```json
   > {
-  >      "EndpointUrl":"opc.tcp://192.168.100.20:50000"
+  >    "EndpointUrl": "opc.tcp://192.168.100.20:50000"
   > }
   > ```
   >
@@ -287,28 +287,30 @@ Returns the nodes configured for one Endpoint (Dataset)
   >
   > ```json
   > {
-  >      "status":200,
-  >      "payload":[
-  >         {
-  >             "id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1",
-  >             "opcSamplingInterval":3000,
-  >             "opcSamplingIntervalTimespan":"00:00:03",
-  >             "heartbeatInterval":0,
-  >             "heartbeatIntervalTimespan":"00:00:00"
-  >          }
+  >    "status": 200,
+  >    "payload": [
+  >       "opcNodes": [
+  >          {
+  >             "id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1",
+  >             "opcSamplingIntervalTimespan": "00:00:10",
+  >             "heartbeatIntervalTimespan": "00:00:50"
+  >           }
   >       ]
-  >   }
+  >    ]
+  > }
   > ```
 
 ## GetDiagnosticInfo_V1
 
 Returns a list of actual metrics for every endpoint (Dataset) .
 
-  _Request_: none
+  _Request_: empty json (`{}`)
 
   _Response_: list of actual metrics for every endpoint (Dataset).
 
   _Exceptions_: an exception is thrown when method call returns status other than 200
+
+  _Note_: passwords are not being part of the response .
 
   _Example_:
 
@@ -321,39 +323,39 @@ Returns a list of actual metrics for every endpoint (Dataset) .
   >    "status":200,
   >    "payload":[
   >       {
-  >             "EndpointInfo":{
-  >                "EndpointUrl":"opc.tcp://opcplc:50000/",
-  >                "DataSetWriterGroup":"Server0",
-  >                "UseSecurity":"false",
-  >                "OpcAuthenticationMode":"UsernamePassword",
-  >                "OpcAuthenticationUsername":"Usr"
-  >             },
-  >             "SentMessagesPerSec":"2.6",
-  >             "IngestionDuration":"{00:00:25.5491702}",
-  >             "IngressDataChanges":"25",
-  >             "IngressValueChanges":"103",
-  >             "IngressBatchBlockBufferSize":"0",
-  >             "EncodingBlockInputSize":"0",
-  >             "EncodingBlockOutputSize":"0",
-  >             "EncoderNotificationsProcessed":"83",
-  >             "EncoderNotificationsDropped":"0",
-  >             "EncoderIoTMessagesProcessed":"2",
-  >             "EncoderAvgNotificationsMessage":"41.5",
-  >             "EncoderAvgIoTMessageBodySize":"6128",
-  >             "EncoderAvgIoTChunkUsage":"1.158034",
-  >             "EstimatedIoTChunksPerDay":"13526.858105160689",
-  >             "OutgressBatchBlockBufferSize":"0",
-  >             "OutgressInputBufferCount":"0",
-  >             "OutgressInputBufferDropped":"0",
-  >             "OutgressIoTMessageCount":"0",
-  >             "ConnectionRetries":"0",
-  >             "OpcEndpointConnected":"true",
-  >             "MonitoredOpcNodesSucceededCount":"5",
-  >             "MonitoredOpcNodesFailedCount":"0"
-  >          }
-  >       ]
-  >    }
-  >   ```
+  >          "endpointInfo": {
+  >             "endpointUrl": "opc.tcp://opcplc:50000/",
+  >             "dataSetWriterGroup": "Asset1",
+  >             "useSecurity": false,
+  >             "opcAuthenticationMode": "UsernamePassword",
+  >             "opcAuthenticationUsername": "Usr"
+  >          },
+  >          "sentMessagesPerSec": 2.6,
+  >          "ingestionDuration": "{00:00:25.5491702}",
+  >          "ingressDataChanges": 25,
+  >          "ingressValueChanges": 103,
+  >          "ingressBatchBlockBufferSize": 0,
+  >          "encodingBlockInputSize": 0,
+  >          "encodingBlockOutputSize": 0,
+  >          "encoderNotificationsProcessed": 83,
+  >          "encoderNotificationsDropped": 0,
+  >          "encoderIoTMessagesProcessed": 2,
+  >          "encoderAvgNotificationsMessage": 41.5,
+  >          "encoderAvgIoTMessageBodySize": 6128,
+  >          "encoderAvgIoTChunkUsage": 1.158034,
+  >          "estimatedIoTChunksPerDay": 13526.858105160689,
+  >          "outgressBatchBlockBufferSize": 0,
+  >          "outgressInputBufferCount": 0,
+  >          "outgressInputBufferDropped": 0,
+  >          "outgressIoTMessageCount": 0,
+  >          "connectionRetries": 0,
+  >          "opcEndpointConnected": true,
+  >          "monitoredOpcNodesSucceededCount": 5,
+  >          "monitoredOpcNodesFailedCount": 0
+  >       }
+  >    ]
+  > }
+  > ```
 
 ## AddOrUpdateEndpoints_V1
 
@@ -382,45 +384,31 @@ previously configured nodes for a specific endpoint (DataSet).
   >
   > ```json
   > [
-  >       {
-  >          "EndpointInfo":{
-  >             "EndpointUrl":"opc.tcp://opcplc:50000/",
-  >             "DataSetWriterGroup":"Server0",
-  >             "UseSecurity":"false",
-  >             "OpcAuthenticationMode":"UsernamePassword",
-  >             "OpcAuthenticationUsername":"Usr"
-  >          },
-  >          "SentMessagesPerSec":"2.6",
-  >          "IngestionDuration":"{00:00:25.5491702}",
-  >          "IngressDataChanges":"25",
-  >          "IngressValueChanges":"103",
-  >          "IngressBatchBlockBufferSize":"0",
-  >          "EncodingBlockInputSize":"0",
-  >          "EncodingBlockOutputSize":"0",
-  >          "EncoderNotificationsProcessed":"83",
-  >          "EncoderNotificationsDropped":"0",
-  >          "EncoderIoTMessagesProcessed":"2",
-  >          "EncoderAvgNotificationsMessage":"41.5",
-  >          "EncoderAvgIoTMessageBodySize":"6128",
-  >          "EncoderAvgIoTChunkUsage":"1.158034",
-  >          "EstimatedIoTChunksPerDay":"13526.858105160689",
-  >          "OutgressBatchBlockBufferSize":"0",
-  >          "OutgressInputBufferCount":"0",
-  >          "OutgressInputBufferDropped":"0",
-  >          "OutgressIoTMessageCount":"0",
-  >          "ConnectionRetries":"0",
-  >          "OpcEndpointConnected":"true",
-  >          "MonitoredOpcNodesSucceededCount":"5",
-  >          "MonitoredOpcNodesFailedCount":"0"
-  >       }
-  >    ]
-  >    ```
+  >    {
+  >       "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >       "DataSetWriterGroup": "Asset1",
+  >       "DataSetWriterId": "DataFlow1",
+  >       "DataSetPublishingInterval": 5000,
+  >       "OpcNodes": [
+  >          {
+  >             "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt0",
+  >          }
+  >       ]
+  >    },
+  >    {
+  >       "EndpointUrl": "opc.tcp://opcplc:50001/",
+  >       "DataSetWriterGroup": "Asset2",
+  >       "DataSetWriterId": "DataFlow2",
+  >       "OpcNodes": []
+  >    }
+  > ]
+  > ```
   >
   > _Response_:
   >
   > ```json
-  >{
-  > "status": 200,
-  > "payload": {}
+  > {
+  >    "status": 200,
+  >    "payload": {}
   > }
   > ```

--- a/docs/modules/publisher-directmethods.md
+++ b/docs/modules/publisher-directmethods.md
@@ -120,7 +120,7 @@ PublishNodes enables a client to add a set of nodes to be published for a specif
   >
   > ```json
   > {
-  >    "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >    "EndpointUrl": "opc.tcp://opcplc:50000",
   >    "DataSetWriterGroup": "Asset0",
   >    "DataSetWriterId": "DataFlow0",
   >    "DataSetPublishingInterval": 5000,
@@ -165,7 +165,7 @@ _Note_: If all the nodes from a DataSet are to be unpublished, the DataSetWriter
   >
   > ```json
   > {
-  >    "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >    "EndpointUrl": "opc.tcp://opcplc:50000",
   >    "DataSetWriterGroup": "Asset0",
   >    "DataSetWriterId": "DataFlow0",
   >    "DataSetPublishingInterval": 5000,
@@ -323,8 +323,8 @@ Returns a list of actual metrics for every endpoint (Dataset) .
   >    "status":200,
   >    "payload":[
   >       {
-  >          "endpointInfo": {
-  >             "endpointUrl": "opc.tcp://opcplc:50000/",
+  >          "endpoint": {
+  >             "endpointUrl": "opc.tcp://opcplc:50000",
   >             "dataSetWriterGroup": "Asset1",
   >             "useSecurity": false,
   >             "opcAuthenticationMode": "UsernamePassword",
@@ -385,7 +385,7 @@ previously configured nodes for a specific endpoint (DataSet).
   > ```json
   > [
   >    {
-  >       "EndpointUrl": "opc.tcp://opcplc:50000/",
+  >       "EndpointUrl": "opc.tcp://opcplc:50000",
   >       "DataSetWriterGroup": "Asset1",
   >       "DataSetWriterId": "DataFlow1",
   >       "DataSetPublishingInterval": 5000,
@@ -396,7 +396,7 @@ previously configured nodes for a specific endpoint (DataSet).
   >       ]
   >    },
   >    {
-  >       "EndpointUrl": "opc.tcp://opcplc:50001/",
+  >       "EndpointUrl": "opc.tcp://opcplc:50001",
   >       "DataSetWriterGroup": "Asset2",
   >       "DataSetWriterId": "DataFlow2",
   >       "OpcNodes": []

--- a/docs/modules/publisher-directmethods.md
+++ b/docs/modules/publisher-directmethods.md
@@ -246,7 +246,7 @@ Returns the configured endpoints (Datasets)
   > ```json
   > {
   >    "status": 200,
-  >    "payload": [
+  >    "payload": {
   >       "endpoints": [
   >          {
   >             "endpointUrl": "opc.tcp://opcplc:50000",
@@ -258,7 +258,7 @@ Returns the configured endpoints (Datasets)
   >              "endpointUrl": "opc.tcp://opcplc:50001"
   >           }
   >       ]  
-  >    ]
+  >    }
   > }
   > ```
 
@@ -289,7 +289,7 @@ Returns the nodes configured for one Endpoint (Dataset)
   > ```json
   > {
   >    "status": 200,
-  >    "payload": [
+  >    "payload": {
   >       "opcNodes": [
   >          {
   >             "id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt1",
@@ -297,7 +297,7 @@ Returns the nodes configured for one Endpoint (Dataset)
   >             "heartbeatIntervalTimespan": "00:00:50"
   >           }
   >       ]
-  >    ]
+  >    }
   > }
   > ```
 

--- a/docs/modules/publisher-dmmigration.md
+++ b/docs/modules/publisher-dmmigration.md
@@ -52,7 +52,7 @@ The following set of direct method api is inherited from 2.5.x API set.
 - GetConfiguredNodesOnEndpoint_V1
 - GetDiagnosticInfo_V1
 
-Please note that in 2.8.2 the recommended way of using the direct methods is with `_V1` suffix however.
+Please note that in 2.8.2 the recommended way of using the direct methods is with `_V1` suffix.
 Direct method name without `_V1` suffix is also supported but is subject of deprecation.
 
 The direct methods definitions of version 2.8.2 are provided in [this](publisher-directmethods.md) document in detail.

--- a/docs/modules/publisher-dmmigration.md
+++ b/docs/modules/publisher-dmmigration.md
@@ -165,7 +165,7 @@ When there are configured endpoints:
             "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000"
          }
       ]
-   ]
+   }
 }
 ```
 
@@ -343,8 +343,8 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 
 ```json
 {
-   "status":200,
-   "payload":[
+   "status": 200,
+   "payload": [
       "Id 'nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf': tagged for removal"
    ]
 }
@@ -354,9 +354,8 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 
 ```json
 {
-   "status":200,
-   "payload":{
-   }
+   "status": 200,
+   "payload": {}
 }
 ```
 
@@ -366,7 +365,7 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 
 ```json
 {
-   "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000"
+   "EndpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000"
 }
 ```
 
@@ -374,8 +373,8 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 
 ```json
 {
-   "status":200,
-   "payload":[
+   "status": 200,
+   "payload": [
       "All monitored items in all subscriptions on endpoint 'opc.tcp://sandboxhost-637811493394507132:50000' tagged for removal"
    ]
 }
@@ -385,9 +384,8 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 
 ```json
 {
-   "status":200,
-   "payload":{
-   }
+   "status": 200,
+   "payload": {}
 }
 ```
 

--- a/docs/modules/publisher-dmmigration.md
+++ b/docs/modules/publisher-dmmigration.md
@@ -1,6 +1,16 @@
 [Home](../../readme.md)
 
-# Migration path for IoT Hub Direct Methods
+# Migration path for publisher version 2.5.x to 2.8.2 - configuration file structure (pn.json)
+**TODO**
+2.8.2 must work in standalone mode for backwards compatibility with 2.5.x functionality
+
+# Migration path for publisher version 2.5.x to 2.8.2 - CLI arguments
+**TODO**
+
+# Migration path for publisher version 2.5.x to 2.8.2 - OPC UA Certificates management
+**TODO**
+
+# Migration path for publisher version 2.5.x to 2.8.2 - Direct Methods API
 
 The latest version 2.8.2 adds support for configuration via IoT Hub direct methods. OPC Publisher implements multiple [IoT Hub Direct Methods](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-direct-methods) which can be called from an application leveraging the [IoT Hub Device SDK](https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-sdks). This document provides the migration path from 2.5.x to 2.8.2.
 
@@ -12,19 +22,19 @@ For this set of methods, the encoding is JSON and no compression or payload chun
 
 The following  table describes the direct methods which were available in OPC Publisher 2.5.x with request and response.
 
-| 2.5.x                            |                                                              |                                                              |              |
-| -------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------ |
-| **MethodName**                   | **Request**                                                  | **Response**                                                 | **in 2.8.2** |
+| 2.5.x                            |                                                                 |                                                              |              |
+| -------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------ | ------------ |
+| **MethodName**                   | **Request**                                                     | **Response**                                                 | **in 2.8.2** |
 | **PublishNodes**                 | EndpointUrl, List\<OpcNodes\>,  UseSecurity, UserName, Password | Status, List\<StatusResponse\>                               | Yes          |
-| **UnpublishNodes**               | EndpointUrl, List\<OpcNodes\>                                | Status, List\<StatusResponse\>                               | Yes          |
-| **UnpublishAllNodes**            | EndpointUrl                                                  | Status, List\<StatusResponse\>                               | Yes          |
-| **GetConfiguredEndpoints**       | -                                                            | List\<EndpointUrl\>                                          | Yes          |
-| **GetConfiguredNodesOnEndpoint** | EndpointUrl                                                  | EndpointUrl, List< OpcNodeOnEndpointModel >    where OpcNodeOnEndpointModel contains:    Id ExpandedNodeId OpcSamplingInterval OpcPublishingInterval DisplayName HeartbeatInterval SkipFirst | Yes          |
-| **GetDiagnosticInfo**            | -                                                            | DiagnosticInfoMethodResponseModel                            | Yes          |
-| **GetDiagnosticLog**             | -                                                            | MissedMessageCount, LogMessageCount, List\<Log\>             | No*          |
-| **GetDiagnosticStartupLog**      | -                                                            | MissedMessageCount, LogMessageCount, List\<Log\>             | No*          |
-| **ExitApplication**              | SecondsTillExit (optional)                                   | StatusCode, List\<StatusResponse\>                           | No*          |
-| **GetInfo**                      | -                                                            | GetInfoMethodResponseModel >>    VersionMajor  VersionMinor  VersionPatch  SemanticVersion  InformationalVersion OS  OSArchitecture  FrameworkDescription | No*          |
+| **UnpublishNodes**               | EndpointUrl, List\<OpcNodes\>                                   | Status, List\<StatusResponse\>                               | Yes          |
+| **UnpublishAllNodes**            | EndpointUrl                                                     | Status, List\<StatusResponse\>                               | Yes          |
+| **GetConfiguredEndpoints**       | -                                                               | List\<EndpointUrl\>                                          | Yes          |
+| **GetConfiguredNodesOnEndpoint** | EndpointUrl                                                     | EndpointUrl, List< OpcNodeOnEndpointModel >    where OpcNodeOnEndpointModel contains:    Id ExpandedNodeId OpcSamplingInterval OpcPublishingInterval DisplayName HeartbeatInterval SkipFirst | Yes          |
+| **GetDiagnosticInfo**            | -                                                               | DiagnosticInfoMethodResponseModel                            | Yes          |
+| **GetDiagnosticLog**             | -                                                               | MissedMessageCount, LogMessageCount, List\<Log\>             | No*          |
+| **GetDiagnosticStartupLog**      | -                                                               | MissedMessageCount, LogMessageCount, List\<Log\>             | No*          |
+| **ExitApplication**              | SecondsTillExit (optional)                                      | StatusCode, List\<StatusResponse\>                           | No*          |
+| **GetInfo**                      | -                                                               | GetInfoMethodResponseModel >>    VersionMajor  VersionMinor  VersionPatch  SemanticVersion  InformationalVersion OS  OSArchitecture  FrameworkDescription | No*          |
 
 *This functionality is provided by the IoT Edge `edgeAget` module via its own direct methods, see [this page](https://docs.microsoft.com/azure/iot-edge/how-to-edgeagent-direct-method) for more information.
 
@@ -34,8 +44,7 @@ _Please note that the samples applications are not actively maintained and may b
 
 ## Direct Methods of version 2.8.2
 
-Inherited direct methods from 2.5.x:
-
+The following set of direct method api is inherited from 2.5.x API set.
 - PublishNodes_V1
 - UnpublishNodes_V1
 - UnpublishAllNodes_V1
@@ -43,17 +52,12 @@ Inherited direct methods from 2.5.x:
 - GetConfiguredNodesOnEndpoint_V1
 - GetDiagnosticInfo_V1
 
-New direct methods:
-
-- AddOrUpdateEndpoints_V1
-
-Please note that the recommended way of using the direct methods is with `_V1` suffix however, direct method without `_V1` suffix is also supported.
+Please note that in 2.8.2 the recommended way of using the direct methods is with `_V1` suffix however.
+Direct method name without `_V1` suffix is also supported but is subject of deprication.
 
 The direct methods definitions of version 2.8.2 are provided in [this](publisher-directmethods.md) document in detail.
 
 # Direct methods of version 2.5.x vs 2.8.2
-
-**TODO**: Update the responses in 2.8.2 after backwards compatibility fixes.
 
 In this section let's see the request and response payloads for the direct methods of version 2.5.x and 2.8.2
 
@@ -63,17 +67,17 @@ In this section let's see the request and response payloads for the direct metho
 
 ```json
 {
-   "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000",
-   "UseSecurity":false,
+   "EndpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
+   "UseSecurity": false,
    "OpcNodes":[
       {
-         "Id":"nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
+         "Id": "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
       },
       {
-         "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
+         "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
       },
       {
-         "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+         "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
       }
    ]
 }
@@ -83,8 +87,8 @@ In this section let's see the request and response payloads for the direct metho
 
 ```json
 {
-   "status":200,
-   "payload":[
+   "status": 200,
+   "payload": [
       "'nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler': added",
       "'nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf': added",
       "'nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1': added"
@@ -96,9 +100,8 @@ In this section let's see the request and response payloads for the direct metho
 
 ```json
 {
-   "status":200,
-   "payload":{
-   }
+   "status": 200,
+   "payload": {}
 }
 ```
 
@@ -112,11 +115,10 @@ When there are no configured endpoints:
 
 ```json
 {
-   "status":200,
-   "payload":{
-      "Endpoints":[
-         
-      ]
+   "status": 200,
+   "payload": 
+   {
+      "Endpoints": []
    }
 }
 ```
@@ -125,9 +127,10 @@ When there are configured endpoints:
 
 ```json
 {
-   "status":200,
-   "payload":{
-      "Endpoints":[
+   "status": 200,
+   "payload": 
+   {
+      "Endpoints": [
          {
             "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000"
          }
@@ -142,10 +145,11 @@ When there are no configured endpoints:
 
 ```json
 {
-   "status":200,
-   "payload":[
-      
-   ]
+   "status": 200,
+   "payload": 
+   {
+      "endpoints": []
+   }   
 }
 ```
 
@@ -153,11 +157,14 @@ When there are configured endpoints:
 
 ```json
 {
-   "status":200,
-   "payload":[
-      {
-         "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000/"
-      }
+   "status": 200,
+   "payload": 
+   {
+      "endpoints": [
+         {
+            "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000/"
+         }
+      ]
    ]
 }
 ```
@@ -168,7 +175,7 @@ When there are configured endpoints:
 
 ```json
 {
-   "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000"
+   "EndpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000"
 }
 ```
 
@@ -176,18 +183,18 @@ When there are configured endpoints:
 
 ```json
 {
-   "status":200,
-   "payload":{
-      "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000",
-      "OpcNodes":[
+   "status": 200,
+   "payload": {
+      "EndpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
+      "OpcNodes": [
          {
-            "Id":"nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
+            "Id": "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
          },
          {
-            "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
+            "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
          },
          {
-            "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+            "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
          }
       ]
    }
@@ -198,11 +205,10 @@ If `UnpublishAllNodes` is called on that endpoint, then the response will be:
 
 ```json
 {
-   "status":200,
-   "payload":{
-      "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000",
-      "OpcNodes":[
-      ]
+   "status": 200,
+   "payload": {
+      "endpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
+      "opcNodes": []
    }
 }
 ```
@@ -212,17 +218,20 @@ If `UnpublishAllNodes` is called on that endpoint, then the response will be:
 ```json
 {
    "status":200,
-   "payload":[
-      {
-         "id":"nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
-      },
-      {
-         "id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
-      },
-      {
-         "id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
-      }
-   ]
+   "payload": 
+   {
+      "opcNodes": [
+         {
+            "id": "nsu=http://microsoft.com/Opc/OpcPlc/Boiler;s=Boiler"
+         },
+         {
+            "id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
+         },
+         {
+            "id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+         }
+      ]
+   }
 }
 ```
 
@@ -230,8 +239,8 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 
 ```json
 {
-   "status":404,
-   "payload":"Endpoint not found: opc.tcp://sandboxhost-637811493394507132:50000/"
+   "status": 404,
+   "payload": "Endpoint not found: opc.tcp://sandboxhost-637811493394507132:50000/"
 }
 ```
 
@@ -243,31 +252,31 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 
 ```json
 {
-   "status":200,
-   "payload":{
-      "PublisherStartTime":"2022-02-22T18:07:56.363511Z",
-      "NumberOfOpcSessionsConfigured":1,
-      "NumberOfOpcSessionsConnected":0,
-      "NumberOfOpcSubscriptionsConfigured":1,
-      "NumberOfOpcSubscriptionsConnected":0,
-      "NumberOfOpcMonitoredItemsConfigured":3,
-      "NumberOfOpcMonitoredItemsMonitored":0,
-      "NumberOfOpcMonitoredItemsToRemove":0,
-      "MonitoredItemsQueueCapacity":8192,
-      "MonitoredItemsQueueCount":0,
-      "EnqueueCount":13060,
-      "EnqueueFailureCount":0,
-      "NumberOfEvents":13060,
-      "SentMessages":30,
-      "SentLastTime":"2022-02-22T19:03:39.3249082Z",
-      "SentBytes":3000192,
-      "FailedMessages":0,
-      "TooLargeCount":0,
-      "MissedSendIntervalCount":8,
-      "WorkingSetMB":118,
-      "DefaultSendIntervalSeconds":10,
-      "HubMessageSize":262144,
-      "HubProtocol":3
+   "status": 200,
+   "payload": {
+      "PublisherStartTime": "2022-02-22T18:07:56.363511Z",
+      "NumberOfOpcSessionsConfigured": 1,
+      "NumberOfOpcSessionsConnected": 0,
+      "NumberOfOpcSubscriptionsConfigured": 1,
+      "NumberOfOpcSubscriptionsConnected": 0,
+      "NumberOfOpcMonitoredItemsConfigured": 3,
+      "NumberOfOpcMonitoredItemsMonitored": 0,
+      "NumberOfOpcMonitoredItemsToRemove": 0,
+      "MonitoredItemsQueueCapacity": 8192,
+      "MonitoredItemsQueueCount": 0,
+      "EnqueueCount": 13060,
+      "EnqueueFailureCount": 0,
+      "NumberOfEvents": 13060,
+      "SentMessages": 30,
+      "SentLastTime": "2022-02-22T19:03:39.3249082Z",
+      "SentBytes": 3000192,
+      "FailedMessages": 0,
+      "TooLargeCount": 0,
+      "MissedSendIntervalCount": 8,
+      "WorkingSetMB": 118,
+      "DefaultSendIntervalSeconds": 10,
+      "HubMessageSize": 262144,
+      "HubProtocol": 3
    }
 }
 ```
@@ -276,13 +285,38 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 
 ```json
 {
-   "status":200,
-   "payload":[
+   "status": 200,
+   "payload": [
       {
-         "EndpointInfo":{
-            "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000/"
+         "endpointInfo": {
+            "endpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
+            "dataSetWriterGroup": "Asset1",
+            "useSecurity": false,
+            "opcAuthenticationMode": "UsernamePassword",
+            "opcAuthenticationUsername": "Usr"
          },
-         "ConnectionRetries":187
+         "sentMessagesPerSec": 2.6,
+         "ingestionDuration": "{00:00:25.5491702}",
+         "ingressDataChanges": 25,
+         "ingressValueChanges": 103,
+         "ingressBatchBlockBufferSize": 0,
+         "encodingBlockInputSize": 0,
+         "encodingBlockOutputSize": 0,
+         "encoderNotificationsProcessed": 83,
+         "encoderNotificationsDropped": 0,
+         "encoderIoTMessagesProcessed": 2,
+         "encoderAvgNotificationsMessage": 41.5,
+         "encoderAvgIoTMessageBodySize": 6128,
+         "encoderAvgIoTChunkUsage": 1.158034,
+         "estimatedIoTChunksPerDay": 13526.858105160689,
+         "outgressBatchBlockBufferSize": 0,
+         "outgressInputBufferCount": 0,
+         "outgressInputBufferDropped": 0,
+         "outgressIoTMessageCount": 0,
+         "connectionRetries": 0,
+         "opcEndpointConnected": true,
+         "monitoredOpcNodesSucceededCount": 5,
+         "monitoredOpcNodesFailedCount": 0
       }
    ]
 }
@@ -290,15 +324,14 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 
 ## UnpublishNodes_V1
 
-**Important**:  _OpcNodes_ is mandatory in 2.8.2 for this method.
-In v2.5.x if _OpcNodes_ is not provided then all nodes are unpublished and endpoint is removed, while in 2.8.2 , it will throw an exception `{"status":400,"payload":"null or empty OpcNodes is provided in request"}`
+If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is removed.
 
 `Request`:
 
 ```json
 {
-   "EndpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000",
-   "OpcNodes":[
+   "EndpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
+   "OpcNodes": [
       {
          "Id":"nsu=http://microsoft.com/Opc/OpcPlc/;s=65e451f1-56f1-ce84-a44f-6addf176beaf"
       }
@@ -357,3 +390,22 @@ In v2.5.x if _OpcNodes_ is not provided then all nodes are unpublished and endpo
    }
 }
 ```
+
+The following direct methods present in 2.5.x were discontinued. 
+The alternatives to these actions are detailed below:
+
+## GetDiagnosticLog
+
+**TODO**
+
+## GetDiagnosticStartupLog
+
+**TODO**
+
+## ExitApplication
+
+**TODO**
+
+## GetInfo
+
+**TODO**

--- a/docs/modules/publisher-dmmigration.md
+++ b/docs/modules/publisher-dmmigration.md
@@ -36,7 +36,7 @@ The following  table describes the direct methods which were available in OPC Pu
 | **ExitApplication**              | SecondsTillExit (optional)                                      | StatusCode, List\<StatusResponse\>                           | No*          |
 | **GetInfo**                      | -                                                               | GetInfoMethodResponseModel >>    VersionMajor  VersionMinor  VersionPatch  SemanticVersion  InformationalVersion OS  OSArchitecture  FrameworkDescription | No*          |
 
-*This functionality is provided by the IoT Edge `edgeAget` module via its own direct methods, see [this page](https://docs.microsoft.com/azure/iot-edge/how-to-edgeagent-direct-method) for more information.
+*This functionality is provided by the IoT Edge `edgeAgent` module via its own direct methods, see [this page](https://docs.microsoft.com/azure/iot-edge/how-to-edgeagent-direct-method) for more information.
 
 A [sample configuration application](https://github.com/Azure-Samples/iot-edge-opc-publisher-nodeconfiguration) as well as an [sample application for reading diagnostic information](https://github.com/Azure-Samples/iot-edge-opc-publisher-diagnostics) are provided from OPC Publisher leveraging this interface.
 
@@ -53,7 +53,7 @@ The following set of direct method api is inherited from 2.5.x API set.
 - GetDiagnosticInfo_V1
 
 Please note that in 2.8.2 the recommended way of using the direct methods is with `_V1` suffix however.
-Direct method name without `_V1` suffix is also supported but is subject of deprication.
+Direct method name without `_V1` suffix is also supported but is subject of deprecation.
 
 The direct methods definitions of version 2.8.2 are provided in [this](publisher-directmethods.md) document in detail.
 
@@ -162,7 +162,7 @@ When there are configured endpoints:
    {
       "endpoints": [
          {
-            "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000/"
+            "endpointUrl":"opc.tcp://sandboxhost-637811493394507132:50000"
          }
       ]
    ]
@@ -288,7 +288,7 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
    "status": 200,
    "payload": [
       {
-         "endpointInfo": {
+         "endpoint": {
             "endpointUrl": "opc.tcp://sandboxhost-637811493394507132:50000",
             "dataSetWriterGroup": "Asset1",
             "useSecurity": false,

--- a/docs/modules/publisher-migrationpath.md
+++ b/docs/modules/publisher-migrationpath.md
@@ -1,16 +1,23 @@
 [Home](../../readme.md)
 
-# Migration path for publisher version 2.5.x to 2.8.2 - configuration file structure (pn.json)
+# Migration path for publisher version 2.5.x to 2.8.2
+
 **TODO**
 2.8.2 must work in standalone mode for backwards compatibility with 2.5.x functionality
 
-# Migration path for publisher version 2.5.x to 2.8.2 - CLI arguments
+## Configuration file (pn.json)
+
 **TODO**
 
-# Migration path for publisher version 2.5.x to 2.8.2 - OPC UA Certificates management
+## Command Line Arguments
+
 **TODO**
 
-# Migration path for publisher version 2.5.x to 2.8.2 - Direct Methods API
+## OPC UA Certificates management
+
+**TODO**
+
+## Direct Methods API
 
 The latest version 2.8.2 adds support for configuration via IoT Hub direct methods. OPC Publisher implements multiple [IoT Hub Direct Methods](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-direct-methods) which can be called from an application leveraging the [IoT Hub Device SDK](https://docs.microsoft.com/azure/iot-hub/iot-hub-devguide-sdks). This document provides the migration path from 2.5.x to 2.8.2.
 
@@ -18,7 +25,10 @@ The direct methods' request payload of version 2.8.2 is backwards compatible wit
 
 For this set of methods, the encoding is JSON and no compression or payload chunking mechanism is applied in order to ensure the backwards compatibility with the 2.5.x version of OPC Publisher module.
 
-## Direct Methods of version 2.5.x
+**Limitations:**
+ - Continuation points for GetConfiguredEndpoints and GetConfiguredNodesOnEndpoint are not available in 2.8.2
+
+### Direct Methods of version 2.5.x
 
 The following  table describes the direct methods which were available in OPC Publisher 2.5.x with request and response.
 
@@ -42,7 +52,7 @@ A [sample configuration application](https://github.com/Azure-Samples/iot-edge-o
 
 _Please note that the samples applications are not actively maintained and may be outdated._
 
-## Direct Methods of version 2.8.2
+### Direct Methods of version 2.8.2
 
 The following set of direct method api is inherited from 2.5.x API set.
 - PublishNodes_V1
@@ -57,11 +67,11 @@ Direct method name without `_V1` suffix is also supported but is subject of depr
 
 The direct methods definitions of version 2.8.2 are provided in [this](publisher-directmethods.md) document in detail.
 
-# Direct methods of version 2.5.x vs 2.8.2
+## Direct methods of version 2.5.x vs 2.8.2
 
 In this section let's see the request and response payloads for the direct methods of version 2.5.x and 2.8.2
 
-## PublishNodes_V1
+### PublishNodes_V1
 
 `Request`:
 
@@ -105,7 +115,7 @@ In this section let's see the request and response payloads for the direct metho
 }
 ```
 
-## GetConfiguredEndpoints_V1
+### GetConfiguredEndpoints_V1
 
 `Request`: {}
 
@@ -169,7 +179,7 @@ When there are configured endpoints:
 }
 ```
 
-## GetConfiguredNodesOnEndpoint_V1
+### GetConfiguredNodesOnEndpoint_V1
 
 `Request`:
 
@@ -244,7 +254,7 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 }
 ```
 
-## GetDiagnosticInfo_V1
+### GetDiagnosticInfo_V1
 
 `Request`: {}
 
@@ -322,7 +332,7 @@ If the endpoint is not configured or `UnpublishAllNodes` is called on that endpo
 }
 ```
 
-## UnpublishNodes_V1
+### UnpublishNodes_V1
 
 If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is removed.
 
@@ -359,7 +369,7 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 }
 ```
 
-## UnpublishAllNodes_V1
+### UnpublishAllNodes_V1
 
 `Request`:
 
@@ -392,18 +402,18 @@ If _OpcNodes_ is not provided then all nodes are unpublished and endpoint is rem
 The following direct methods present in 2.5.x were discontinued. 
 The alternatives to these actions are detailed below:
 
-## GetDiagnosticLog
+### GetDiagnosticLog
 
 **TODO**
 
-## GetDiagnosticStartupLog
+### GetDiagnosticStartupLog
 
 **TODO**
 
-## ExitApplication
+### ExitApplication
 
 **TODO**
 
-## GetInfo
+### GetInfo
 
 **TODO**

--- a/docs/modules/publisher.md
+++ b/docs/modules/publisher.md
@@ -147,7 +147,7 @@ There are several command line arguments that can be used to set global settings
 
 There are multiple IoT Hub direct methods which could be used to configure OPC Publisher. Please refer to [this](publisher-directmethods.md) document for additional details.
 
-To learn how to migrate from version 2.5.x to version 2.8.2 for the direct methods, please check this [migration path](publisher-dmmigration.md).
+To learn how to migrate from version 2.5.x to version 2.8.2 for the direct methods, please check this [migration path](publisher-migrationpath.md).
 
 
 ### Configuration via the built-in OPC UA Server Interface


### PR DESCRIPTION
* fix the backward compatibility issues on the following DMs
  -  UnpublishAllNodes_V1
  - GetConfiguredEndpoints_V1
  - GetConfiguredNodesOnEndpoint_V1
  - GetDiagnosticInfo_V1 
* a few additions and fixes
* add todos for the migration topics not covered
* rename the migration path doc