### PR TITLE
Consolidating versions of FluentAssertions NuGet package.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Using `6.2.0` version of `FluentAssertions` NuGet package in all projects.