### PR TITLE
test publisher incremental configuration change behavior

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/B_PublishMultipleNodesStandaloneDirectMethodTestTheory.cs
@@ -122,7 +122,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 250, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
@@ -222,7 +222,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
@@ -241,7 +241,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
@@ -316,7 +316,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 250, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
@@ -409,7 +409,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
@@ -428,7 +428,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -953,6 +953,9 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             Assert.Equal((int)HttpStatusCode.OK, response.Status);
 
+            // Delay a bit so the unpublish is performed
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
+
             // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
                 new MethodParameterModel {

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PublishMultipleEndpointsStandaloneDirectMethodTestTheory.cs
@@ -10,7 +10,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
     using Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models;
     using Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models;
     using Microsoft.Azure.IIoT.Serializers;
-    using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -166,7 +165,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
@@ -365,14 +364,14 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(0, diagInfoList.Count);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Use test event processor to verify data send to IoT Hub (expected* set to zero
             // as data gap analysis is not part of this test case)
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
@@ -522,7 +521,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             }
 
             // Wait some time to generate events to process.
-            await Task.Delay(2 * TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(2 * TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var publishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
@@ -544,7 +543,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 10_000, 20_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time before running unpublishing to allow test event processor to start.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetDiagnosticInfo direct method and validate that we have data for all endpoints.
             var diagInfoListResponse = await CallMethodAsync(
@@ -693,7 +692,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             // ToDo: Add sequence number checks once we support multi-endpoint validation.
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Now check that no more data is coming.
 
@@ -702,7 +701,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token);
@@ -806,7 +805,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 500, 10_000, 90_000_000, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitDataInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetConfiguredEndpoints direct method
             responseGetConfiguredEndpoints = await CallMethodAsync(
@@ -928,7 +927,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             // Cleanup of sessions is an operation that happens in parallel to unpublishing. So getting diagnostic info immediately
             // after unpublishing might not yet show the cleaned up state. So we will wait for some time to allow for that to happen.
-            await Task.Delay(TestConstants.DefaultDelayMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
@@ -967,7 +966,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             Assert.Equal(0, configuredEndpointsResponse.Endpoints.Count);
 
             // Wait till the publishing has stopped.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Call GetDiagnosticInfo direct method
             responseGetDiagnosticInfo = await CallMethodAsync(
@@ -986,7 +985,7 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             await TestHelper.StartMonitoringIncomingMessagesAsync(_context, 0, 0, 0, cts.Token).ConfigureAwait(false);
 
             // Wait some time to generate events to process.
-            await Task.Delay(TestConstants.DefaultTimeoutInMilliseconds, cts.Token).ConfigureAwait(false);
+            await Task.Delay(TestConstants.AwaitCleanupInMilliseconds, cts.Token).ConfigureAwait(false);
 
             // Stop monitoring and get the result.
             var unpublishingMonitoringResultJson = await TestHelper.StopMonitoringIncomingMessagesAsync(_context, cts.Token).ConfigureAwait(false);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
@@ -4,7 +4,6 @@
 // ------------------------------------------------------------
 
 namespace IIoTPlatform_E2E_Tests {
-    using System;
 
     /// <summary>
     /// Contains constants using for End 2 End testing
@@ -19,6 +18,21 @@ namespace IIoTPlatform_E2E_Tests {
         /// Name of the test assembly
         /// </summary>
         public const string TestAssemblyName = "IIoTPlatform-E2E-Tests";
+
+        /// <summary>
+        /// Await time for initialization/setup or no data expected.
+        /// </summary>
+        public const int AwaitInitInMilliseconds = 30 * 1000;
+
+        /// <summary>
+        /// Await time for waiting new data
+        /// </summary>
+        public const int AwaitDataInMilliseconds = 90 * 1000;
+
+        /// <summary>
+        /// Await time for cleanup or no data expected.
+        /// </summary>
+        public const int AwaitCleanupInMilliseconds = 20 * 1000;
 
         /// <summary>
         /// Default timeout of web calls

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -26,7 +26,6 @@ namespace IIoTPlatform_E2E_Tests {
     using System.Text.RegularExpressions;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.IIoT.Hub.Models;
-    using Microsoft.Azure.IIoT.OpcUa.Api.Publisher;
     using IIoTPlatform_E2E_Tests.TestEventProcessor;
 
     internal static partial class TestHelper {
@@ -608,7 +607,7 @@ namespace IIoTPlatform_E2E_Tests {
                     OpcNodes = new OpcUaNodesModel[] {
                         new OpcUaNodesModel {
                             Id = "ns=2;s=SlowUInt1",
-                            OpcPublishingInterval = 10000
+                            OpcPublishingInterval = 10000,
                         }
                     }
                 };
@@ -625,6 +624,7 @@ namespace IIoTPlatform_E2E_Tests {
                     var opcPlcPublishingInterval = opcNode.OpcPublishingInterval;
                     opcNode.OpcPublishingInterval = opcPlcPublishingInterval / 2;
                     opcNode.OpcSamplingInterval = opcPlcPublishingInterval / 4;
+                    opcNode.QueueSize = 4;
                     return opcNode;
                 })
                 .ToArray();
@@ -663,6 +663,7 @@ namespace IIoTPlatform_E2E_Tests {
                         var opcPlcPublishingInterval = opcNode.OpcPublishingInterval;
                         opcNode.OpcPublishingInterval = opcPlcPublishingInterval / 2;
                         opcNode.OpcSamplingInterval = opcPlcPublishingInterval / 4;
+                        opcNode.QueueSize = 4;
                         return opcNode;
                     })
                     .ToArray();
@@ -681,7 +682,8 @@ namespace IIoTPlatform_E2E_Tests {
                     nodes.Add(new OpcUaNodesModel {
                         Id = $"ns=2;s=SlowUInt{i + 1}",
                         OpcPublishingInterval = 10000 / 2,
-                        OpcSamplingInterval = 10000 / 4
+                        OpcSamplingInterval = 10000 / 4,
+                        QueueSize = 4,
                     });
                 }
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/OpcUaNodesModel.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/OpcUaNodesModel.cs
@@ -36,6 +36,11 @@ namespace IIoTPlatform_E2E_Tests.TestModels {
         public string DisplayName { get; set; }
 
         /// <summary>
+        /// DataSetFieldId
+        /// </summary>
+        public string DataSetFieldId { get; set; }
+
+        /// <summary>
         /// Heartbeat
         /// </summary>
         public uint? HeartbeatInterval { get; set; }
@@ -44,5 +49,10 @@ namespace IIoTPlatform_E2E_Tests.TestModels {
         /// Skip first value
         /// </summary>
         public bool? SkipFirst { get; set; }
+
+        /// <summary>
+        /// QueueSize value
+        /// </summary>
+        public uint QueueSize { get; set; }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PublisherExtensions.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestModels/PublisherExtensions.cs
@@ -47,11 +47,13 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Models {
             return new PublishedNodeApiModel {
                 Id = model.Id,
                 DisplayName = model.DisplayName,
+                DataSetFieldId = model.DataSetFieldId,
                 ExpandedNodeId = model.ExpandedNodeId,
                 OpcPublishingInterval = (int?)model.OpcPublishingInterval,
                 OpcSamplingInterval = (int?)model.OpcSamplingInterval,
                 HeartbeatInterval = (int?)model.HeartbeatInterval,
-                SkipFirst = model.SkipFirst
+                SkipFirst = model.SkipFirst,
+                QueueSize = model.QueueSize,
             };
         }
     }


### PR DESCRIPTION
 * changed SingleNodeStandaloneDirectMethod Tests to iteratively change the configuration while observing telemetry consistency.
 * adapted the timeout values to try to reduce the test running duration