### PR TITLE
Increased proxy-connect-timeout of NGINX from default 5 seconds to 30.

### DIFF
--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -812,6 +812,7 @@ deployment:
       nginx.ingress.kubernetes.io/session-cookie-max-age: "14400"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
 ```
 
 ### Prometheus
@@ -1028,6 +1029,7 @@ deployment:
       nginx.ingress.kubernetes.io/session-cookie-max-age: "14400"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
 ```
 
 These annotations make sure that:
@@ -1045,6 +1047,7 @@ These annotations make sure that:
 * WebSocket connection is kept alive. For this we set [adequate timeout values](https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets) for:
   * [`nginx.ingress.kubernetes.io/proxy-read-timeout`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts)
   * [`nginx.ingress.kubernetes.io/proxy-send-timeout`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts)
+  * [`nginx.ingress.kubernetes.io/proxy-connect-timeout`](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts)
 
   Here are general NGINX Ingress Controller
   [recommendations for WebSocket](https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets).

--- a/deploy/helm/azure-industrial-iot/values.yaml
+++ b/deploy/helm/azure-industrial-iot/values.yaml
@@ -600,6 +600,7 @@ deployment:
     #   nginx.ingress.kubernetes.io/session-cookie-max-age: "14400"
     #   nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     #   nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    #   nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
     annotations: {}
 
     # host for the Ingress. We do not support multiple hosts at the moment.

--- a/docs/deploy/howto-add-aks-to-ps1.md
+++ b/docs/deploy/howto-add-aks-to-ps1.md
@@ -341,6 +341,7 @@ deployment:
       nginx.ingress.kubernetes.io/session-cookie-max-age: "14400"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
     - hosts:
@@ -472,6 +473,7 @@ deployment:
       nginx.ingress.kubernetes.io/session-cookie-max-age: "14400"
       nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
       nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "30"
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
     - hosts:


### PR DESCRIPTION
Increasing the timeout allows for more time for microservices, such as job-orchestration microservice, to respond to connect requests from NGINX. This comes into picture when a microservice is under a heavy load which is causing delays in responding to REST API calls.

More about `proxy-connect-timeout` is available here:

- https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-timeouts
- https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-connect-timeout
