### PR TITLE
Aligning number of fast and slow nodes in simulation OPC PLCs.

### DIFF
--- a/deploy/scripts/default.yml
+++ b/deploy/scripts/default.yml
@@ -3,18 +3,18 @@ services:
   opcserver0:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51200
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51200:51200"
   opcserver1:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51201    
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51201:51201"
   opcserver2:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51202
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51202:51202"


### PR DESCRIPTION
Aligned the number of fast (`50`) and slow (`250`) nodes of docker-compose definition (`deploy\scripts\default.yml`) with defaults that are used in `tools\e2etesting\DeployPLCs.ps1`.