### PR TITLE
Increased E2E test time limit to 150 minutes from 120.

### DIFF
--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -78,7 +78,7 @@ stages:
   condition: and(not(canceled()), or(eq(dependencies.deploy.result, 'Succeeded'), eq(dependencies.deploy.result, 'Skipped')))
   jobs:
   - job: runtests
-    timeoutInMinutes: 150
+    timeoutInMinutes: 180
     displayName: 'Run End 2 End Tests'
     steps:
     - template: steps/runtests.yml

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -94,7 +94,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   displayName: 'Executing xUnit tests (with ${{ parameters.ModeName }}=${{ parameters.ModeValue }})'
-  timeoutInMinutes: 120
+  timeoutInMinutes: 150
   inputs:
     command: test
     projects: '$(TestPath)\IIoTPlatform-E2E-Tests.csproj'


### PR DESCRIPTION
Standalone E2E tests are taking `115` minutes when successful. So one failed test might cause a timeout for the remaining ones. This PR increases the time limit to `150` minutes from `120` to allow for normal completion of the test pipeline even in the case of some test failures.

Similar to #1567