### PR TITLE
Reverted changes related to CompressedPayload.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
+++ b/api/src/Microsoft.Azure.IIoT.Api/src/Publisher/Extensions/ModelExtensions.cs
@@ -1350,7 +1350,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 IsEnabled = model.IsEnabled,
                 UpdateInterval = model.UpdateInterval,
                 SnapshotInterval = model.SnapshotInterval,
-                CompressedPayload = model.CompressedPayload
             };
         }
 
@@ -1366,7 +1365,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Models {
                 IsEnabled = model.IsEnabled,
                 UpdateInterval = model.UpdateInterval,
                 SnapshotInterval = model.SnapshotInterval,
-                CompressedPayload = model.CompressedPayload
             };
         }
 

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api/src/Core/Models/PendingAlarmsOptionsApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api/src/Core/Models/PendingAlarmsOptionsApiModel.cs
@@ -31,11 +31,5 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Core.Models {
         [DataMember(Name = "snapshotInterval", Order = 2,
             EmitDefaultValue = false)]
         public int? SnapshotInterval { get; set; }
-
-        /// <summary>
-        /// Should we compress messages using GZip?
-        /// </summary>
-        [DataMember(Name = "compressedPayload", Order = 3)]
-        public bool CompressedPayload { get; set; } = false;
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/WriterGroupMessageSource.cs
@@ -543,7 +543,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
                         ApplicationUri = notification.ApplicationUri,
                         EndpointUrl = notification.EndpointUrl,
                         TimeStamp = notification.Timestamp,
-                        CompressedPayload = notification.CompressedPayload,
                         PublisherId = _outer._publisherId,
                         Writer = _dataSetWriter,
                         WriterGroup = _outer._writerGroup

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/DataSetMessageModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Models/DataSetMessageModel.cs
@@ -41,11 +41,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
         public DateTime? TimeStamp { get; set; }
 
         /// <summary>
-        /// Should we compress messages using GZip?
-        /// </summary>
-        public bool CompressedPayload { get; set; }
-
-        /// <summary>
         /// Service message context
         /// </summary>
         public IServiceMessageContext ServiceMessageContext { get; set; }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -2406,8 +2406,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                 ""PendingAlarms"": {
                     ""IsEnabled"": true,
                     ""UpdateInterval"": 10000,
-                    ""SnapshotInterval"": 20000,
-                    ""CompressedPayload"": false
+                    ""SnapshotInterval"": 20000
                 }
             }
         ]
@@ -2445,7 +2444,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             Assert.True(eventModel.PendingAlarms.IsEnabled);
             Assert.Equal(10000, eventModel.PendingAlarms.UpdateInterval);
             Assert.Equal(20000, eventModel.PendingAlarms.SnapshotInterval);
-            Assert.False(eventModel.PendingAlarms.CompressedPayload);
         }
 
         private readonly IJsonSerializer _serializer = new NewtonSoftJsonSerializer();

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Models/SubscriptionNotificationModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Models/SubscriptionNotificationModel.cs
@@ -47,10 +47,5 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Models {
         /// Publishing time
         /// </summary>
         public DateTime Timestamp { get; internal set; }
-
-        /// <summary>
-        /// Shold we compress messages using GZip?
-        /// </summary>
-        public bool CompressedPayload { get; internal set; }
     }
 }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -947,7 +947,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                                 EndpointUrl = subscription.Session?.Endpoint?.EndpointUrl,
                                 SubscriptionId = Id,
                                 Timestamp = publishTime,
-                                CompressedPayload = false,
                                 Notifications = new List<MonitoredItemNotificationModel>()
                             };
 
@@ -1023,7 +1022,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                         EndpointUrl = subscription?.Session?.Endpoint?.EndpointUrl,
                         SubscriptionId = Id,
                         Timestamp = publishTime,
-                        CompressedPayload = false,
                         Notifications = notification.ToMonitoredItemNotifications(
                                 subscription?.MonitoredItems)?.ToList()
                                 ?? new List<MonitoredItemNotificationModel>(),
@@ -1746,7 +1744,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                     EndpointUrl = Item.Subscription?.Session?.Endpoint?.EndpointUrl,
                     SubscriptionId = (Item.Subscription?.Handle as SubscriptionWrapper)?.Id,
                     Timestamp = DateTime.UtcNow,
-                    CompressedPayload = EventTemplate.PendingAlarms.CompressedPayload,
                     Notifications = new List<MonitoredItemNotificationModel>()
                 };
                 message.Notifications.Add(pendingAlarmsNotification);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublishedDataSetSourceModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublishedDataSetSourceModelEx.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
             sb.Append(publishedEventData?.PendingAlarms?.IsEnabled);
             sb.Append(publishedEventData?.PendingAlarms?.UpdateInterval);
             sb.Append(publishedEventData?.PendingAlarms?.SnapshotInterval);
-            sb.Append(publishedEventData?.PendingAlarms?.CompressedPayload);
             sb.Append(publishedEventData?.TypeDefinitionId);
             return sb.ToString().ToSha1Hash();
         }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/Events/PendingAlarmsOptionsModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/Events/PendingAlarmsOptionsModel.cs
@@ -68,12 +68,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
         public bool Dirty { get; set; } = false;
 
         /// <summary>
-        /// Should we compress using GZip when sending pending alarm messages for this item?
-        /// </summary>
-        [DataMember(EmitDefaultValue = true)]
-        public bool CompressedPayload { get; set; } = false;
-
-        /// <summary>
         /// Clone
         /// </summary>
         /// <returns></returns>
@@ -85,7 +79,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
                 ConditionIdIndex = ConditionIdIndex,
                 RetainIndex = RetainIndex,
                 Dirty = Dirty,
-                CompressedPayload = CompressedPayload
             };
         }
 
@@ -101,8 +94,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
                    SnapshotInterval == model.SnapshotInterval &&
                    ConditionIdIndex == model.ConditionIdIndex &&
                    RetainIndex == model.RetainIndex &&
-                   Dirty == model.Dirty &&
-                   CompressedPayload == model.CompressedPayload;
+                   Dirty == model.Dirty;
         }
 
         /// <summary>
@@ -110,7 +102,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
         /// </summary>
         /// <returns>Return the hash code for this object</returns>
         public override int GetHashCode() {
-            return HashCode.Combine(IsEnabled, UpdateInterval, SnapshotInterval, ConditionIdIndex, RetainIndex, Dirty, CompressedPayload);
+            return HashCode.Combine(IsEnabled, UpdateInterval, SnapshotInterval, ConditionIdIndex, RetainIndex, Dirty);
         }
 
         /// <summary>

--- a/docs/opc-event-configuration.md
+++ b/docs/opc-event-configuration.md
@@ -1,17 +1,20 @@
 # Use configuration files for OPC UA Events in OPC Publisher
 
 This section describes how to configure the OPC Publisher to listen to events. Primarily you have to configure three things:
+
 * The source node you want to receive events for.
 * A select clause specifying which fields that should be in the event.
 * A where clause specifying which events to receive.
 
- OPC Publisher supports two types of configurations to specify that:
+OPC Publisher supports two types of configurations to specify that:
+
 * Normal, or advanced, configuration mode where you explicitly specify the select and where clauses.
 * Simple configuration mode, where you specify the source node and the event type you want to filter on and then the OPC Publisher constructs the select and where clauses for you.
 
 In the configuration file you can specify how many event configurations as you like and you can also combine events and data nodes for a single endpoint.
 
 Here is an example of a configuration file in normal or advanced mode:
+
 ```json
 [
     {
@@ -63,9 +66,11 @@ Here is an example of a configuration file in normal or advanced mode:
     }
 ]
 ```
+
 As highlighted in the example above you can specify namespaces both by using the index or the full name for the namespace. Also look at how the BrowsePath can be configured.
 
 And here is an example of a configuration file in simple mode:
+
 ```json
 [
     {
@@ -82,12 +87,14 @@ And here is an example of a configuration file in simple mode:
 ```
 
 When you specify a simple mode configuration, the OPC Publisher does two things:
+
 * It looks at the TypeDefinitionId and traverses the inheritance tree for that event type, collecting all the fields. Then it constructs a select clause with all the fields it finds.
 * It creates a where clause that is OfType(TypeDefinitionId).
 
 In addition to this, you can also configure to enable pending alarms view. What this does is that it listens to ConditionType derived events, record unique occurrences of them and on periodic updates will send a message containing all the unique events that has the Retain property set to True. This enables you to get a snapshot view of all pending, or active, alarms and conditions which can be very useful for dashboard-like scenarios.
 
 Here is an example of a configuration for a pending alarms:
+
 ```json
 [
     {
@@ -100,8 +107,7 @@ Here is an example of a configuration for a pending alarms:
                 "PendingAlarms": {
                     "IsEnabled": true,
                     "UpdateInterval": 10,
-                    "SnapshotInterval": 20,
-                    "CompressedPayload": false
+                    "SnapshotInterval": 20
                 }
             }
         ]
@@ -110,9 +116,9 @@ Here is an example of a configuration for a pending alarms:
 ```
 
 The PendingAlarms section consists of the following properties:
+
 * IsEnabled - defines if pending alarms view is enabled or not. If disabled it will work as normal events.
 * UpdateInterval - the interval, in seconds, which a message is sent if anything has been updated during this interval.
 * SnapshotInterval - the interval, in seconds, that triggers a message to be sent regardless of if there has been an update or not.
-* CompressedPayload - Should the message be compressed using GZip? Since we are accumulating all retained messages we might be sending a large message, so compression can be used to overcome the limit of a single IoTHub message.
 
 You can use the pending alarm configuration regardless if you are using normal or simple mode.

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PendingAlarmTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Standalone/C_PendingAlarmTestTheory.cs
@@ -39,7 +39,8 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
             var pnJson = _context.PublishedNodesJson(
                 50000,
                 _writerId,
-            TestConstants.PublishedNodesConfigurations.PendingAlarmsForAlarmsView(false));
+                TestConstants.PublishedNodesConfigurations.PendingAlarmsForAlarmsView()
+            );
             await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(_context, TestConstants.PublishedNodesFullName, pnJson, _timeoutToken);
             // take any message
             var ev = await messages
@@ -47,31 +48,6 @@ namespace IIoTPlatform_E2E_Tests.Standalone {
 
             // Assert
             ValidatePendingAlarmsView(ev, false);
-        }
-
-        // ToDo: remove ´skip test´ when event and alarm are fully implemented
-        [Fact(Skip = "PublishedNodesJobConverter does not parse OpcEvents now."), PriorityOrder(11)]
-        public async void Test_VerifyDataAvailableAtIoTHub_Expect_PendingAlarmsView_WithCompression() {
-
-            // Arrange
-            await TestHelper.CreateSimulationContainerAsync(_context, new List<string>
-                {"/bin/sh", "-c", "./opcplc --autoaccept --alm --pn=50000"},
-                _timeoutToken);
-
-            var messages = _consumer.ReadPendingAlarmMessagesFromWriterIdAsync<ConditionTypePayload>(_writerId, _timeoutToken);
-
-            // Act
-            var pnJson = _context.PublishedNodesJson(
-                50000,
-                _writerId,
-            TestConstants.PublishedNodesConfigurations.PendingAlarmsForAlarmsView(true));
-            await TestHelper.SwitchToStandaloneModeAndPublishNodesAsync(_context, TestConstants.PublishedNodesFullName, pnJson, _timeoutToken);
-            // take any message
-            var ev = await messages
-                .FirstAsync(_timeoutToken);
-
-            // Assert
-            ValidatePendingAlarmsView(ev, true);
         }
 
         private static void ValidatePendingAlarmsView(PendingAlarmEventData<ConditionTypePayload> eventData, bool expectCompressedPayload) {

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
@@ -553,7 +553,7 @@ namespace IIoTPlatform_E2E_Tests {
                         new JProperty("TypeDefinitionId", typeDefinitionId)));
             }
 
-            public static JArray PendingAlarmsForAlarmsView(bool compressedPayload) {
+            public static JArray PendingAlarmsForAlarmsView() {
                 return new JArray(
                     new JObject(
                         new JProperty("Id", "i=2253"),
@@ -561,8 +561,7 @@ namespace IIoTPlatform_E2E_Tests {
                         new JProperty("PendingAlarms", new JObject(
                             new JProperty("IsEnabled", "true"),
                             new JProperty("UpdateInterval", 10),
-                            new JProperty("SnapshotInterval", 20),
-                            new JProperty("CompressedPayload", compressedPayload)
+                            new JProperty("SnapshotInterval", 20)
                         ))));
             }
         }

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublishedNodes/PendingAlarms.json
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublishedNodes/PendingAlarms.json
@@ -10,8 +10,7 @@
         "PendingAlarms": {
           "IsEnabled": true,
           "UpdateInterval": 10,
-          "SnapshotInterval": 20,
-          "CompressedPayload": false
+          "SnapshotInterval": 20
         }
       }
     ]


### PR DESCRIPTION
This PR reverts back payload compression pieces in `crpogace/events-and-alarms` branch as discussed in a [comment](https://github.com/Azure/Industrial-IoT/pull/1667#discussion_r870237159) in #1667. We will keep the changes in a separate branch for future evaluation, but for now they will be reverted back as the implementation was partial and was not covering all encoders.