### PR TITLE
Upgrade of NuGet packages.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
 
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
@@ -12,7 +12,7 @@
     </PackageReference>
 
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.OpcUa.Api.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Api.Publisher.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi/src/Microsoft.Azure.IIoT.AspNetCore.OpenApi.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.4.0" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Auth.OpenId/src/Microsoft.Azure.IIoT.Auth.OpenId.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Auth.OpenId/src/Microsoft.Azure.IIoT.Auth.OpenId.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
-    <PackageReference Include="IdentityModel" Version="5.1.0" />
+    <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.11.0" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="prometheus-net" Version="4.1.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.24" />

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.3.7.5" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.18.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />

--- a/common/src/Microsoft.Azure.IIoT.Http.HealthChecks/Microsoft.Azure.IIoT.Http.HealthChecks.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Http.HealthChecks/Microsoft.Azure.IIoT.Http.HealthChecks.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
 	<PackageReference Include="Serilog" Version="2.10.0" />
-	<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+	<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
 	<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 

--- a/common/src/Microsoft.Azure.IIoT.Http.HealthChecks/Microsoft.Azure.IIoT.Http.HealthChecks.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Http.HealthChecks/Microsoft.Azure.IIoT.Http.HealthChecks.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Serilog" Version="2.10.0" />
+	<PackageReference Include="Serilog" Version="2.12.0" />
 	<PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
 	<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Microsoft.Azure.IIoT.Hub.Module.Client.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Microsoft.Azure.IIoT.Hub.Module.Client.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT edge module service framework</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.38.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.41.2" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.SignalR/src/Microsoft.Azure.IIoT.Messaging.SignalR.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.2.1" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.11.0" />
+    <PackageReference Include="Microsoft.Azure.SignalR.Management" Version="1.18.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Serializers.MessagePack\src\Microsoft.Azure.IIoT.Serializers.MessagePack.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
@@ -12,7 +12,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
@@ -22,7 +22,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -18,7 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -19,7 +19,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
@@ -39,20 +39,20 @@
   <Choose>
     <When Condition="'$(Configuration)'=='Release'">
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.370.9" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.370.12" />
       </ItemGroup>
     </When>
     <Otherwise>
       <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core.Debug" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration.Debug" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server.Debug" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.Debug" Version="1.4.370.9" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes.Debug" Version="1.4.370.9" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core.Debug" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration.Debug" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server.Debug" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.Debug" Version="1.4.370.12" />
+        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes.Debug" Version="1.4.370.12" />
       </ItemGroup>
     </Otherwise>
   </Choose>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
@@ -12,7 +12,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
@@ -10,7 +10,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/tests/Microsoft.Azure.IIoT.OpcUa.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -24,7 +24,7 @@
 
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.1" />
 
-    <PackageReference Include="Microsoft.Graph" Version="3.33.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.35.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.7" />
 
     <PackageReference Include="Microsoft.Identity.Client" Version="4.31.0" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
    </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Accelist.FluentValidation.Blazor" Version="2.1.0" />
     <PackageReference Include="Blazored.Modal" Version="4.1.0" />
-    <PackageReference Include="Blazored.SessionStorage" Version="2.1.0" />
+    <PackageReference Include="Blazored.SessionStorage" Version="2.2.0" />
     <PackageReference Include="FluentValidation" Version="8.6.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.24" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Changes:
* Bump xunit.runner.visualstudio from 2.4.3 to 2.4.5 (#1809)
* Bump Microsoft.NET.Test.Sdk from 16.11.0 to 17.3.2 (#1807)
* Bump Microsoft.Azure.Devices.Client from 1.38.0 to 1.41.2 (#1794)
* Bump Serilog.Sinks.Console from 3.1.1 to 4.1.0 (#1805)
* Bump Blazored.SessionStorage from 2.1.0 to 2.2.0 (#1795)
* Bump coverlet.msbuild from 3.1.0 to 3.1.2 (#1783)
* Bump Microsoft.ApplicationInsights.SnapshotCollector (#1813)
* Bump Microsoft.Azure.SignalR.Management from 1.11.0 to 1.18.3 (#1787)
* Bump Serilog from 2.10.0 to 2.12.0 (#1802)
* Bump xunit from 2.4.1 to 2.4.2 (#1803)
* Bump Swashbuckle.AspNetCore.Newtonsoft from 6.1.4 to 6.4.0 (#1810)
* Bump IdentityModel from 5.1.0 to 6.0.0 (#1808)
* Bump Swashbuckle.AspNetCore.Annotations from 6.1.4 to 6.4.0 (#1819)
* Bump Microsoft.Graph from 3.33.0 to 3.35.0 (#1822)