### PR TITLE
IAI: Changed deployment to use 0.4.4 version of Helm chart and 2.8.4 version of platform.

### DIFF
--- a/deploy/helm/azure-industrial-iot/Chart.yaml
+++ b/deploy/helm/azure-industrial-iot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: azure-industrial-iot
-version: 0.4.4
+version: 0.4.5-rc
 description: Azure Industrial IoT allows plant operators to discover OPC UA enabled servers in a factory network and register them in Azure IoT Hub.
 type: application
 keywords:

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Configuration/HelmSettings.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.IIoT.Deployment.Configuration {
 
         // Defaults
         public static string _defaultRepoUrl = "https://azure.github.io/Industrial-IoT/helm";
-        public static string _defaultChartVersion = "0.4.3";
+        public static string _defaultChartVersion = "0.4.4";
         public static string _defaultImageTag = "2.8.4";
         public static string _defaultImageNamespace = "";
         public static string _defaultContainerRegistryServer = "mcr.microsoft.com";

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/appsettings.json
@@ -110,7 +110,7 @@
     // Helm repository URL
     "RepoUrl": "https://azure.github.io/Industrial-IoT/helm",
     // azure-industrial-iot Helm chart version
-    "ChartVersion": "0.4.3",
+    "ChartVersion": "0.4.4",
     // Azure IIoT components image tag
     "ImageTag": "2.8.4",
     // Azure IIoT components image namespace

--- a/docs/deploy/howto-deploy-aks.md
+++ b/docs/deploy/howto-deploy-aks.md
@@ -476,7 +476,7 @@ Command line argument key-value pairs can be specified with:
 | `ResourceGroup:UseExisting`      | If set, should be `true` or `false`.                | Determines whether an existing Resource Group should be used or a new one should be created. |                                               |
 | `ResourceGroup:Region`           | Check bellow for list of supported Azure regions.   | Region where new Resource Group should be created.                                           |                                               |
 | `Helm:RepoUrl`                   | Should be URL.                                      | Helm repository URL for `azure-industrial-iot` Helm chart.                                   | `https://azure.github.io/Industrial-IoT/helm` |
-| `Helm:ChartVersion`              |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.4.3`                                       |
+| `Helm:ChartVersion`              |                                                     | `azure-industrial-iot` Helm chart version to be deployed.                                    | `0.4.4`                                       |
 | `Helm:ImageTag`                  |                                                     | Docker image tag for Azure Industrial IoT components to be deployed.                         | `2.8.4`                                       |
 | `Helm:ImageNamespace`            |                                                     | Docker image namespace for Azure Industrial IoT components to be deployed.                   | `""`                                          |
 | `Helm:ContainerRegistryServer`   |                                                     | Docker container registry server to use for pulling images.                                  | `mcr.microsoft.com`                           |
@@ -625,7 +625,7 @@ Kubernetes Dashboard.
 `azure-industrial-iot` Helm chart will be deployed. For more details about the chart please check its
 [documentation](../../deploy/helm/azure-industrial-iot/README.md).
 
-By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.4.3` version of `azure-industrial-iot` Helm chart
+By default, `Microsoft.Azure.IIoT.Deployment` deploys `0.4.4` version of `azure-industrial-iot` Helm chart
 with `2.8.4` version of Azure Industrial IoT components. Both chart version and components version can be
 changed using configuration parameters. Please check `Helm:ChartVersion` and `Helm:ImageTag` parameters for
 that.


### PR DESCRIPTION
Incorporates changes for IAI for newly release `0.4.4` version of `azure-industrial-iot` Helm chart. Similar to #1751 and #1752.

Changes:

- IAI: Changed deployment to use `0.4.4` version of Helm chart and `2.8.4` version of platform.
- Helm: Changed Helm chart version in main to `0.4.5-rc`.
