### PR TITLE
Change "content-encoding" name in SystemProperties of NetworkMessages to WebName

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/JsonMetadataMessage.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/JsonMetadataMessage.cs
@@ -26,7 +26,7 @@ namespace Opc.Ua.PubSub {
         public override string ContentType => UseGzipCompression ? ContentMimeType.JsonGzip : ContentMimeType.Json;
 
         /// <inheritdoc/>
-        public override string ContentEncoding => Encoding.UTF8.EncodingName;
+        public override string ContentEncoding => Encoding.UTF8.WebName;
 
         /// <summary>
         /// Ua meta data message type

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/JsonNetworkMessage.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/PubSub/JsonNetworkMessage.cs
@@ -28,7 +28,7 @@ namespace Opc.Ua.PubSub {
             ContentMimeType.JsonGzip : ContentMimeType.Json;
 
         /// <inheritdoc/>
-        public override string ContentEncoding => Encoding.UTF8.EncodingName;
+        public override string ContentEncoding => Encoding.UTF8.WebName;
 
         /// <summary>
         /// Ua data message type


### PR DESCRIPTION
The "content-encoding" should be standard (IANA preferred) name for this encoding that can be simply casted to Encoding by Encoding.GetEncoding(name).

Also the "content-encoding" SystemProperty should be backwards compatible to the previous publisher versions. And they had the WebName rather EncodingName(== DisplayName)

