### PR TITLE
Using managed windows-2019 agents for E2E tests.

### DIFF
--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -27,10 +27,16 @@ schedules:
 #         - refs/heads/release/*
 #         - refs/heads/main
 
+# pool:
+#   name: '$(AgentPool)'
+#   demands:
+#   - agent.os -equals Windows_NT
+
+# pool:
+#   name: Hosted Windows 2019 with VS2019
+
 pool:
-  name: '$(AgentPool)'
-  demands:
-  - agent.os -equals Windows_NT
+  vmImage: 'windows-2019'
 
 variables:
 - template: steps/variables.yml

--- a/tools/e2etesting/pipeline_orchestrated.yml
+++ b/tools/e2etesting/pipeline_orchestrated.yml
@@ -27,14 +27,6 @@ schedules:
 #         - refs/heads/release/*
 #         - refs/heads/main
 
-# pool:
-#   name: '$(AgentPool)'
-#   demands:
-#   - agent.os -equals Windows_NT
-
-# pool:
-#   name: Hosted Windows 2019 with VS2019
-
 pool:
   vmImage: 'windows-2019'
 

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -28,14 +28,6 @@ schedules:
 #         - refs/heads/release/*
 #         - refs/heads/main
 
-# pool:
-#   name: '$(AgentPool)'
-#   demands:
-#   - agent.os -equals Windows_NT
-
-# pool:
-#   name: Hosted Windows 2019 with VS2019
-
 pool:
   vmImage: 'windows-2019'
 

--- a/tools/e2etesting/pipeline_standalone.yml
+++ b/tools/e2etesting/pipeline_standalone.yml
@@ -28,10 +28,16 @@ schedules:
 #         - refs/heads/release/*
 #         - refs/heads/main
 
+# pool:
+#   name: '$(AgentPool)'
+#   demands:
+#   - agent.os -equals Windows_NT
+
+# pool:
+#   name: Hosted Windows 2019 with VS2019
+
 pool:
-  name: '$(AgentPool)'
-  demands:
-  - agent.os -equals Windows_NT
+  vmImage: 'windows-2019'
 
 variables:
 - template: steps/variables.yml

--- a/tools/e2etesting/steps/cleanup.yml
+++ b/tools/e2etesting/steps/cleanup.yml
@@ -22,8 +22,8 @@ steps:
     scriptType: 'InlineScript'
     inline: |
       Write-Host "Deleting AD App Registration: '$(ApplicationName)-aks' ..."
-      Remove-AzADApplication -DisplayName "$(ApplicationName)-aks" -Force -ErrorAction SilentlyContinue
+      Remove-AzADApplication -DisplayName "$(ApplicationName)-aks" -ErrorAction SilentlyContinue
       Write-Host "Deleting AD App Registration: '$(ApplicationName)-client' ..."
-      Remove-AzADApplication -DisplayName "$(ApplicationName)-client" -Force -ErrorAction SilentlyContinue
+      Remove-AzADApplication -DisplayName "$(ApplicationName)-client" -ErrorAction SilentlyContinue
       Write-Host "Deleting AD App Registration: '$(ApplicationName)-service' ..."
-      Remove-AzADApplication -DisplayName "$(ApplicationName)-service" -Force -ErrorAction SilentlyContinue
+      Remove-AzADApplication -DisplayName "$(ApplicationName)-service" -ErrorAction SilentlyContinue

--- a/tools/e2etesting/steps/variables.yml
+++ b/tools/e2etesting/steps/variables.yml
@@ -4,7 +4,6 @@ variables:
   DevAcrCredentialsKeyVaultName: kv-developer-pipeline
   ReleaseAcrCredentialsKeyVaultName: kv-release-pipeline
   AzureSubscription: IIOT_TEST-SP # Use Services-Connection with Service-Principal-Authentication as subscription
-  AgentPool: Azure-IoT-Manufacturing
   IAILocalFilename: Microsoft.Azure.IIoT.Deployment.exe
   TestPath: $(System.DefaultWorkingDirectory)\e2e-tests\IIoTPlatform-E2E-Tests
   Runtime: 'win-x64'


### PR DESCRIPTION
* Using managed `windows-2019` agents for E2E tests.
* Removed `-Force` from `Remove-AzADApplication` call.