### PR TITLE
Fix / enchance CLI configuration options recognition (solves "OPC Publisher 2.8.4: --messagingmode flag not working as expected. #1945")

### DIFF
--- a/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
+++ b/modules/src/Microsoft.Azure.IIoT.Modules.OpcUa.Publisher/src/Runtime/StandaloneCliOptions.cs
@@ -35,11 +35,13 @@ namespace Microsoft.Azure.IIoT.Modules.OpcUa.Publisher.Runtime {
         /// </summary>
         /// <param name="config"></param>
         public StandaloneCliOptions(IConfiguration config) {
+            var configKeyNames = typeof(StandaloneCliConfigKeys).GetFields().Select(fi => fi.Name).ToList();
             foreach (var item in config.GetChildren()) {
-                this[item.Key] = item.Value;
+                var keyName = configKeyNames.FirstOrDefault(n => string.Compare(n, item.Key, StringComparison.OrdinalIgnoreCase) == 0);
+                this[keyName ?? item.Key] = item.Value;
             }
-            Config = ToAgentConfigModel();
 
+            Config = ToAgentConfigModel();
             _logger = ConsoleLogger.Create(LogEventLevel.Warning);
         }
 


### PR DESCRIPTION
This PR solves the bug "OPC Publisher 2.8.4: --messagingmode flag not working as expected. #1945" among others. The described in this bug error does not only affect the mentioned key _MessagingMode_, but all CLI configuration keys for which two options with different notations (like -sampleoption|SampleOption=) are defined.

The reason for this is the following. The calls .AddCommandLine(args) and .AddStandalonePublisherCommandLine(args) in the Program.cs add two providers (CommandLineConfigurationProvider and MemoryConfigurationProvider), which have in the Data-member Key-Value-pairs with keys with different notation, e.g.:
[**messagingmode**, PubSub] 
and 
[**MessagingMode**, PubSub].

So in the operation config.GetChildren() in the consturctor of the class StandaloneCliOptions we have two keys
messagingmode, 
MessagingMode

To which then the operations Sort(ConfigurationKeyComparer.Comparison(StringComparison.**OrdinalIgnoreCase**)) and Distinct(StringComparer.**OrdinalIgnoreCase**) are applied. Since the two operations have **IgnoreCase**, the order after Sort and before Distinct is in general not deterministic for such keys with different notations. And in case of e.g. the Key _MessagingMode_ the "messaginmode" is selected by Distinct. Or with other words the right key "MessagingMode" will be "eliminated" by "messagingmode"

So the class StandaloneCliOptions has at the end only the Key-Value-pair
[messagingmode, PubSub]

And when the key _MessagingMode_ (from StandaloneCliConfigKeys) is queried, it does not exist. So the default "Samples" is taken.

In the proposed solution StandaloneCliConfig Keys in config.GetChildren() with "wrong" notation are replaced by correct ones from StandaloneCliConfigKeys class.

An even simpler solution would be to remove the CommandLineConfigurationProvider completely (delete the .AddCommandLine(args) call). But it is needed for other purposes, I suppose.