### PR TITLE
Using casing reported in deployment output in Azure.

### DIFF
--- a/tools/e2etesting/DeployEdge.ps1
+++ b/tools/e2etesting/DeployEdge.ps1
@@ -157,7 +157,7 @@ Write-Host "Adding/Updating KeVault-Certificate 'iot-edge-vm-publickey'..."
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'iot-edge-vm-publickey' -SecretValue (ConvertTo-SecureString $sshPublicKey -AsPlainText -Force) | Out-Null
 
 ## This needs to be refactored. However, currently the SSH-Command is the only output from the Edge deployment script. And that command includes the FQDN of the VM.
-$sshUrl = $edgeDeployment.Outputs["Public_SSH"].Value
+$sshUrl = $edgeDeployment.Outputs["public_SSH"].Value
 $fqdn = $sshUrl.Split("@")[1]
 
 Write-Host "Adding/Updating KeyVault-Secret 'iot-edge-device-dnsname' with value '$($fqdn)'..."


### PR DESCRIPTION
Follow-up to #1841. Changed the casing of the `Public_SSH` key to use the one reported as output in Azure, which is `public_SSH`.

![image](https://user-images.githubusercontent.com/20900945/196908033-1d17656e-15dc-451c-9aca-8e6e7d7d2bad.png)
