### PR TITLE
Fixed HttpTunnelTests.TestGetWebAsync() test.

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Module/HttpTunnelTests.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Module/HttpTunnelTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.IIoT.Module.Default {
             Assert.NotNull(payload);
             Assert.NotNull(result.Headers);
             Assert.True(result.Headers.Any());
-            Assert.Contains("<!DOCTYPE html>", payload);
+            Assert.Contains("Microsoft", payload);
         }
 
 


### PR DESCRIPTION
Changes:
* Checking for some other data in `payload` as `<!DOCTYPE html>` does not seem to always be present.