### PR TITLE
IAI: Using virtual machine scale set instead of availability set.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -154,12 +154,14 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
                 //Fqdn = null,
                 AgentPoolProfiles = new List<ManagedClusterAgentPoolProfile> {
                     new ManagedClusterAgentPoolProfile {
+                        Type = AgentPoolType.VirtualMachineScaleSets,
                         Name = "agentpool",
                         Count = 2,
                         VmSize = ContainerServiceVMSizeTypes.StandardDS2V2,
                         OsDiskSizeGB = 100,
                         OsType = OSType.Linux,
-                        VnetSubnetID = virtualNetworkSubnet.Id
+                        VnetSubnetID = virtualNetworkSubnet.Id,
+                        MaxPods = 40,
                     }
                 },
                 LinuxProfile = new ContainerServiceLinuxProfile {


### PR DESCRIPTION
Changes:
* Using [virtual machine scale set](https://docs.microsoft.com/en-us/azure/virtual-machines/flexible-virtual-machine-scale-sets) instead of [availability set](https://docs.microsoft.com/en-us/azure/virtual-machines/availability-set-overview) for AKS agent pool. This will allow for addition of new node pools after cluster creation. It will also allow us to stop and restart the cluster.
* Increased maximum number of pods per node from `30` to `40` as we are already near the limit.