### PR TITLE
Helm: Change the chart to deploy 2.8.4 version of Azure IIoT platform.

### DIFF
--- a/deploy/helm/azure-industrial-iot/Chart.yaml
+++ b/deploy/helm/azure-industrial-iot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: azure-industrial-iot
-version: 0.4.5-rc
+version: 0.4.4
 description: Azure Industrial IoT allows plant operators to discover OPC UA enabled servers in a factory network and register them in Azure IoT Hub.
 type: application
 keywords:

--- a/deploy/helm/azure-industrial-iot/README.md
+++ b/deploy/helm/azure-industrial-iot/README.md
@@ -457,7 +457,7 @@ The following details of the Azure Log Analytics Workspace would be required:
 
 ## Installing the Chart
 
-This chart installs `2.8.3` version of components by default.
+This chart installs `2.8.4` version of components by default.
 
 To install the chart first ensure that you have added `azure-iiot` repository:
 
@@ -519,7 +519,7 @@ values.
 | Parameter           | Description                              | Default             |
 |---------------------|------------------------------------------|---------------------|
 | `image.registry`    | URL of Docker Image Registry             | `mcr.microsoft.com` |
-| `image.tag`         | Image tag                                | `2.8.3`             |
+| `image.tag`         | Image tag                                | `2.8.4`             |
 | `image.pullPolicy`  | Image pull policy                        | `IfNotPresent`      |
 | `image.pullSecrets` | docker-registry secret names as an array | `[]`                |
 

--- a/deploy/helm/azure-industrial-iot/values.yaml
+++ b/deploy/helm/azure-industrial-iot/values.yaml
@@ -5,7 +5,7 @@ image:
   # image.registry is URL of Docker registry from where images will be pulled.
   registry: mcr.microsoft.com
   # image.tag defines which version of Docker images to pull.
-  tag: 2.8.3
+  tag: 2.8.4
   # image.pullPolicy defines value of imagePullPolicy of deployments.
   pullPolicy: IfNotPresent
   # image.pullSecrets defined docker-registry secrets that should be used for private container registries.

--- a/docs/deploy/howto-add-aks-to-ps1.md
+++ b/docs/deploy/howto-add-aks-to-ps1.md
@@ -513,7 +513,7 @@ For that you would first add Helm repository and then install the chart from the
 ```bash
 helm repo add azure-iiot https://azure.github.io/Industrial-IoT/helm
 helm repo update
-helm install aiiot azure-iiot/azure-industrial-iot --namespace aiiot --version 0.4.3 -f aiiot.yaml
+helm install aiiot azure-iiot/azure-industrial-iot --namespace aiiot --version 0.4.4 -f aiiot.yaml
 ```
 
 Please note that the version of the chart in GitHub repo will be ahead of chart versions that we publish

--- a/docs/deploy/howto-deploy-helm.md
+++ b/docs/deploy/howto-deploy-helm.md
@@ -19,7 +19,9 @@ of our microservices:
   Platform microservices.
 - `0.4.2` version of `azure-industrial-iot` Helm chart to deploy `2.8.2` version of Azure Industrial IoT
   Platform microservices.
-- `0.4.3` version of `azure-industrial-iot` Helm chart to deploy `2.8.3` and later version of Azure Industrial IoT
+- `0.4.3` version of `azure-industrial-iot` Helm chart to deploy `2.8.3` version of Azure Industrial IoT
+  Platform microservices.
+- `0.4.4` version of `azure-industrial-iot` Helm chart to deploy `2.8.4` and later version of Azure Industrial IoT
   Platform microservices.
 
 ## Installing The Chart
@@ -36,6 +38,7 @@ Kubernetes cluster:
 - For `0.4.1` version of the Chart: [Azure Industrial IoT Helm Chart v0.4.1](https://github.com/Azure/Industrial-IoT/blob/helm_0.4.1/deploy/helm/azure-industrial-iot/README.md)
 - For `0.4.2` version of the Chart: [Azure Industrial IoT Helm Chart v0.4.2](https://github.com/Azure/Industrial-IoT/blob/helm_0.4.2/deploy/helm/azure-industrial-iot/README.md)
 - For `0.4.3` version of the Chart: [Azure Industrial IoT Helm Chart v0.4.3](https://github.com/Azure/Industrial-IoT/blob/helm_0.4.3/deploy/helm/azure-industrial-iot/README.md)
+- For `0.4.4` version of the Chart: [Azure Industrial IoT Helm Chart v0.4.4](https://github.com/Azure/Industrial-IoT/blob/helm_0.4.4/deploy/helm/azure-industrial-iot/README.md)
 
 For latest documentation and chart sources please check [deploy/helm/azure-industrial-iot/](../../deploy/helm/azure-industrial-iot/)
 directory on `main` branch.

--- a/docs/manual/readme.md
+++ b/docs/manual/readme.md
@@ -726,7 +726,7 @@ References:
 
 [Helm](https://helm.sh/docs/) is a [Kubernetes](https://kubernetes.io/docs/concepts/overview/what-is-kubernetes/) package and operations manager, analogous to yum and apt. Application packages themselves are called Helm Charts and can be installed using the Helm tool. Helm allows users to easily templatize their Kubernetes manifests and provide a set of configuration parameters that allows users to customize their deployment.
 
-For the deployment of cloud microservices of Azure Industrial IoT platform into a Kubernetes cluster we provide **azure-industrial-iot** Helm chart. Version `0.4.3` of azure-industrial-iot Helm chart should be used for deployment of `2.8.x` versions of Azure Industrial IoT microservices.
+For the deployment of cloud microservices of Azure Industrial IoT platform into a Kubernetes cluster we provide **azure-industrial-iot** Helm chart. Version `0.4.4` of azure-industrial-iot Helm chart should be used for deployment of `2.8.x` versions of Azure Industrial IoT microservices.
 
 #### Prerequisites
 
@@ -2282,7 +2282,7 @@ In the below commands "`azure-industrial-iot`" is used as the namespace. Please 
 
    This command will keep existing setup unchanged, except for the version of docker images that are deployed.
 
-It should be noted that different versions of Helm chart are intended for deploying different versions of the Azure Industrial IoT platform. This stems from the fact that there can be a different number of components in different versions of the Azure Industrial IoT platform, so deployment requirements and configuration parameters differ between versions. Currently, the latest version of the Helm chart is `0.4.3` which by default deploys the latest version of the components. The same version can be used for deployment of `2.8.0` and higher `2.8.x` versions. For the version compatibility matrix, please check out [how to deploy using Helm](../deploy/howto-deploy-helm.md).
+It should be noted that different versions of Helm chart are intended for deploying different versions of the Azure Industrial IoT platform. This stems from the fact that there can be a different number of components in different versions of the Azure Industrial IoT platform, so deployment requirements and configuration parameters differ between versions. Currently, the latest version of the Helm chart is `0.4.4` which by default deploys the latest version of the components. The same version can be used for deployment of `2.8.0` and higher `2.8.x` versions. For the version compatibility matrix, please check out [how to deploy using Helm](../deploy/howto-deploy-helm.md).
 
 #### IoT Edge Modules
 


### PR DESCRIPTION
Similar to the changes in #1748 that were done for the release of `0.4.3` version of `azure-industrial-iot` Helm chart.