### PR TITLE
Using PCS_AUTH_TENANT instead of PCS_TENANT_ID.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestConstants.cs
@@ -339,11 +339,6 @@ namespace IIoTPlatform_E2E_Tests {
             public const string PCS_IMAGES_TAG = "PCS_IMAGES_TAG";
 
             /// <summary>
-            /// Tenant Id
-            /// </summary>
-            public const string PCS_TENANT_ID = "PCS_TENANT_ID";
-
-            /// <summary>
             /// Resource group name
             /// </summary>
             public const string PCS_RESOURCE_GROUP = "PCS_RESOURCE_GROUP";

--- a/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/TestExtensions/IIoTPlatformTestContext.cs
@@ -226,7 +226,7 @@ namespace IIoTPlatform_E2E_Tests.TestExtensions {
         string IOpcPlcConfig.Urls => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.PLC_SIMULATION_URLS,
             () => throw new Exception("Semicolon separated list of URLs of OPC-PLCs is not provided."));
 
-        string IOpcPlcConfig.TenantId => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.PCS_TENANT_ID,
+        string IOpcPlcConfig.TenantId => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.PCS_AUTH_TENANT,
             () => throw new Exception("Tenant Id is not provided."));
 
         string IOpcPlcConfig.ResourceGroupName => GetStringOrDefault(TestConstants.EnvironmentVariablesNames.PCS_RESOURCE_GROUP,

--- a/tools/e2etesting/DeployStandalone.ps1
+++ b/tools/e2etesting/DeployStandalone.ps1
@@ -113,7 +113,7 @@ $SubscriptionId = $context.Subscription.Id
 
 Write-Host "Adding/Updating KeyVault-Secret 'PCS-IOTHUB-CONNSTRING' with value '***'..."
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-IOTHUB-CONNSTRING' -SecretValue (ConvertTo-SecureString $connectionString.PrimaryConnectionString -AsPlainText -Force) | Out-Null
-Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-TENANT-ID' -SecretValue (ConvertTo-SecureString $TenantId -AsPlainText -Force) | Out-Null
+Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-AUTH-TENANT' -SecretValue (ConvertTo-SecureString $TenantId -AsPlainText -Force) | Out-Null
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-SUBSCRIPTION-ID' -SecretValue (ConvertTo-SecureString $SubscriptionId -AsPlainText -Force) | Out-Null
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-RESOURCE-GROUP' -SecretValue (ConvertTo-SecureString $ResourceGroupName -AsPlainText -Force) | Out-Null
 

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -55,7 +55,7 @@ steps:
   inputs:
     azureSubscription: '$(AzureSubscription)'
     KeyVaultName: '$(KeyVaultName)'
-    SecretsFilter: 'PCS-IOTHUB-CONNSTRING,plc-simulation-urls,iot-edge-vm-username,iot-edge-vm-publickey,iot-edge-vm-privatekey,iot-edge-device-id,iot-edge-device-dnsname,testeventprocessor-baseurl,testeventprocessor-username,testeventprocessor-password,iothub-eventhub-connectionstring,storageaccount-iothubcheckpoint-connectionstring,PCS-TENANT-ID,PCS-SUBSCRIPTION-ID'
+    SecretsFilter: 'PCS-IOTHUB-CONNSTRING,plc-simulation-urls,iot-edge-vm-username,iot-edge-vm-publickey,iot-edge-vm-privatekey,iot-edge-device-id,iot-edge-device-dnsname,testeventprocessor-baseurl,testeventprocessor-username,testeventprocessor-password,iothub-eventhub-connectionstring,storageaccount-iothubcheckpoint-connectionstring,PCS-AUTH-TENANT,PCS-SUBSCRIPTION-ID'
 
 - task: AzureKeyVault@1
   displayName: 'Retrieve KeyVault secrets for API tests'
@@ -63,7 +63,7 @@ steps:
   inputs:
     azureSubscription: '$(AzureSubscription)'
     KeyVaultName: '$(KeyVaultName)'
-    SecretsFilter: 'PCS-SERVICE-URL,PCS-AUTH-TENANT,PCS-AUTH-CLIENT-APPID,PCS-AUTH-CLIENT-SECRET'
+    SecretsFilter: 'PCS-SERVICE-URL,PCS-AUTH-CLIENT-APPID,PCS-AUTH-CLIENT-SECRET'
 
 - task: AzureKeyVault@1
   displayName: 'Load secrets from Key Vault as variables by default'
@@ -127,6 +127,5 @@ steps:
     IOT_EDGE_VERSION: "$(EdgeVersion)"
     NESTED_EDGE_FLAG: "$(NestedEdgeFlag)"
     NESTED_EDGE_SSH_CONNECTIONS: "$(NestedEdgeSshConnection)"
-    PCS_TENANT_ID: '$(PCS-TENANT-ID)'
     PCS_SUBSCRIPTION_ID: '$(PCS-SUBSCRIPTION-ID)'
     PCS_RESOURCE_GROUP: '$(ResourceGroupName)'


### PR DESCRIPTION
This PR aligns name of the variable for the tenant in standalone and orchestrated E2E tests. The discrepancy was causing failure of orchestrated tests.