### PR TITLE
Upgraded SSH.NET package to 2020.0.2 to address CVE-2022-29245.

### DIFF
--- a/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
+++ b/e2e-tests/IIoTPlatform-E2E-Tests/IIoTPlatform-E2E-Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.24" />
     <PackageReference Include="RestSharp" Version="107.2.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.1" />
+    <PackageReference Include="SSH.NET" Version="2020.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgraded SSH.NET package to `2020.0.2` to address [CVE-2022-29245](https://nvd.nist.gov/vuln/detail/CVE-2022-29245).