### PR TITLE
Using updated output key name in output of edgeDeploy.json.

### DIFF
--- a/tools/e2etesting/DeployEdge.ps1
+++ b/tools/e2etesting/DeployEdge.ps1
@@ -157,7 +157,7 @@ Write-Host "Adding/Updating KeVault-Certificate 'iot-edge-vm-publickey'..."
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'iot-edge-vm-publickey' -SecretValue (ConvertTo-SecureString $sshPublicKey -AsPlainText -Force) | Out-Null
 
 ## This needs to be refactored. However, currently the SSH-Command is the only output from the Edge deployment script. And that command includes the FQDN of the VM.
-$sshUrl = $edgeDeployment.Outputs["public SSH"].Value
+$sshUrl = $edgeDeployment.Outputs["Public_SSH"].Value
 $fqdn = $sshUrl.Split("@")[1]
 
 Write-Host "Adding/Updating KeyVault-Secret 'iot-edge-device-dnsname' with value '$($fqdn)'..."


### PR DESCRIPTION
https://github.com/Azure/iotedge-vm-deploy/pull/17 PR changed output key from `Public SSH` to `Public_SSH` in [`edgeDeploy.json`](https://github.com/Azure/iotedge-vm-deploy/blob/master/edgeDeploy.json) that is used by `tools\e2etesting\DeployEdge.ps1` to deploy an IoT Edge VM. Here I have changed the script to retrieve the correct key from output of the deployment.

Currently the following error is reported when `tools\e2etesting\DeployEdge.ps1` is executed in E2E tests:

```
Using suffix for testing resources: XXXXX
IoT Hub Name: iothub-YYYYY
WARNING: We have migrated the API calls for this cmdlet from Azure Active Directory Graph to Microsoft Graph.

Visit https://go.microsoft.com/fwlink/?linkid=2181475 for any permission issues.
Key Vault Name: keyvault-QQQQQ
Iot Hub Device Identity: e2etestdevice_XXXXX
Creating edge-enabled device identity e2etestdevice_XXXXX in Iot Hub iothub-YYYYY
Adding/Updating KeyVault-Secret 'iot-edge-device-id' with value 'e2etestdevice_XXXXX'...
Updating 'os' and '__type__'-Tags in Device Twin...
Getting Device Connection String for IoT Edge Deployment...
Using DNS prefix: e2etesting-edgevm-XXXXX
Running IoT Edge VM Deployment...
Adding/Updating KeVault-Secret 'iot-edge-vm-username' with value 'ZZZZZZZZZZZ'...
Adding/Updating KeVault-Certificate 'iot-edge-vm-privatekey'...
Adding/Updating KeVault-Certificate 'iot-edge-vm-publickey'...
##[error]You cannot call a method on a null-valued expression.
##[error]PowerShell exited with code '1'.
```