### PR TITLE
Commented out warnings about unsupported command line options.

### DIFF
--- a/docs/release-announcement.md
+++ b/docs/release-announcement.md
@@ -9,7 +9,7 @@ We are pleased to announce the release of version 2.8.2 of our Industrial IoT Pl
 
 ### Fundamentals related fixes
 
-- [OPC Publisher] Implemented the backwards compatible [Direct Methods API](docs/modules/publisher-directmethods.md) of 2.5.x publisher. The migration path is documented [here](docs/modules/publisher-migrationpath.md)
+- [OPC Publisher] Implemented the backwards compatible [Direct Methods API](modules/publisher-directmethods.md) of 2.5.x publisher. The migration path is documented [here](modules/publisher-migrationpath.md)
 - [OPC Publisher] Optimizations in opc subscriptions/monitored items management in case of configuration changes. Only incremental changes are applied to a subscription.
 - [OPC Publisher] Added support for setting QueueSize on monitored items for publisher in standalone mode.
 - [OPC Publisher] Hardened the retry mechanism for activating monitored items.

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         public StandaloneCliOptions(string[] args) {
 
             bool showHelp = false;
-            List<string> unsupportedOptions = new List<string>();
+            //List<string> unsupportedOptions = new List<string>();
             List<string> legacyOptions = new List<string>();
             var logger = ConsoleLogger.Create(LogEventLevel.Warning);
 
@@ -206,7 +206,8 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 };
 
             try {
-                unsupportedOptions = options.Parse(args);
+                //unsupportedOptions = options.Parse(args);
+                options.Parse(args);
             }
             catch (Exception e) {
                 logger.Warning("Parse args exception: " + e.Message);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
@@ -213,11 +213,12 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
                 Exit(160);
             }
 
-            if (unsupportedOptions.Any()) {
-                foreach (var option in unsupportedOptions) {
-                    logger.Warning("Option {option} wrong or not supported, please use -h option to get all the supported options.", option);
-                }
-            }
+            // Commenting out as we need to add parsing and awareness of long-form parameter names.
+            //if (unsupportedOptions.Any()) {
+            //    foreach (var option in unsupportedOptions) {
+            //        logger.Warning("Option {option} wrong or not supported, please use -h option to get all the supported options.", option);
+            //    }
+            //}
 
             if (legacyOptions.Any()) {
                 foreach (var option in legacyOptions) {


### PR DESCRIPTION
Commenting out warnings as we need to add parsing and awareness of long-form parameter names.