### PR TITLE
Using 3.1.15 version of Microsoft.Extensions.* and Microsoft.AspNetCore.* NuGet packages.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api.Testing/cli/Microsoft.Azure.IIoT.Test.Scenarios.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api.Testing/cli/Microsoft.Azure.IIoT.Test.Scenarios.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/api/src/Microsoft.Azure.IIoT.Api/cli/Microsoft.Azure.IIoT.Cli.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/cli/Microsoft.Azure.IIoT.Cli.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore.SignalR/src/Microsoft.Azure.IIoT.AspNetCore.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore.SignalR/src/Microsoft.Azure.IIoT.AspNetCore.SignalR.csproj
@@ -8,8 +8,8 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
@@ -7,11 +7,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="3.1.19" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.19" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />

--- a/common/src/Microsoft.Azure.IIoT.Core/cli/Microsoft.Azure.IIoT.Core.Cli.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/cli/Microsoft.Azure.IIoT.Core.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Azure.IIoT.Core.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.15" />
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
   </ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Http.SignalR/src/Microsoft.Azure.IIoT.Http.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Http.SignalR/src/Microsoft.Azure.IIoT.Http.SignalR.csproj
@@ -5,9 +5,9 @@
     <Description>Azure Industrial IoT SignalR messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.15" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
@@ -5,8 +5,8 @@
     <Description>Azure Industrial IoT SignalR messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.15" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/common/src/Microsoft.Azure.IIoT.Storage.CosmosDb/cli/Microsoft.Azure.IIoT.Storage.CosmosDb.Cli.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Storage.CosmosDb/cli/Microsoft.Azure.IIoT.Storage.CosmosDb.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Cdm/src/Microsoft.Azure.IIoT.OpcUa.Cdm.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Cdm/src/Microsoft.Azure.IIoT.OpcUa.Cdm.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CommonDataModel.ObjectModel" Version="1.0.15" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.OpcUa\src\Microsoft.Azure.IIoT.OpcUa.csproj" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.15" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/cli/Microsoft.Azure.IIoT.OpcUa.Registry.Cli.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/cli/Microsoft.Azure.IIoT.OpcUa.Registry.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\common\src\Microsoft.Azure.IIoT.Messaging.ServiceBus\src\Microsoft.Azure.IIoT.Messaging.ServiceBus.csproj" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/cli/Microsoft.Azure.IIoT.OpcUa.Testing.Cli.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/cli/Microsoft.Azure.IIoT.OpcUa.Testing.Cli.csproj
@@ -9,7 +9,7 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.OpcUa.Edge.Twin\src\Microsoft.Azure.IIoT.OpcUa.Edge.Twin.csproj" />

--- a/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.28.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.15" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Microsoft.Azure.IIoT.Modules.Discovery.Cli.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/cli/Microsoft.Azure.IIoT.Modules.Discovery.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Azure.IIoT.Modules.Discovery.csproj" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/src/Microsoft.Azure.IIoT.Modules.Discovery.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.Discovery/src/Microsoft.Azure.IIoT.Modules.Discovery.csproj
@@ -13,9 +13,9 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Cli.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/cli/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Auth.ActiveDirectory\src\Microsoft.Azure.IIoT.Auth.ActiveDirectory.csproj" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.csproj
@@ -14,9 +14,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Mono.Options" Version="6.6.0.161" />
   </ItemGroup>
   <ItemGroup>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Cli.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/cli/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Cli.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Auth.ActiveDirectory\src\Microsoft.Azure.IIoT.Auth.ActiveDirectory.csproj" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.csproj
@@ -13,9 +13,9 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
@@ -8,8 +8,8 @@
     <PackageReference Include="Blazored.SessionStorage" Version="2.1.0" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.15" />
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="3.1.19" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />

--- a/services/src/Microsoft.Azure.IIoT.Services.All/src/Microsoft.Azure.IIoT.Services.All.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.All/src/Microsoft.Azure.IIoT.Services.All.csproj
@@ -9,9 +9,9 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Microsoft.Azure.IIoT.Services.OpcUa.Events.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/src/Microsoft.Azure.IIoT.Services.OpcUa.Events.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -3,8 +3,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.Edge.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights\src\Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Services.OpcUa.Publisher.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Sync.csproj
@@ -5,9 +5,9 @@
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Gateway.csproj
@@ -10,9 +10,9 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.csproj
@@ -4,9 +4,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.15" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Events/src/Microsoft.Azure.IIoT.Services.Processor.Events.csproj
@@ -5,9 +5,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding/src/Microsoft.Azure.IIoT.Services.Processor.Onboarding.csproj
@@ -5,9 +5,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.Cdm.csproj
@@ -5,9 +5,9 @@
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry/src/Microsoft.Azure.IIoT.Services.Processor.Telemetry.csproj
@@ -5,9 +5,9 @@
      <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />

--- a/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel/src/Microsoft.Azure.IIoT.Services.Processor.Tunnel.csproj
@@ -5,9 +5,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.15" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.15" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\common\src\Microsoft.Azure.IIoT.AspNetCore\src\Microsoft.Azure.IIoT.AspNetCore.csproj" />


### PR DESCRIPTION
Changes:
 * Using `3.1.15` version of `Microsoft.Extensions.*` NuGet packages.
 * Using `3.1.15` version of `Microsoft.AspNetCore.*` NuGet packages.

This will also reduce the amount of file changes that we now see in #1667 and align the branches more.