### PR TITLE
Fixed propagation of ports in DeployPLCs.ps1.

### DIFF
--- a/tools/e2etesting/DeployPLCs.ps1
+++ b/tools/e2etesting/DeployPLCs.ps1
@@ -90,12 +90,11 @@ Write-Host
 $jobs = @()
 
 if ($aciNamesToCreate.Length -gt 0) {
-    $ports = @(50000, 80)
-
     if ($UsePrivateIp -eq $false) {
         $script = {
             Param($Name)
             $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
+            $ports = @(50000, 80)
             az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --os-type Linux --command $aciCommand --ports @ports --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Public --dns-name-label $Name
             if ($LASTEXITCODE -ne 0) {
                 throw "Job failed with exit code: $LASTEXITCODE"
@@ -113,6 +112,7 @@ if ($aciNamesToCreate.Length -gt 0) {
         $script = {
             Param($Name)
             $aciCommand = "/bin/sh -c './opcplc --ctb --pn=50000 --autoaccept --nospikes --nodips --nopostrend --nonegtrend --nodatavalues --sph --wp=80 --sn=$($using:NumberOfSlowNodes) --sr=$($using:SlowNodeRate) --st=$($using:SlowNodeType) --fn=$($using:NumberOfFastNodes) --fr=$($using:FastNodeRate) --ft=$($using:FastNodeType)'"
+            $ports = @(50000, 80)
             az container create --resource-group $using:ResourceGroupName --name $Name --image $using:PLCImage --os-type Linux --command $aciCommand --ports @ports --cpu $using:CpuCount --memory $using:MemoryInGb --ip-address Private --vnet $using:vNet --subnet $using:subNet
             if ($LASTEXITCODE -ne 0) {
                 throw "Job failed with exit code: $LASTEXITCODE"


### PR DESCRIPTION
Fixing changes in #1836. Refactoring that I did after adding the initial changes broke the script.

Output after running the script with those changes:

```powershell
PS C:\dev\github\Azure\Industrial-IoT> .\tools\e2etesting\DeployPLCs.ps1 -ResourceGroupName e2etesting202210121008 -UsePrivateIp $false
Resource Group: e2etesting202210121008
The following Key Vault has been selected: keyvault-86013


Getting IPs of ACIs for simulated PLCs...
52.226.230.182
20.232.7.97
20.75.162.228
20.246.201.72
4.236.219.141
20.232.7.171
52.226.234.177
52.226.225.199
20.253.8.142
20.121.78.163
Adding/Updating KeyVault-Secret 'plc-simulation-urls' with value '52.226.230.182;20.232.7.97;20.75.162.228;20.246.201.72;4.236.219.141;20.232.7.171;52.226.234.177;52.226.225.199;20.253.8.142;20.121.78.163;'...
Deployment finished.
PS C:\dev\github\Azure\Industrial-IoT>
```