### PR TITLE
Enabling OPC Events related unit tests.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api/src/Core/Models/PendingAlarmsOptionsApiModel.cs
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api/src/Core/Models/PendingAlarmsOptionsApiModel.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Azure.IIoT.OpcUa.Api.Core.Models {
         public bool IsEnabled { get; set; } = false;
 
         /// <summary>
-        /// Update interval for pending alarm
+        /// Update interval for pending alarm in seconds.
         /// </summary>
         [DataMember(Name = "updateInterval", Order = 1,
             EmitDefaultValue = false)]
         public int? UpdateInterval { get; set; }
 
         /// <summary>
-        /// Snapshot interval for pending alarm
+        /// Snapshot interval for pending alarm in seconds.
         /// </summary>
         [DataMember(Name = "snapshotInterval", Order = 2,
             EmitDefaultValue = false)]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Extensions/WriterGroupModelEx.cs
@@ -20,11 +20,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
         public static IWriterGroupConfig ToWriterGroupJobConfiguration(
             this WriterGroupJobModel model, string publisherId) {
             return new WriterGroupJobConfig {
+                // IWriterGroupConfig
+                PublisherId = publisherId,
+                WriterGroup = model.WriterGroup,
+                // IEngineConfiguration
                 BatchSize = model.Engine?.BatchSize,
                 BatchTriggerInterval = model.Engine?.BatchTriggerInterval,
-                PublisherId = publisherId,
                 DiagnosticsInterval = model.Engine?.DiagnosticsInterval,
-                WriterGroup = model.WriterGroup,
                 MaxMessageSize = model.Engine?.MaxMessageSize,
                 MaxOutgressMessages = model.Engine?.MaxOutgressMessages,
                 UseReversibleEncoding = model.Engine?.UseReversibleEncoding,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Runtime/WriterGroupJobConfig.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Runtime {
         IEngineConfiguration {
 
         /// <inheritdoc/>
+        public string PublisherId { get; set; }
+
+        /// <inheritdoc/>
         public WriterGroupModel WriterGroup { get; set; }
 
         /// <inheritdoc/>
@@ -28,9 +31,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Runtime {
 
         /// <inheritdoc/>
         public TimeSpan? DiagnosticsInterval { get; set; }
-
-        /// <inheritdoc/>
-        public string PublisherId { get; set; }
 
         /// <inheritdoc/>
         public int? MaxOutgressMessages { get; set; }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -131,7 +131,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                         //  Prio 1: DataSetFieldId (need to be read from message)
                                         //  Prio 2: DisplayName - nothing to do, because notification.Id
                                         //                        already contains DisplayName
-                                        //  Prio 3: NodeId as configured; Id remains null in this case
                                         Id = !string.IsNullOrEmpty(node.Item2.DataSetFieldId)
                                             ? node.Item2.DataSetFieldId
                                             : node.Item2.DisplayName,
@@ -154,7 +153,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
                                         //  Prio 1: DataSetFieldId (need to be read from message)
                                         //  Prio 2: DisplayName - nothing to do, because notification.Id
                                         //                        already contains DisplayName
-                                        //  Prio 3: NodeId as configured; Id remains null in this case
                                         Id = !string.IsNullOrEmpty(node.Item2.DataSetFieldId)
                                             ? node.Item2.DataSetFieldId
                                             : node.Item2.DisplayName,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Storage/PublishedNodesJobConverter.cs
@@ -175,14 +175,17 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Models {
 
                 var result = flattenedGroups.Select(dataSetSourceBatches => dataSetSourceBatches.Any() ? new WriterGroupJobModel {
                     MessagingMode = standaloneCliModel.MessagingMode,
-                    Engine = _engineConfig == null ? null : new EngineConfigurationModel {
-                        BatchSize = _engineConfig.BatchSize,
-                        BatchTriggerInterval = _engineConfig.BatchTriggerInterval,
-                        DiagnosticsInterval = _engineConfig.DiagnosticsInterval,
-                        MaxMessageSize = _engineConfig.MaxMessageSize,
-                        MaxOutgressMessages = _engineConfig.MaxOutgressMessages,
-                        EnableRoutingInfo = _engineConfig.EnableRoutingInfo,
-                    },
+                    Engine = _engineConfig == null
+                        ? null
+                        : new EngineConfigurationModel {
+                            BatchSize = _engineConfig.BatchSize,
+                            BatchTriggerInterval = _engineConfig.BatchTriggerInterval,
+                            DiagnosticsInterval = _engineConfig.DiagnosticsInterval,
+                            MaxMessageSize = _engineConfig.MaxMessageSize,
+                            MaxOutgressMessages = _engineConfig.MaxOutgressMessages,
+                            UseReversibleEncoding = _engineConfig.UseReversibleEncoding,
+                            EnableRoutingInfo = _engineConfig.EnableRoutingInfo,
+                        },
                     WriterGroup = new WriterGroupModel {
                         MessageType = standaloneCliModel.MessageEncoding,
                         WriterGroupId = dataSetSourceBatches.First().Connection.Group,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -2153,7 +2153,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
         ""EndpointUrl"": ""opc.tcp://localhost3:50000"",
         ""OpcNodes"": [
             {
-                ""ExpandedNodeId"": ""nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean""
+                ""ExpandedNodeId"": ""nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean"",
+                ""DisplayName"": ""AlternatingBoolean""
             },
             {
                 ""Id"": ""i=2253"",
@@ -2235,19 +2236,16 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             Assert.Empty(jobs[3].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData);
 
             var dataItemModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            //Assert.Equal("i=2258", dataItemModel.Id);
             Assert.Equal("i=2258", dataItemModel.PublishedVariableNodeId);
 
             dataItemModel = jobs[1].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            //Assert.Equal("ns=0;i=2261", dataItemModel.Id);
             Assert.Equal("ns=0;i=2261", dataItemModel.PublishedVariableNodeId);
 
             dataItemModel = jobs[2].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            //Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean", dataItemModel.Id);
+            Assert.Equal("AlternatingBoolean", dataItemModel.Id);
             Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean", dataItemModel.PublishedVariableNodeId);
 
             var eventModel = jobs[2].WriterGroup.DataSetWriters[1].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            //Assert.Equal("i=2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Single(eventModel.SelectClauses);
             Assert.Equal("i=2041", eventModel.SelectClauses[0].TypeDefinitionId);
@@ -2270,6 +2268,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
         ""OpcNodes"": [
             {
                 ""Id"": ""i=2253"",
+                ""DisplayName"": ""DisplayName2253"",
                 ""OpcPublishingInterval"": 5000,
                 ""EventFilter"": {
                     ""SelectClauses"": [
@@ -2387,7 +2386,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                Assert.Single(dataSetWriter.DataSet.DataSetSource.PublishedEvents.PublishedData));
 
             var eventModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            //Assert.Equal("i=2253", eventModel.Id);
+            Assert.Equal("DisplayName2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Equal(11, eventModel.SelectClauses.Count);
             Assert.All(eventModel.SelectClauses, x => {
@@ -2462,7 +2461,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                Assert.Single(dataSetWriter.DataSet.DataSetSource.PublishedEvents.PublishedData));
 
             var eventModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            //Assert.Equal("i=2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Equal("ns=2;i=235", eventModel.TypeDefinitionId);
             Assert.NotNull(eventModel.PendingAlarms);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -2076,7 +2076,6 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
     }
 ]
 ");
-            using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
 
             // ToDo: Add definition for events in schema validator.
             //using var schemaReader = new StreamReader("Storage/publishednodesschema.json");

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -2029,45 +2029,47 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                     dataSetWriter.DataSet.DataSetSource.PublishedVariables.PublishedData.Count));
         }
 
-        // ToDo: Add definition for OpcEvents in publishednodesschema.json.
-        [Fact(Skip = "publishednodesschema.json does not contain definition for OpcEvents.")]
-        public async Task PnPlcJobWithAllEventPropertiesTest() {
+        [Fact]
+        public void PnPlcJobWithAllEventPropertiesTest() {
             var pn = new StringBuilder(@"
 [
     {
         ""EndpointUrl"": ""opc.tcp://localhost:50000"",
-        ""OpcEvents"": [
+        ""OpcNodes"": [
             {
                 ""Id"": ""i=2258"",
-                ""SelectClauses"": [
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""EventId""
-                        ],
-                        ""AttributeId"": ""BrowseName"",
-                        ""IndexRange"": ""5:20""
-                    }
-                ],
-                ""WhereClause"": {
-                    ""Elements"": [
+                ""DisplayName"": ""TestingDisplayName"",
+                ""EventFilter"": {
+                    ""SelectClauses"": [
                         {
-                            ""FilterOperator"": ""OfType"",
-                            ""FilterOperands"": [
-                                {
-                                    ""NodeId"": ""i=2041"",
-                                    ""BrowsePath"": [
-                                        ""EventId""
-                                    ],
-                                    ""AttributeId"": ""BrowseName"",
-                                    ""Value"": ""ns=2;i=235"",
-                                    ""IndexRange"": ""5:20"",
-                                    ""Index"": 10,
-                                    ""Alias"": ""Test"",
-                                }
-                            ]
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""EventId""
+                            ],
+                            ""AttributeId"": ""BrowseName"",
+                            ""IndexRange"": ""5:20""
                         }
-                    ]
+                    ],
+                    ""WhereClause"": {
+                        ""Elements"": [
+                            {
+                                ""FilterOperator"": ""OfType"",
+                                ""FilterOperands"": [
+                                    {
+                                        ""NodeId"": ""i=2041"",
+                                        ""BrowsePath"": [
+                                            ""EventId""
+                                        ],
+                                        ""AttributeId"": ""BrowseName"",
+                                        ""Value"": ""ns=2;i=235"",
+                                        ""IndexRange"": ""5:20"",
+                                        ""Index"": 10,
+                                        ""Alias"": ""Test"",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         ]
@@ -2075,6 +2077,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
 ]
 ");
             using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+
+            // ToDo: Add definition for events in schema validator.
+            //using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            //var publishedNodesSchemaContent = await schemaReader.ReadToEndAsync().ConfigureAwait(false);
+            //using var publishedNodesSchemaFile = new StringReader(publishedNodesSchemaContent);
+
+            TextReader publishedNodesSchemaFile = null;
 
             var engineConfigMock = new Mock<IEngineConfiguration>();
             var clientConfignMock = new Mock<IClientServicesConfig>();
@@ -2084,7 +2093,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                 engineConfigMock.Object, clientConfignMock.Object);
 
             var standaloneCli = new StandaloneCliModel();
-            var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
+            var entries = converter.Read(pn.ToString(), publishedNodesSchemaFile);
             var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             // Check jobs
@@ -2098,7 +2107,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
 
             // Check model
             var model = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            Assert.Equal("i=2258", model.Id);
+            Assert.Equal("TestingDisplayName", model.Id);
             Assert.Equal("i=2258", model.EventNotifier);
 
             // Check select clauses
@@ -2125,9 +2134,8 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             Assert.Equal("Test", model.WhereClause.Elements[0].FilterOperands[0].Alias);
         }
 
-        // ToDo: Parts of job converter for OpcEvents are commented out for now. So parts of the test that check this bellow are also commented out.
-        [Fact(Skip = "PublishedNodesJobConverter does not parse OpcEvents now.")]
-        public async Task PnPlcMultiJob1TestWithDataItemsAndEvents() {
+        [Fact]
+        public void PnPlcMultiJob1TestWithDataItemsAndEvents() {
             var pn = @"
 [
     {
@@ -2147,31 +2155,31 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
         ""OpcNodes"": [
             {
                 ""ExpandedNodeId"": ""nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean""
-            }
-        ],
-        ""OpcEvents"": [
+            },
             {
                 ""Id"": ""i=2253"",
                 ""OpcPublishingInterval"": 5000,
-                ""SelectClauses"": [
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""EventId""
-                        ]
-                    }
-                ],
-                ""WhereClause"": {
-                    ""Elements"": [
+                ""EventFilter"": {
+                    ""SelectClauses"": [
                         {
-                            ""FilterOperator"": ""OfType"",
-                            ""FilterOperands"": [
-                                {
-                                    ""Value"": ""ns=2;i=235""
-                                }
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""EventId""
                             ]
                         }
-                    ]
+                    ],
+                    ""WhereClause"": {
+                        ""Elements"": [
+                            {
+                                ""FilterOperator"": ""OfType"",
+                                ""FilterOperands"": [
+                                    {
+                                        ""Value"": ""ns=2;i=235""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         ]
@@ -2192,7 +2200,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
     }
 ]
 ";
-            using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+
+            // ToDo: Add definition for events in schema validator.
+            //using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            //var publishedNodesSchemaContent = await schemaReader.ReadToEndAsync().ConfigureAwait(false);
+            //using var publishedNodesSchemaFile = new StringReader(publishedNodesSchemaContent);
+
+            TextReader publishedNodesSchemaFile = null;
 
             var engineConfigMock = new Mock<IEngineConfiguration>();
             var clientConfignMock = new Mock<IClientServicesConfig>();
@@ -2202,7 +2216,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                 engineConfigMock.Object, clientConfignMock.Object);
 
             var standaloneCli = new StandaloneCliModel();
-            var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
+            var entries = converter.Read(pn, publishedNodesSchemaFile);
             var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             Assert.Equal(4, jobs.Count);
@@ -2222,19 +2236,19 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             Assert.Empty(jobs[3].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData);
 
             var dataItemModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            Assert.Equal("i=2258", dataItemModel.Id);
+            //Assert.Equal("i=2258", dataItemModel.Id);
             Assert.Equal("i=2258", dataItemModel.PublishedVariableNodeId);
 
             dataItemModel = jobs[1].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            Assert.Equal("ns=0;i=2261", dataItemModel.Id);
+            //Assert.Equal("ns=0;i=2261", dataItemModel.Id);
             Assert.Equal("ns=0;i=2261", dataItemModel.PublishedVariableNodeId);
 
             dataItemModel = jobs[2].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedVariables.PublishedData[0];
-            Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean", dataItemModel.Id);
+            //Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean", dataItemModel.Id);
             Assert.Equal("nsu=http://microsoft.com/Opc/OpcPlc/;s=AlternatingBoolean", dataItemModel.PublishedVariableNodeId);
 
             var eventModel = jobs[2].WriterGroup.DataSetWriters[1].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            Assert.Equal("i=2253", eventModel.Id);
+            //Assert.Equal("i=2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Single(eventModel.SelectClauses);
             Assert.Equal("i=2041", eventModel.SelectClauses[0].TypeDefinitionId);
@@ -2247,97 +2261,98 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             Assert.Equal("ns=2;i=235", eventModel.WhereClause.Elements[0].FilterOperands[0].Value);
         }
 
-        // ToDo: Add definition for OpcEvents in publishednodesschema.json.
-        [Fact (Skip = "publishednodesschema.json does not contain definition for OpcEvents.")]
-        public async Task PnPlcJobTestWithEvents() {
+        [Fact]
+        public void PnPlcJobTestWithEvents() {
             var pn = @"
 [
     {
         ""EndpointUrl"": ""opc.tcp://desktop-fhd2fr4:62563/Quickstarts/SimpleEventsServer"",
         ""UseSecurity"": false,
-        ""OpcEvents"": [
+        ""OpcNodes"": [
             {
                 ""Id"": ""i=2253"",
                 ""OpcPublishingInterval"": 5000,
-                ""SelectClauses"": [
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""EventId""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""EventType""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""SourceNode""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""SourceName""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""Time""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""ReceiveTime""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""LocalTime""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""Message""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""Severity""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""2:CycleId""
-                        ]
-                    },
-                    {
-                        ""TypeDefinitionId"": ""i=2041"",
-                        ""BrowsePath"": [
-                            ""2:CurrentStep""
-                        ]
-                    }
-                ],
-                ""WhereClause"": {
-                    ""Elements"": [
+                ""EventFilter"": {
+                    ""SelectClauses"": [
                         {
-                            ""FilterOperator"": ""OfType"",
-                            ""FilterOperands"": [
-                                {
-                                    ""Value"": ""ns=2;i=235""
-                                }
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""EventId""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""EventType""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""SourceNode""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""SourceName""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""Time""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""ReceiveTime""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""LocalTime""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""Message""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""Severity""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""2:CycleId""
+                            ]
+                        },
+                        {
+                            ""TypeDefinitionId"": ""i=2041"",
+                            ""BrowsePath"": [
+                                ""2:CurrentStep""
                             ]
                         }
-                    ]
+                    ],
+                    ""WhereClause"": {
+                        ""Elements"": [
+                            {
+                                ""FilterOperator"": ""OfType"",
+                                ""FilterOperands"": [
+                                    {
+                                        ""Value"": ""ns=2;i=235""
+                                    }
+                                ]
+                            }
+                        ]
+                    }
                 }
             }
         ]
@@ -2345,7 +2360,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
 ]
 ";
 
-            using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            // ToDo: Add definition for events in schema validator.
+            //using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            //var publishedNodesSchemaContent = await schemaReader.ReadToEndAsync().ConfigureAwait(false);
+            //using var publishedNodesSchemaFile = new StringReader(publishedNodesSchemaContent);
+
+            TextReader publishedNodesSchemaFile = null;
 
             var engineConfigMock = new Mock<IEngineConfiguration>();
             var clientConfignMock = new Mock<IClientServicesConfig>();
@@ -2355,7 +2375,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                 engineConfigMock.Object, clientConfignMock.Object);
 
             var standaloneCli = new StandaloneCliModel();
-            var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
+            var entries = converter.Read(pn, publishedNodesSchemaFile);
             var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             Assert.NotEmpty(jobs);
@@ -2368,7 +2388,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                Assert.Single(dataSetWriter.DataSet.DataSetSource.PublishedEvents.PublishedData));
 
             var eventModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            Assert.Equal("i=2253", eventModel.Id);
+            //Assert.Equal("i=2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Equal(11, eventModel.SelectClauses.Count);
             Assert.All(eventModel.SelectClauses, x => {
@@ -2390,23 +2410,24 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
             }, eventModel.SelectClauses.Select(x => x.BrowsePath[0]));
         }
 
-        // ToDo: Add definition for OpcEvents in publishednodesschema.json.
-        [Fact(Skip = "publishednodesschema.json does not contain definition for OpcEvents.")]
-        public async Task PnPlcJobTestWithPendingAlarms() {
+        [Fact]
+        public void PnPlcJobTestWithPendingAlarms() {
             var pn = @"
 [
     {
         ""EndpointUrl"": ""opc.tcp://desktop-fhd2fr4:62563/Quickstarts/SimpleEventsServer"",
         ""UseSecurity"": false,
-        ""OpcEvents"": [
+        ""OpcNodes"": [
             {
                 ""Id"": ""i=2253"",
                 ""OpcPublishingInterval"": 5000,
-                ""TypeDefinitionId"": ""ns=2;i=235"",
-                ""PendingAlarms"": {
-                    ""IsEnabled"": true,
-                    ""UpdateInterval"": 10000,
-                    ""SnapshotInterval"": 20000
+                ""EventFilter"": {
+                    ""TypeDefinitionId"": ""ns=2;i=235"",
+                    ""PendingAlarms"": {
+                        ""IsEnabled"": true,
+                        ""UpdateInterval"": 10000,
+                        ""SnapshotInterval"": 20000
+                    }
                 }
             }
         ]
@@ -2414,7 +2435,12 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
 ]
 ";
 
-            using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            // ToDo: Add definition for events in schema validator.
+            //using var schemaReader = new StreamReader("Storage/publishednodesschema.json");
+            //var publishedNodesSchemaContent = await schemaReader.ReadToEndAsync().ConfigureAwait(false);
+            //using var publishedNodesSchemaFile = new StringReader(publishedNodesSchemaContent);
+
+            TextReader publishedNodesSchemaFile = null;
 
             var engineConfigMock = new Mock<IEngineConfiguration>();
             var clientConfignMock = new Mock<IClientServicesConfig>();
@@ -2424,7 +2450,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                 engineConfigMock.Object, clientConfignMock.Object);
 
             var standaloneCli = new StandaloneCliModel();
-            var entries = converter.Read(pn.ToString(), new StringReader(await schemaReader.ReadToEndAsync()));
+            var entries = converter.Read(pn, publishedNodesSchemaFile);
             var jobs = converter.ToWriterGroupJobs(entries, standaloneCli).ToList();
 
             Assert.NotEmpty(jobs);
@@ -2437,7 +2463,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Storage {
                Assert.Single(dataSetWriter.DataSet.DataSetSource.PublishedEvents.PublishedData));
 
             var eventModel = jobs[0].WriterGroup.DataSetWriters[0].DataSet.DataSetSource.PublishedEvents.PublishedData[0];
-            Assert.Equal("i=2253", eventModel.Id);
+            //Assert.Equal("i=2253", eventModel.Id);
             Assert.Equal("i=2253", eventModel.EventNotifier);
             Assert.Equal("ns=2;i=235", eventModel.TypeDefinitionId);
             Assert.NotNull(eventModel.PendingAlarms);

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/src/Services/PublisherJobService.cs
@@ -276,6 +276,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Services {
                             DiagnosticsInterval = TimeSpan.FromSeconds(60),
                             MaxMessageSize = 0,
                             MaxOutgressMessages = DefaultMaxOutgressMessages.Value,
+                            UseReversibleEncoding = false,
                             EnableRoutingInfo = false,
                         };
                     }
@@ -313,6 +314,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Services {
                     DiagnosticsInterval = TimeSpan.FromSeconds(60),
                     MaxMessageSize = 0,
                     MaxOutgressMessages = DefaultMaxOutgressMessages.Value,
+                    UseReversibleEncoding = false,
                     EnableRoutingInfo = false
                 },
                 ConnectionString = null

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Extensions/PublisherConfigModelEx.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Models {
                 DiagnosticsInterval = model.DiagnosticsInterval,
                 MaxMessageSize = model.MaxMessageSize,
                 MaxOutgressMessages = model.MaxOutgressMessages,
+                UseReversibleEncoding = model.UseReversibleEncoding,
                 EnableRoutingInfo = model.EnableRoutingInfo,
             };
         }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/Events/PendingAlarmsOptionsModel.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Publisher/Models/Events/PendingAlarmsOptionsModel.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
         public bool IsEnabled { get; set; } = false;
 
         /// <summary>
-        /// Time interval for sending pending interval updates
+        /// Time interval for sending pending interval updates in seconds.
         /// </summary>
         [DataMember(EmitDefaultValue = true)]
         public int? UpdateInterval { get; set; } = 30000;
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Publisher.Config.Models.Events {
         }
 
         /// <summary>
-        /// Time interval for sending pending interval snapshot
+        /// Time interval for sending pending interval snapshot in seconds.
         /// </summary>
         [DataMember(EmitDefaultValue = true)]
         public int? SnapshotInterval { get; set; } = 60000;

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Agent/PublisherJobsConfiguration.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Agent/PublisherJobsConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
@@ -45,7 +45,12 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
         public async Task CanSendPendingAlarmsToIoTHubTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var messages = await ProcessMessagesAsync(publishedNodesFile, new TimeSpan(0, 0, 1), new TimeSpan(0, 2, 0), 1);
+            var messages = await ProcessMessagesAsync(
+                publishedNodesFile,
+                new TimeSpan(0, 0, 1),
+                new TimeSpan(0, 2, 0),
+                1
+            );
 
             // Assert
             Assert.Single(messages);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/BasicIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
         public async Task CanSendDataItemToIoTHubTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var messages = await ProcessMessagesAsync(publishedNodesFile);
+            var messages = await ProcessMessagesAsync(publishedNodesFile).ConfigureAwait(false);
 
             // Assert
             Assert.Single(messages);
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
         public async Task CanSendEventToIoTHubTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var messages = await ProcessMessagesAsync(publishedNodesFile);
+            var messages = await ProcessMessagesAsync(publishedNodesFile).ConfigureAwait(false);
 
             // Assert
             Assert.Single(messages);
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
                 new TimeSpan(0, 0, 1),
                 new TimeSpan(0, 2, 0),
                 1
-            );
+            ).ConfigureAwait(false);
 
             // Assert
             Assert.Single(messages);

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublishedNodes/SimpleEvents.json
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublishedNodes/SimpleEvents.json
@@ -6,6 +6,7 @@
       {
         "Id": "i=2253",
         "DisplayName": "SimpleEvents",
+        "QueueSize": 10,
         "EventFilter": {
           "SelectClauses": [
             {

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublisherIntegrationTestBase.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/PublisherIntegrationTestBase.cs
@@ -82,7 +82,11 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             string[] arguments = default) {
 
             // publishedNodesFile points to the local server on the same machine and port currently as tests are run one at a time (not parallel) it does not need randomly generated port numbers.
-            _ = Task.Run(() => HostPublisherAsync(Mock.Of<ILogger>(), publishedNodesFile, arguments = arguments ?? Array.Empty<string>()));
+            _ = Task.Run(() => HostPublisherAsync(
+                Mock.Of<ILogger>(),
+                publishedNodesFile,
+                arguments ?? Array.Empty<string>()
+            ));
 
             var stopWatch = new Stopwatch();
             stopWatch.Start();

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             var result = await ProcessMessagesAsync(
                 publishedNodesFile,
                 new[] { "--mm=PubSub", "--UseReversibleEncoding=False" }
-            );
+            ).ConfigureAwait(false);
 
             Assert.Single(result);
 
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             var result = await ProcessMessagesAsync(
                 publishedNodesFile,
                 new[] { "--mm=PubSub", "--UseReversibleEncoding=True" }
-            );
+            ).ConfigureAwait(false);
 
             Assert.Single(result);
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             var result = await ProcessMessagesAsync(
                 publishedNodesFile,
                 new[] { "--mm=PubSub", "--UseReversibleEncoding=True" }
-            );
+            ).ConfigureAwait(false);
 
             Assert.Single(result);
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/ReversibleEncodingIntegrationTests.cs
@@ -23,13 +23,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
         private const string kCycleId = "http://opcfoundation.org/SimpleEvents#CycleId";
         private const string kCurrentStep = "http://opcfoundation.org/SimpleEvents#CurrentStep";
 
-        // ToDo: Parts of job converter for OpcEvents are commented out for now.
-        [Theory(Skip = "PublishedNodesJobConverter does not parse OpcEvents now.")]
+        [Theory]
         [InlineData(@"./PublishedNodes/SimpleEvents.json")]
         public async Task CanEncodeWithoutReversibleEncodingTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var result = await ProcessMessagesAsync(publishedNodesFile, arguments: new[] { "--mm=PubSub", "--UseReversibleEncoding=False" });
+            var result = await ProcessMessagesAsync(
+                publishedNodesFile,
+                new[] { "--mm=PubSub", "--UseReversibleEncoding=False" }
+            );
 
             Assert.Single(result);
 
@@ -55,13 +57,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             });
         }
 
-        // ToDo: Parts of job converter for OpcEvents are commented out for now.
-        [Theory(Skip = "PublishedNodesJobConverter does not parse OpcEvents now.")]
+        [Theory]
         [InlineData(@"./PublishedNodes/SimpleEvents.json")]
         public async Task CanEncodeWithReversibleEncodingTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var result = await ProcessMessagesAsync(publishedNodesFile, arguments: new[] { "--mm=PubSub", "--UseReversibleEncoding=True" });
+            var result = await ProcessMessagesAsync(
+                publishedNodesFile,
+                new[] { "--mm=PubSub", "--UseReversibleEncoding=True" }
+            );
 
             Assert.Single(result);
 
@@ -107,13 +111,15 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Tests {
             });
         }
 
-        // ToDo: Parts of job converter for OpcEvents are commented out for now.
-        [Theory(Skip = "PublishedNodesJobConverter does not parse OpcEvents now.")]
+        [Theory]
         [InlineData(@"./PublishedNodes/SimpleEvents.json")]
         public async Task CanDecodeWithReversibleEncodingTest(string publishedNodesFile) {
             // Arrange
             // Act
-            var result = await ProcessMessagesAsync(publishedNodesFile, arguments: new[] { "--mm=PubSub", "--UseReversibleEncoding=True" });
+            var result = await ProcessMessagesAsync(
+                publishedNodesFile,
+                new[] { "--mm=PubSub", "--UseReversibleEncoding=True" }
+            );
 
             Assert.Single(result);
 


### PR DESCRIPTION
Changes:
* Enabled OPC events related tests in `PublishedNodesJobConverterTests`.
* Removed comment about priorities of id generation that is no longer valid.
* Enabled tests in `ReversibleEncodingIntegrationTests` suite.
* Minor addition to comments.