### PR TITLE
fix AutoAcceptUntrustedCertificates in publisher deployment

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Deploy/IoTHubPublisherDeployment.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Deploy/IoTHubPublisherDeployment.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Deploy {
                     Hostname = "publisher",
                     Cmd = new[] {
                         "PkiRootPath=/mount/pki",
-                        "--aa"
+                        "AutoAcceptUntrustedCertificates=true"
                     },
                     HostConfig = new {
                         Binds = new [] {
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Deploy {
                     Hostname = "publisher",
                     Cmd = new[] {
                         "PkiRootPath=/mount/pki",
-                        "--aa"
+                        "AutoAcceptUntrustedCertificates=true"
                     },
                     HostConfig = new {
                         Mounts = new[] {


### PR DESCRIPTION
The publisher in orchestrated mode does not support short cli arguments form like --aa. Replaced with long form