### PR TITLE
Propagating cancellation token to downstream calls in discovery E2E tests.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
@@ -39,7 +39,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
             AddTestOpcServers(endpointUrls, _cancellationTokenSource.Token);
 
             // Discover all servers
-            dynamic result = await TestHelper.Discovery.WaitForDiscoveryToBeCompletedAsync(
+            var result = await TestHelper.Discovery.WaitForDiscoveryToBeCompletedAsync(
                 _context, _cancellationTokenSource.Token, endpointUrls).ConfigureAwait(false);
 
             // Validate that all servers are discovered

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
@@ -33,7 +33,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
         }
 
         [Fact, PriorityOrder(0)]
-        public async Task Test_Discover_All_OPC_UA_Endpoints() {
+        public async Task TestDiscoverAllOpcUaEndpoints() {
             // Add 5 servers
             var endpointUrls = TestHelper.GetSimulatedOpcServerUrls(_context).Take(5).ToList();
             AddTestOpcServers(endpointUrls, _cancellationTokenSource.Token);
@@ -59,7 +59,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
         }
 
         [Fact, PriorityOrder(1)]
-        public async Task Test_Discover_OPC_UA_Endpoints_IpAddress() {
+        public async Task TestDiscoverOpcUaEndpointsIpAddress() {
             // Add 1 server
             var ipAddress = _context.OpcPlcConfig.Urls.Split(TestConstants.SimulationUrlsSeparator).First();
             var url = $"opc.tcp://{ipAddress}:50000";
@@ -91,7 +91,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
         }
 
         [Fact, PriorityOrder(2)]
-        public async Task Test_Discover_OPC_UA_Endpoints_PortRange() {
+        public async Task TestDiscoverOpcUaEndpointsPortRange() {
             // Add 5 servers
             var urls = TestHelper.GetSimulatedOpcServerUrls(_context).Take(5).ToList();
             AddTestOpcServers(urls, _cancellationTokenSource.Token);

--- a/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/Discovery/DiscoveryTestTheory.cs
@@ -9,6 +9,7 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using TestExtensions;
     using Xunit;
     using Xunit.Abstractions;
@@ -32,14 +33,14 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
         }
 
         [Fact, PriorityOrder(0)]
-        public void Test_Discover_All_OPC_UA_Endpoints() {
+        public async Task Test_Discover_All_OPC_UA_Endpoints() {
             // Add 5 servers
             var endpointUrls = TestHelper.GetSimulatedOpcServerUrls(_context).Take(5).ToList();
-            AddTestOpcServers(endpointUrls);
+            AddTestOpcServers(endpointUrls, _cancellationTokenSource.Token);
 
             // Discover all servers
-            var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-            dynamic result = TestHelper.Discovery.WaitForDiscoveryToBeCompletedAsync(_context, cts.Token, requestedEndpointUrls: endpointUrls).GetAwaiter().GetResult();
+            dynamic result = await TestHelper.Discovery.WaitForDiscoveryToBeCompletedAsync(
+                _context, _cancellationTokenSource.Token, endpointUrls).ConfigureAwait(false);
 
             // Validate that all servers are discovered
             var applicationIds = new List<string>(endpointUrls.Count);
@@ -53,17 +54,17 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
 
             // Clean up
             foreach (var applicationId in applicationIds) {
-                RemoveApplication(applicationId);
+                RemoveApplication(applicationId, _cancellationTokenSource.Token);
             }
         }
 
         [Fact, PriorityOrder(1)]
-        public void Test_Discover_OPC_UA_Endpoints_IpAddress() {
+        public async Task Test_Discover_OPC_UA_Endpoints_IpAddress() {
             // Add 1 server
             var ipAddress = _context.OpcPlcConfig.Urls.Split(TestConstants.SimulationUrlsSeparator).First();
             var url = $"opc.tcp://{ipAddress}:50000";
             var urls = new List<string> { url };
-            AddTestOpcServers(urls);
+            AddTestOpcServers(urls, _cancellationTokenSource.Token);
 
             // Registers servers by running a discovery scan
             var cidr = ipAddress + "/16";
@@ -72,23 +73,28 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
                     addressRangesToScan = cidr
                 }
             };
-            TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryDiscover, body);
+            TestHelper.CallRestApi(
+                _context,
+                Method.Post,
+                TestConstants.APIRoutes.RegistryDiscover,
+                body,
+                ct: _cancellationTokenSource.Token
+            );
 
             // Validate that the endpoint can be found
-            var result = TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(_context, _cancellationTokenSource.Token, requestedEndpointUrls: urls).GetAwaiter().GetResult();
+            var result = await TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(
+                _context, _cancellationTokenSource.Token, urls).ConfigureAwait(false);
             Assert.Equal(url, ((string)result.items[0].registration.endpoint.url).TrimEnd('/'));
 
             // Clean up
-            RemoveApplication((string)result.items[0].applicationId);
+            RemoveApplication((string)result.items[0].applicationId, _cancellationTokenSource.Token);
         }
 
         [Fact, PriorityOrder(2)]
-        public void Test_Discover_OPC_UA_Endpoints_PortRange() {
-            var cts = new CancellationTokenSource(TestConstants.MaxTestTimeoutMilliseconds);
-
+        public async Task Test_Discover_OPC_UA_Endpoints_PortRange() {
             // Add 5 servers
             var urls = TestHelper.GetSimulatedOpcServerUrls(_context).Take(5).ToList();
-            AddTestOpcServers(urls);
+            AddTestOpcServers(urls, _cancellationTokenSource.Token);
 
             // Registers servers by running a discovery scan
             var body = new {
@@ -96,10 +102,17 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
                     portRangesToScan = "50000:51000"
                 }
             };
-            TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryDiscover, body);
+            TestHelper.CallRestApi(
+                _context,
+                Method.Post,
+                TestConstants.APIRoutes.RegistryDiscover,
+                body,
+                ct: _cancellationTokenSource.Token
+            );
 
             // Validate that all endpoints are found
-            var result = TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(_context, cts.Token, requestedEndpointUrls: urls).GetAwaiter().GetResult();
+            var result = await TestHelper.Discovery.WaitForEndpointDiscoveryToBeCompleted(
+                _context, _cancellationTokenSource.Token, urls).ConfigureAwait(false);
             var applicationIds = new List<string>(urls.Count);
             foreach (var item in result.items) {
                 Assert.Contains(((string)item.registration.endpoint.url).TrimEnd('/'), urls);
@@ -108,22 +121,22 @@ namespace IIoTPlatform_E2E_Tests.Discovery {
 
             // Clean up
             foreach (var applicationId in applicationIds) {
-                RemoveApplication(applicationId);
+                RemoveApplication(applicationId, _cancellationTokenSource.Token);
             }
         }
 
-        private void AddTestOpcServers(List<string> endpointUrls) {
+        private void AddTestOpcServers(List<string> endpointUrls, CancellationToken ct) {
             foreach (var endpointUrl in endpointUrls) {
                 var body = new {
                     discoveryUrl = endpointUrl
                 };
-                TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryApplications, body);
+                TestHelper.CallRestApi(_context, Method.Post, TestConstants.APIRoutes.RegistryApplications, body, ct: ct);
             }
         }
 
-        private void RemoveApplication(string applicationId) {
+        private void RemoveApplication(string applicationId, CancellationToken ct) {
             var route = $"{TestConstants.APIRoutes.RegistryApplications}/{applicationId}";
-            TestHelper.CallRestApi(_context, Method.Delete, route);
+            TestHelper.CallRestApi(_context, Method.Delete, route, ct: ct);
         }
     }
 }


### PR DESCRIPTION
This PR aims to enforce test timeouts in discovery E2E tests. Current pipeline sometimes encounters situations where single tests do not seem to timeout properly as can be seen [here](https://iotcat.visualstudio.com/Industrial-IoT-E2E-Testing/_build/results?buildId=4817&view=results).