### PR TITLE
Ad hoc discovery fails with "capacity must be non negative" error found during bug bash.

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Discovery/src/Models/DiscoveryRequest.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Discovery/src/Models/DiscoveryRequest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Discovery.Models {
             DiscoveryConfigModel configuration) :
             this(new DiscoveryRequestModel {
                 Id = "",
-                Configuration = configuration,
+                Configuration = configuration.Clone(),
                 Context = null,
                 Discovery = mode
             }, NetworkClass.Wired, true) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Extensions/DiscoveryConfigModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Extensions/DiscoveryConfigModelEx.cs
@@ -4,6 +4,7 @@
 // ------------------------------------------------------------
 
 namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
+    using System;
     using System.Linq;
 
     /// <summary>
@@ -22,16 +23,26 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
             }
             return new DiscoveryConfigModel {
                 ActivationFilter = model.ActivationFilter.Clone(),
-                AddressRangesToScan = model.AddressRangesToScan,
-                DiscoveryUrls = model.DiscoveryUrls?.ToList(),
-                Locales = model.Locales?.ToList(),
-                IdleTimeBetweenScans = model.IdleTimeBetweenScans,
-                MaxNetworkProbes = model.MaxNetworkProbes,
-                MaxPortProbes = model.MaxPortProbes,
-                MinPortProbesPercent = model.MinPortProbesPercent,
-                NetworkProbeTimeout = model.NetworkProbeTimeout,
-                PortProbeTimeout = model.PortProbeTimeout,
-                PortRangesToScan = model.PortRangesToScan
+                DiscoveryUrls = model.DiscoveryUrls?.Count > 0 ?
+                    model.DiscoveryUrls.ToList() : null,
+                Locales = model.Locales?.Count > 0 ?
+                    model.Locales.ToList() : null,
+                PortRangesToScan = string.IsNullOrEmpty(model.PortRangesToScan) ?
+                    null : model.PortRangesToScan,
+                AddressRangesToScan = string.IsNullOrEmpty(model.AddressRangesToScan) ?
+                    null : model.AddressRangesToScan,
+                IdleTimeBetweenScans = model.IdleTimeBetweenScans < TimeSpan.Zero ?
+                    null : model.IdleTimeBetweenScans,
+                MaxNetworkProbes = model.MaxNetworkProbes <= 0 ?
+                    null : model.MaxNetworkProbes,
+                MaxPortProbes = model.MaxPortProbes <= 0 ?
+                    null : model.MaxPortProbes,
+                MinPortProbesPercent = model.MinPortProbesPercent <= 0 ?
+                    null : model.MinPortProbesPercent,
+                NetworkProbeTimeout = model.NetworkProbeTimeout <= TimeSpan.Zero ?
+                    null : model.IdleTimeBetweenScans,
+                PortProbeTimeout = model.PortProbeTimeout <= TimeSpan.Zero ?
+                    null : model.PortProbeTimeout,
             };
         }
     }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Extensions/DiscoveryConfigModelEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa/src/Registry/Extensions/DiscoveryConfigModelEx.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Registry.Models {
                 MinPortProbesPercent = model.MinPortProbesPercent <= 0 ?
                     null : model.MinPortProbesPercent,
                 NetworkProbeTimeout = model.NetworkProbeTimeout <= TimeSpan.Zero ?
-                    null : model.IdleTimeBetweenScans,
+                    null : model.NetworkProbeTimeout,
                 PortProbeTimeout = model.PortProbeTimeout <= TimeSpan.Zero ?
                     null : model.PortProbeTimeout,
             };


### PR DESCRIPTION
Engineering tool passes negative values as defaults when running ad hoc discovery. Use Clone method to sanitize them to null like the rest of the code demands.