### PR TITLE
Upgraded NuGet packages of E2E solution.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
@@ -19,14 +19,14 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
     public class DiscoveryTestTheory {
         private readonly DiscoveryTestContext _context;
         private readonly CancellationTokenSource _cancellationTokenSource;
-        private readonly RestClient _restClient;      
+        private readonly RestClient _restClient;
 
         public DiscoveryTestTheory(DiscoveryTestContext context, ITestOutputHelper output) {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _context.OutputHelper = output ?? throw new ArgumentNullException(nameof(output));
-            
+
             _cancellationTokenSource = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            _restClient = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+            _restClient = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl);
 
             // Get OAuth token
             var token = TestHelper.GetTokenAsync(_context, _cancellationTokenSource.Token).GetAwaiter().GetResult();
@@ -67,14 +67,14 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
             var urls = new List<string> { url };
             AddTestOpcServers(urls);
 
-            // Registers servers by running a discovery scan 
+            // Registers servers by running a discovery scan
             var cidr = ipAddress + "/16";
             var body = new {
                 configuration = new {
                     addressRangesToScan = cidr
                 }
             };
-            TestHelper.CallRestApi(_context, Method.POST, TestConstants.APIRoutes.RegistryDiscover, body);
+            TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryDiscover, body);
 
             // Validate that the endpoint can be found
             var result = TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(_context, _cancellationTokenSource.Token, requestedEndpointUrls: urls).GetAwaiter().GetResult();
@@ -98,7 +98,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
                     portRangesToScan = "50000:51000"
                 }
             };
-            TestHelper.CallRestApi(_context, Method.POST, TestConstants.APIRoutes.RegistryDiscover, body);
+            TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryDiscover, body);
 
             // Validate that all endpoints are found
             var result = TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(_context, cts.Token, requestedEndpointUrls: urls).GetAwaiter().GetResult();
@@ -113,19 +113,19 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
                 RemoveApplication(applicationId);
             }
         }
-      
+
         private void AddTestOpcServers(List<string> endpointUrls) {
             foreach (var endpointUrl in endpointUrls) {
                 var body = new {
                     discoveryUrl = endpointUrl
                 };
-                TestHelper.CallRestApi(_context, Method.POST, TestConstants.APIRoutes.RegistryApplications, body);
+                TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryApplications, body);
             }
         }
 
         private void RemoveApplication(string applicationId) {
             var route = $"{TestConstants.APIRoutes.RegistryApplications}/{applicationId}";
-            TestHelper.CallRestApi(_context, Method.DELETE, route);
+            TestHelper.CallRestApi(_context, Method.Delete, route);
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
@@ -19,14 +19,12 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
     public class DiscoveryTestTheory {
         private readonly DiscoveryTestContext _context;
         private readonly CancellationTokenSource _cancellationTokenSource;
-        private readonly RestClient _restClient;
 
         public DiscoveryTestTheory(DiscoveryTestContext context, ITestOutputHelper output) {
             _context = context ?? throw new ArgumentNullException(nameof(context));
             _context.OutputHelper = output ?? throw new ArgumentNullException(nameof(output));
 
             _cancellationTokenSource = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            _restClient = new RestClient(_context.IIoTPlatformConfigHubConfig.BaseUrl);
 
             // Get OAuth token
             var token = TestHelper.GetTokenAsync(_context, _cancellationTokenSource.Token).GetAwaiter().GetResult();

--- a/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
@@ -15,12 +15,12 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="6.3.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.37.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.37.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.14" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
-    <PackageReference Include="RestSharp" Version="106.12.0" />
+    <PackageReference Include="RestSharp" Version="107.2.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/A_PublishSingleNodeOrchestratedTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/A_PublishSingleNodeOrchestratedTestTheory.cs
@@ -71,7 +71,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             };
 
             var route = TestConstants.APIRoutes.RegistryApplications;
-            var response = TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            var response = TestHelper.CallRestApi(_context, Method.Post, route, body, ct: cts.Token);
             Assert.True(response.IsSuccessful);
         }
 
@@ -155,7 +155,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
                 }
             };
 
-            var response = TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            var response = TestHelper.CallRestApi(_context, Method.Post, route, body, ct: cts.Token);
             Assert.Equal("{}",response.Content);
         }
 
@@ -170,7 +170,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var simulatedOpcServer = await TestHelper.GetSimulatedPublishedNodesConfigurationAsync(_context, cts.Token);
             var route = TestConstants.APIRoutes.PublisherJobs;
-            var response = TestHelper.CallRestApi(_context, Method.GET, route, ct: cts.Token);
+            var response = TestHelper.CallRestApi(_context, Method.Get, route, ct: cts.Token);
             dynamic json = JsonConvert.DeserializeObject(response.Content);
 
             Assert.NotEqual(0, json.jobs.Count);
@@ -225,7 +225,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var route = string.Format(TestConstants.APIRoutes.PublisherJobsFormat, _context.OpcUaEndpointId);
-            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Delete, route, ct: cts.Token);
         }
 
         [Fact, PriorityOrder(12)]
@@ -251,7 +251,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
         public void Test_RemoveAllApplications() {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var route = TestConstants.APIRoutes.RegistryApplications;
-            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Delete, route, ct: cts.Token);
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Orchestrated/B_PublishMultipleNodesOrchestratedTestTheory.cs
@@ -65,7 +65,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             };
 
             var route = TestConstants.APIRoutes.RegistryApplications;
-            TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Post, route, body, ct: cts.Token);
 
             // Check that Application was registered
             cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
@@ -108,7 +108,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             };
 
             var route = string.Format(TestConstants.APIRoutes.PublisherBulkFormat, _context.OpcUaEndpointId);
-            TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Post, route, body, ct: cts.Token);
         }
 
         [Fact, PriorityOrder(53)]
@@ -122,7 +122,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var route = TestConstants.APIRoutes.PublisherJobs;
-            var response = TestHelper.CallRestApi(_context, Method.GET, route, ct: cts.Token);
+            var response = TestHelper.CallRestApi(_context, Method.Get, route, ct: cts.Token);
             dynamic json = JsonConvert.DeserializeObject<ExpandoObject>(response.Content, new ExpandoObjectConverter());
 
             bool found = false;
@@ -204,7 +204,7 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
             };
 
             var route = string.Format(TestConstants.APIRoutes.PublisherBulkFormat, _context.OpcUaEndpointId);
-            TestHelper.CallRestApi(_context, Method.POST, route, body, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Post, route, body, ct: cts.Token);
         }
 
         [Fact, PriorityOrder(56)]
@@ -236,14 +236,14 @@ namespace IIoTPlatform_E2E_Tests.Orchestrated
 
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var route = string.Format(TestConstants.APIRoutes.PublisherJobsFormat, _context.OpcUaEndpointId);
-            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Delete, route, ct: cts.Token);
         }
 
         [Fact, PriorityOrder(58)]
         public void Test_RemoveAllApplications() {
             var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
             var route = TestConstants.APIRoutes.RegistryApplications;
-            TestHelper.CallRestApi(_context, Method.DELETE, route, ct: cts.Token);
+            TestHelper.CallRestApi(_context, Method.Delete, route, ct: cts.Token);
         }
     }
 }

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Discovery.cs
@@ -45,7 +45,7 @@ namespace IIoTPlatform_E2E_Tests {
                         foundEndpoints = 0;
 
                         var route = TestConstants.APIRoutes.RegistryApplications;
-                        var response = CallRestApi(context, Method.GET, route, ct);
+                        var response = CallRestApi(context, Method.Get, route, ct);
                         Assert.NotEmpty(response.Content);
                         json = JsonConvert.DeserializeObject<ExpandoObject>(response.Content, new ExpandoObjectConverter());
                         Assert.NotNull(json);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Registry.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Registry.cs
@@ -36,9 +36,7 @@ namespace IIoTPlatform_E2E_Tests {
                 IEnumerable<string> requestedEndpointUrls = null) {
 
                 var accessToken = await GetTokenAsync(context, ct);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                    Timeout = TestConstants.DefaultTimeoutInMilliseconds
-                };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
                 ct.ThrowIfCancellationRequested();
                 try {
@@ -46,9 +44,10 @@ namespace IIoTPlatform_E2E_Tests {
                     var activationStates = new List<string>(10);
                     do {
                         activationStates.Clear();
-                        var request = new RestRequest(Method.GET);
+                        var request = new RestRequest(TestConstants.APIRoutes.RegistryEndpoints, Method.Get) {
+                            Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                        };
                         request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                        request.Resource = TestConstants.APIRoutes.RegistryEndpoints;
 
                         var response = await client.ExecuteAsync(request, ct);
                         Assert.NotNull(response);
@@ -112,11 +111,12 @@ namespace IIoTPlatform_E2E_Tests {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest(TestConstants.APIRoutes.RegistryApplications, Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = TestConstants.APIRoutes.RegistryApplications;
 
                 var body = new { discoveryUrl };
 
@@ -145,11 +145,12 @@ namespace IIoTPlatform_E2E_Tests {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.GET);
+                var request = new RestRequest(TestConstants.APIRoutes.RegistryApplications, Method.Get) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = TestConstants.APIRoutes.RegistryApplications;
 
                 var response = await client.ExecuteAsync(request, ct).ConfigureAwait(false);
                 Assert.NotNull(response);
@@ -205,11 +206,13 @@ namespace IIoTPlatform_E2E_Tests {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.DELETE);
+                var resource = string.Format(TestConstants.APIRoutes.RegistryApplicationsWithApplicationIdFormat, applicationId);
+                var request = new RestRequest(resource, Method.Delete) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = string.Format(TestConstants.APIRoutes.RegistryApplicationsWithApplicationIdFormat, applicationId);
 
                 var response = await client.ExecuteAsync(request, ct).ConfigureAwait(false);
                 Assert.NotNull(response);
@@ -231,13 +234,12 @@ namespace IIoTPlatform_E2E_Tests {
 
                 Assert.False(string.IsNullOrWhiteSpace(endpointId), "Endpoint not set in the test context");
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                    Timeout = TestConstants.DefaultTimeoutInMilliseconds
-                };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest(string.Format(TestConstants.APIRoutes.RegistryActivateEndpointsFormat, endpointId), Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = string.Format(TestConstants.APIRoutes.RegistryActivateEndpointsFormat, endpointId);
 
                 // TODO remove workaround
                 // This request used to fail when called for the first time. The bug was fixed in the master,
@@ -280,13 +282,12 @@ namespace IIoTPlatform_E2E_Tests {
 
                 Assert.False(string.IsNullOrWhiteSpace(endpointId), "Endpoint not set in the test context");
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                    Timeout = TestConstants.DefaultTimeoutInMilliseconds
-                };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest(string.Format(TestConstants.APIRoutes.RegistryDeactivateEndpointsFormat, endpointId), Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = string.Format(TestConstants.APIRoutes.RegistryDeactivateEndpointsFormat, endpointId);
 
                 var response = client.ExecuteAsync(request, ct).GetAwaiter().GetResult();
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Twin.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.Twin.cs
@@ -74,22 +74,26 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.GET);
-                request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-
+                RestRequest request;
                 if (continuationToken == null) {
-                    request.Resource = $"twin/v2/browse/{endpointId}";
+                    request = new RestRequest($"twin/v2/browse/{endpointId}", Method.Get) {
+                        Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                    };
 
                     if (!string.IsNullOrEmpty(nodeId)) {
                         request.AddQueryParameter("nodeId", nodeId);
                     }
                 }
                 else {
-                    request.Resource = $"twin/v2/browse/{endpointId}/next";
+                    request = new RestRequest($"twin/v2/browse/{endpointId}/next", Method.Get) {
+                        Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                    };
                     request.AddQueryParameter("continuationToken", continuationToken);
                 }
+
+                request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
 
                 var response = await client.ExecuteAsync(request, ct).ConfigureAwait(false);
 
@@ -198,12 +202,12 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/call/{endpointId}/metadata", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-
-                request.Resource = $"twin/v2/call/{endpointId}/metadata";
 
                 var body = new {
                     methodId,
@@ -236,11 +240,12 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/read/{endpointId}/attributes", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = $"twin/v2/read/{endpointId}/attributes";
 
                 var body = new { attributes };
 
@@ -273,11 +278,12 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/write/{endpointId}/attributes", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = $"twin/v2/write/{endpointId}/attributes";
 
                 var body = new { attributes };
 
@@ -313,12 +319,12 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/call/{endpointId}", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-
-                request.Resource = $"twin/v2/call/{endpointId}";
 
                 var body = new {
                     methodId,
@@ -355,11 +361,12 @@ namespace IIoTPlatform_E2E_Tests {
                     CancellationToken ct = default) {
 
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/browse/{endpointId}/path", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = $"twin/v2/browse/{endpointId}/path";
 
                 var body = new {
                     nodeId,
@@ -395,11 +402,12 @@ namespace IIoTPlatform_E2E_Tests {
             {
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/read/{endpointId}", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = $"twin/v2/read/{endpointId}";
 
                 var body = new { nodeId };
 
@@ -444,11 +452,12 @@ namespace IIoTPlatform_E2E_Tests {
             {
                 var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
 
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-                var request = new RestRequest(Method.POST);
+                var request = new RestRequest($"twin/v2/write/{endpointId}", Method.Post) {
+                    Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+                };
                 request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-                request.Resource = $"twin/v2/write/{endpointId}";
 
                 var body = new { nodeId, value, dataType };
 

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestHelper.cs
@@ -71,11 +71,12 @@ namespace IIoTPlatform_E2E_Tests {
             Assert.True(!string.IsNullOrWhiteSpace(applicationName), "applicationName is null");
 
             var client = new RestClient($"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token") {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
-                Authenticator = new HttpBasicAuthenticator(clientId, clientSecret)
+                Authenticator = new HttpBasicAuthenticator(clientId, clientSecret),
             };
 
-            var request = new RestRequest(Method.POST);
+            var request = new RestRequest("", Method.Post) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+            };
             request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
             request.AddParameter("grant_type", "client_credentials");
             request.AddParameter("scope", $"api://{tenantId}/{applicationName}-service/.default");
@@ -176,7 +177,7 @@ namespace IIoTPlatform_E2E_Tests {
         /// <param name="body">Body for the request</param>
         /// <param name="queryParameters">Additional query parameters</param>
         /// /// <param name="ct">Cancellation token</param>
-        public static IRestResponse CallRestApi(
+        public static RestResponse CallRestApi(
             IIoTPlatformTestContext context,
             Method method,
             string route,
@@ -186,8 +187,9 @@ namespace IIoTPlatform_E2E_Tests {
         ) {
             var accessToken = GetTokenAsync(context, ct).GetAwaiter().GetResult();
 
-            var request = new RestRequest(method);
-            request.Resource = route;
+            var request = new RestRequest(route, method) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+            };
             request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
 
             if (body != null) {
@@ -200,7 +202,7 @@ namespace IIoTPlatform_E2E_Tests {
                 }
             }
 
-            var restClient = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+            var restClient = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
             var response = restClient.ExecuteAsync(request, ct).GetAwaiter().GetResult();
             return response;
         }
@@ -438,9 +440,8 @@ namespace IIoTPlatform_E2E_Tests {
             var runtimeUrl = context.TestEventProcessorConfig.TestEventProcessorBaseUrl.TrimEnd('/') + "/Runtime";
 
             var client = new RestClient(runtimeUrl) {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                 Authenticator = new HttpBasicAuthenticator(context.TestEventProcessorConfig.TestEventProcessorUsername,
-                    context.TestEventProcessorConfig.TestEventProcessorPassword)
+                    context.TestEventProcessorConfig.TestEventProcessorPassword),
             };
 
             var body = new {
@@ -457,7 +458,9 @@ namespace IIoTPlatform_E2E_Tests {
                 }
             };
 
-            var request = new RestRequest(Method.PUT);
+            var request = new RestRequest("", Method.Put) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+            };
             request.AddJsonBody(body);
 
             var response = await client.ExecuteAsync(request, ct);
@@ -481,16 +484,17 @@ namespace IIoTPlatform_E2E_Tests {
             var runtimeUrl = context.TestEventProcessorConfig.TestEventProcessorBaseUrl.TrimEnd('/') + "/Runtime";
 
             var client = new RestClient(runtimeUrl) {
-                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                 Authenticator = new HttpBasicAuthenticator(context.TestEventProcessorConfig.TestEventProcessorUsername,
-                    context.TestEventProcessorConfig.TestEventProcessorPassword)
+                    context.TestEventProcessorConfig.TestEventProcessorPassword),
             };
 
             var body = new {
                 CommandType = CommandEnum.Stop,
             };
 
-            var request = new RestRequest(Method.PUT);
+            var request = new RestRequest("", Method.Put) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+            };
             request.AddJsonBody(body);
 
             var response = await client.ExecuteAsync(request, ct);
@@ -521,18 +525,16 @@ namespace IIoTPlatform_E2E_Tests {
             };
 
             try {
-                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) {
-                    Timeout = TestConstants.DefaultTimeoutInMilliseconds
-                };
+                var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
                 while (true) {
                     ct.ThrowIfCancellationRequested();
 
-                    var tasks = new List<Task<IRestResponse>>();
+                    var tasks = new List<Task<RestResponse>>();
 
                     foreach (var healthRoute in healthRoutes) {
-                        var request = new RestRequest(Method.GET) {
-                            Resource = healthRoute
+                        var request = new RestRequest(healthRoute, Method.Get) {
+                            Timeout = TestConstants.DefaultTimeoutInMilliseconds,
                         };
 
                         tasks.Add(client.ExecuteAsync(request, ct));
@@ -723,11 +725,12 @@ namespace IIoTPlatform_E2E_Tests {
         /// <param name="ct">Cancellation token</param>
         private static async Task<dynamic> GetEndpointInternalAsync(IIoTPlatformTestContext context, CancellationToken ct) {
             var accessToken = await GetTokenAsync(context, ct).ConfigureAwait(false);
-            var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl) { Timeout = TestConstants.DefaultTimeoutInMilliseconds };
+            var client = new RestClient(context.IIoTPlatformConfigHubConfig.BaseUrl);
 
-            var request = new RestRequest(Method.GET);
+            var request = new RestRequest(TestConstants.APIRoutes.RegistryEndpoints, Method.Get) {
+                Timeout = TestConstants.DefaultTimeoutInMilliseconds,
+            };
             request.AddHeader(TestConstants.HttpHeaderNames.Authorization, accessToken);
-            request.Resource = TestConstants.APIRoutes.RegistryEndpoints;
 
             var response = await client.ExecuteAsync(request, ct).ConfigureAwait(false);
             Assert.NotNull(response);


### PR DESCRIPTION
Changes:
* Upgraded NuGet packages of E2E solution.
* Moved `Timeout` to the definition of requests as `RestClient` does not accept it any more.