### PR TITLE
Fixed processing of legacy NodeId-based published nodes files.

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/StandaloneJobOrchestrator.cs
@@ -339,12 +339,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                 return;
             }
 
-            entries.RemoveAll(entry => (entry.OpcNodes == null || entry.OpcNodes.Count == 0)
-                && (entry.NodeId == null || string.IsNullOrEmpty(entry.NodeId.Identifier)));
+            entries.RemoveAll(entry => entry.OpcNodes == null || entry.OpcNodes.Count == 0);
         }
 
         /// <summary>
         /// Transforms legacy entries that use NodeId into ones using OpcNodes.
+        /// The transformation will happen in-place.
         /// </summary>
         /// <param name="entries"></param>
         private static void TransformFromLegacyNodeId(List<PublishedNodesEntryModel> entries) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
@@ -87,6 +87,35 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         }
 
         [Theory]
+        [InlineData("Engine/pn_2.5_legacy.json")]
+        public async Task Leacy25PublishedNodesFile(string publishedNodesFile) {
+            Utils.CopyContent(publishedNodesFile, _tempFile);
+            InitStandaloneJobOrchestrator();
+
+            var endpoints = await _standaloneJobOrchestrator.GetConfiguredEndpointsAsync();
+
+            Assert.Equal(1, endpoints.Count);
+
+            var endpoint = endpoints[0];
+
+            Assert.Equal(endpoint.DataSetWriterGroup, "DataSetWriterGroup0");
+            Assert.Equal(endpoint.EndpointUrl, new Uri("opc.tcp://opcplc:50000"));
+            Assert.Equal(endpoint.UseSecurity, false);
+            Assert.Equal(endpoint.OpcAuthenticationMode, OpcAuthenticationMode.UsernamePassword);
+            Assert.Equal(endpoint.OpcAuthenticationUsername, "username");
+            Assert.Equal(endpoint.OpcAuthenticationPassword, null);
+            Assert.Equal(endpoint.DataSetWriterId, "DataSetWriterId0");
+            Assert.Equal(endpoint.DataSetPublishingInterval, 10000);
+
+            endpoint.OpcAuthenticationPassword = "password";
+
+            var nodes = await _standaloneJobOrchestrator.GetConfiguredNodesOnEndpointAsync(endpoint);
+
+            Assert.Equal(1, nodes.Count);
+            Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1", nodes[0].Id);
+        }
+
+        [Theory]
         [InlineData("Engine/publishednodes.json")]
         [InlineData("Engine/publishednodeswithoptionalfields.json")]
         public async Task GetAvailableJobAsyncMulithreading(string publishedNodesFile) {
@@ -130,7 +159,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
             InitStandaloneJobOrchestrator();
 
             var exceptionResponse = $"{{\"Message\":\"Response 400 null request is provided\",\"Details\":{{}}}}";
-            
+
             // Check null request.
             await FluentActions
                 .Invoking(async () => await _standaloneJobOrchestrator
@@ -140,7 +169,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
                 .ThrowAsync<MethodCallStatusException>()
                 .WithMessage(exceptionResponse)
                 .ConfigureAwait(false);
-            
+
             // empty description
             var exceptionModel = new MethodCallStatusExceptionModel {
                 Message = "Response 400 null request is provided",

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_2.5_legacy.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_2.5_legacy.json
@@ -1,0 +1,15 @@
+﻿[
+  {
+    "DataSetWriterGroup": "DataSetWriterGroup0",
+    "EndpointUrl": "opc.tcp://opcplc:50000",
+    "UseSecurity": false,
+    "OpcAuthenticationMode": "UsernamePassword",
+    "OpcAuthenticationUsername": "username",
+    "OpcAuthenticationPassword": "password",
+    "DataSetWriterId": "DataSetWriterId0",
+    "DataSetPublishingInterval": 10000,
+    "NodeId": {
+      "Identifier": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+    }
+  }
+]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_2.5_legacy_error.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/pn_2.5_legacy_error.json
@@ -10,6 +10,11 @@
     "DataSetPublishingInterval": 10000,
     "NodeId": {
       "Identifier": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
-    }
+    },
+    "OpcNodes": [
+      {
+        "Id": "nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt1"
+      }
+    ]
   }
 ]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -44,6 +44,9 @@
     <None Update="Controller\DmApiPayloadCollection.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Engine\pn_2.5_legacy_error.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Engine\pn_opc_nodes_empty_and_null.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -65,6 +65,9 @@
     <None Update="Engine\pn_assets.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Engine\pn_2.5_legacy.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ProjectExtensions><VisualStudio><UserProperties /></VisualStudio></ProjectExtensions>
 </Project>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Schemas/publishednodesschema.json
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Schemas/publishednodesschema.json
@@ -90,7 +90,10 @@
             "type": "string"
           },
           "DataSetPublishingInterval": {
-            "type": "string"
+            "type": [
+              "integer",
+              "string"
+            ]
           },
           "EncryptedAuthPassword": {
             "type": "string"
@@ -143,7 +146,10 @@
             "type": "string"
           },
           "DataSetPublishingInterval": {
-            "type": "string"
+            "type": [
+              "integer",
+              "string"
+            ]
           },
           "EncryptedAuthPassword": {
             "type": "string"

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Schemas/strict-publishednodesschema.json
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Schemas/strict-publishednodesschema.json
@@ -89,7 +89,10 @@
 						"type": "string"
 					},
 					"DataSetPublishingInterval": {
-						"type": "string"
+						"type": [
+							"integer",
+							"string"
+						]
 					},
 					"EncryptedAuthPassword": {
 						"type": "string"
@@ -144,7 +147,10 @@
 						"type": "string"
 					},
 					"DataSetPublishingInterval": {
-						"type": "string"
+						"type": [
+							"integer",
+							"string"
+						]
 					},
 					"EncryptedAuthPassword": {
 						"type": "string"


### PR DESCRIPTION
Changes:
* Fixed processing of legacy `NodeId`-based published nodes files. Added transformation of legacy `NodeId`-based definitions to `OpcNodes`-base ones. Transformation will throw a `SerializerException` if an entry is found in published nodes file that has both `NodeId`-based and `OpcNodes`-base node definitions.
* Fixed expected type of `DataSetPublishingInterval` in validation schemas. Now it can be either `string` or `integer`.
* Added tests to validate processing of legacy published nodes filed.