### PR TITLE
add mandatory field for edgeHub in the base deployment template

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Hub/Services/IoTHubEdgeBaseDeployment.cs
@@ -116,6 +116,8 @@ namespace Microsoft.Azure.IIoT.Hub.Services {
             ""schemaVersion"": """ + kDefaultSchemaVersion + @""",
             ""storeAndForwardConfiguration"": {
                 ""timeToLiveSecs"": 7200
+            },
+            ""routes"" : {
             }
         }
     }


### PR DESCRIPTION
 * fix for the deployment clone issue due to infringement of schema validation (https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/azure-iot-edgehub-deployment-1.0.json)