### PR TITLE
IAI: Upgraded Kubernetes version in AKS from 1.21.9 to 1.22.6.

### DIFF
--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Infrastructure/AksMgmtClient.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Azure.IIoT.Deployment.Infrastructure {
         public const string NETWORK_PROFILE_DNS_SERVICE_IP = "10.0.0.10";
         public const string NETWORK_PROFILE_DOCKER_BRIDGE_CIDR = "172.17.0.1/16";
 
-        public const string KUBERNETES_VERSION_FALLBACK = "1.21.9";
-        public const string KUBERNETES_VERSION_MAJ_MIN = "1.21";
+        public const string KUBERNETES_VERSION_FALLBACK = "1.22.6";
+        public const string KUBERNETES_VERSION_MAJ_MIN = "1.22";
 
         private readonly ContainerServiceManagementClient _containerServiceManagementClient;
 

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -609,7 +609,7 @@ The following Azure regions are supported by `Microsoft.Azure.IIoT.Deployment` f
 ### AKS
 
 All cloud microservices of Azure Industrial IoT solution are deployed to an AKS Kubernetes cluster.
-`Microsoft.Azure.IIoT.Deployment` deploys latest available patch version of `1.21` Kubernetes.
+`Microsoft.Azure.IIoT.Deployment` deploys latest available patch version of `1.22` Kubernetes.
 
 #### Kubernetes Dashboard
 


### PR DESCRIPTION
Changes:
- Upgraded Kubernetes version in AKS from `1.21.9` to `1.22.6` as [deprecation of `1.21` version will start taking effect from July 31st, 2022](https://github.com/Azure/AKS/releases/tag/2022-06-19).

Similar to #1628.