### PR TITLE
Update of NuGet packages by debendabot.

### DIFF
--- a/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
+++ b/api/src/Microsoft.Azure.IIoT.Api/tests/Microsoft.Azure.IIoT.Api.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Agent.Framework/tests/Microsoft.Azure.IIoT.Agent.Framework.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/tests/Microsoft.Azure.IIoT.Core.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights/src/Microsoft.Azure.IIoT.Diagnostics.AppInsights.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.18.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
   </ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Framework/tests/Microsoft.Azure.IIoT.Hub.Module.Framework.Tests.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Messaging.EventHub/src/Microsoft.Azure.IIoT.Messaging.EventHub.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.EventHub/src/Microsoft.Azure.IIoT.Messaging.EventHub.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT Eventhub messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.1" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Core\src\Microsoft.Azure.IIoT.Core.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Messaging.ServiceBus/src/Microsoft.Azure.IIoT.Messaging.ServiceBus.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Messaging.ServiceBus/src/Microsoft.Azure.IIoT.Messaging.ServiceBus.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT Servicebus messaging</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Core\src\Microsoft.Azure.IIoT.Core.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/tests/Microsoft.Azure.IIoT.Serializers.MessagePack.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/tests/Microsoft.Azure.IIoT.Serializers.NewtonSoft.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/common/src/Microsoft.Azure.IIoT.Storage.CosmosDb/src/Microsoft.Azure.IIoT.Storage.CosmosDb.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Storage.CosmosDb/src/Microsoft.Azure.IIoT.Storage.CosmosDb.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT Core Azure Storage Implementations</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.16.2" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.18.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet/tests/Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.Tests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Autofac.Extras.Moq" Version="5.0.1" />
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="coverlet.msbuild" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Twin.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/tests/Microsoft.Azure.IIoT.OpcUa.Protocol.Tests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Registry/tests/Microsoft.Azure.IIoT.OpcUa.Registry.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/src/Microsoft.Azure.IIoT.OpcUa.Testing.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Testing/src/Microsoft.Azure.IIoT.OpcUa.Testing.csproj
@@ -49,7 +49,7 @@
     <EmbeddedResource Include="Servers\Views\Design\Operations.PredefinedNodes.uanodes" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.OpcUa.Protocol\src\Microsoft.Azure.IIoT.OpcUa.Protocol.csproj" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Twin/tests/Microsoft.Azure.IIoT.OpcUa.Twin.Tests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.36.1" />
-    <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="4.0.0" />
+    <PackageReference Include="Microsoft.Azure.Management.IotHub" Version="4.2.0" />
     <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.23.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ApplicationInsights" Version="0.3.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.Authorization" Version="2.12.0-preview" />

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.24" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.24" />
 
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.14.0" />
 
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
 

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.24" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="3.1.24" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.24" />
-    <PackageReference Include="Mono.Options" Version="6.6.0.161" />
+    <PackageReference Include="Mono.Options" Version="6.12.0.148" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\api\src\Microsoft.Azure.IIoT.Api\src\Microsoft.Azure.IIoT.Api.csproj" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/tests/Microsoft.Azure.IIoT.Modules.Publisher.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.2.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />

--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Modules.OpcUa.Twin.Tests.csproj
@@ -4,7 +4,7 @@
    </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
+++ b/samples/src/Microsoft.Azure.IIoT.App/src/Microsoft.Azure.IIoT.App.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Accelist.FluentValidation.Blazor" Version="2.1.0" />
     <PackageReference Include="Blazored.Modal" Version="4.1.0" />
     <PackageReference Include="Blazored.SessionStorage" Version="2.2.0" />
-    <PackageReference Include="FluentValidation" Version="8.6.2" />
+    <PackageReference Include="FluentValidation" Version="11.2.2" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="8.6.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="3.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="3.1.24" />

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Events/tests/Microsoft.Azure.IIoT.Services.OpcUa.Events.Tests.csproj
@@ -6,7 +6,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.24" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Registry/tests/Microsoft.Azure.IIoT.Services.OpcUa.Registry.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.History.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
+++ b/services/src/Microsoft.Azure.IIoT.Services.OpcUa.Twin/tests/Microsoft.Azure.IIoT.Services.OpcUa.Twin.Tests.csproj
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.24" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Changes:
- Bump Microsoft.Azure.ServiceBus from 4.1.3 to 5.2.0 (#1782)
- Bump Moq from 4.16.1 to 4.18.2 (#1831)
- Bump xunit.assert from 2.4.1 to 2.4.2 (#1837)
- Bump Microsoft.Azure.EventHubs from 4.3.1 to 4.3.2 (#1858)
- Bump Azure.Storage.Blobs from 12.13.0 to 12.14.0 (#1857)
- Bump FluentValidation from 8.6.2 to 11.2.2 (#1856)
- Bump Microsoft.Azure.DocumentDB.Core from 2.16.2 to 2.18.0 (#1855)
- Bump Serilog.Sinks.ApplicationInsights from 3.1.0 to 4.0.0 (#1867)
- Bump Mono.Options from 6.6.0.161 to 6.12.0.148 (#1852)
- Bump FluentAssertions from 6.2.0 to 6.7.0 (#1874)
- Bump Microsoft.Azure.Management.IotHub from 4.0.0 to 4.2.0 (#1876)