### PR TITLE
Fix issue crashing in diagnostics handler (#1956)

### DIFF
--- a/common/src/Microsoft.Azure.IIoT.Abstractions/src/Microsoft.Azure.IIoT.Abstractions.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Abstractions/src/Microsoft.Azure.IIoT.Abstractions.csproj
@@ -7,6 +7,6 @@
     <Description>Azure Industrial IoT common abstractions and primitives</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 </Project>

--- a/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
+++ b/common/src/Microsoft.Azure.IIoT.AspNetCore/src/Microsoft.Azure.IIoT.AspNetCore.csproj
@@ -13,8 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory/src/Microsoft.Azure.IIoT.Auth.ActiveDirectory.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.25.1" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
   </ItemGroup>
   <ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Auth.OpenId/src/Microsoft.Azure.IIoT.Auth.OpenId.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Auth.OpenId/src/Microsoft.Azure.IIoT.Auth.OpenId.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
     <PackageReference Include="IdentityModel" Version="6.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.25.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Core\src\Microsoft.Azure.IIoT.Core.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Core/src/Microsoft.Azure.IIoT.Core.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="prometheus-net" Version="6.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="prometheus-net" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Microsoft.Azure.IIoT.Hub.Module.Client.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Module.Client/src/Microsoft.Azure.IIoT.Hub.Module.Client.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT edge module service framework</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.41.2" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.41.3" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />

--- a/common/src/Microsoft.Azure.IIoT.Hub.Service.Client/src/Microsoft.Azure.IIoT.Hub.Service.Client.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Hub.Service.Client/src/Microsoft.Azure.IIoT.Hub.Service.Client.csproj
@@ -5,7 +5,7 @@
     <Description>Azure Industrial IoT common IoT Hub service client</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.38.1" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.38.2" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
   </ItemGroup>

--- a/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/src/Microsoft.Azure.IIoT.Serializers.MessagePack.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.MessagePack/src/Microsoft.Azure.IIoT.Serializers.MessagePack.csproj
@@ -7,7 +7,7 @@
     <Description>Azure Industrial IoT Json Serializer</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="2.4.35" />
+    <PackageReference Include="MessagePack" Version="2.4.59" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Core\src\Microsoft.Azure.IIoT.Core.csproj" />

--- a/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj
+++ b/common/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft/src/Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj
@@ -7,7 +7,7 @@
     <Description>Azure Industrial IoT Json Serializer</Description>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet\src\Microsoft.Azure.IIoT.Validators.JsonSchemaDotNet.csproj" />

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/src/Engine/DataFlowProcessingEngine.cs
@@ -208,116 +208,124 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Engine {
         /// Diagnostics timer
         /// </summary>
         private void DiagnosticsOutputTimer_Elapsed(object state) {
-            var info = GetDiagnosticInfo();
-            var totalSeconds = (DateTime.UtcNow - _diagnosticStart).TotalSeconds;
-            double valueChangesPerSec = info.IngressValueChanges / info.IngestionDuration.TotalSeconds;
-            double dataChangesPerSec = info.IngressDataChanges / info.IngestionDuration.TotalSeconds;
-            double valueChangesPerSecLastMin = _messageTrigger.ValueChangesCountLastMinute / Math.Min(totalSeconds, 60d);
-            double dataChangesPerSecLastMin = _messageTrigger.DataChangesCountLastMinute / Math.Min(totalSeconds, 60d);
-            double messageSizeAveragePercent = Math.Round(info.EncoderAvgIoTMessageBodySize / _maxEncodedMessageSize * 100);
-            string messageSizeAveragePercentFormatted = $"({messageSizeAveragePercent}%)";
+            try {
+                var info = GetDiagnosticInfo();
+                if (info == null) {
+                    return;
+                }
+                var totalSeconds = (DateTime.UtcNow - _diagnosticStart).TotalSeconds;
+                double valueChangesPerSec = info.IngressValueChanges / info.IngestionDuration.TotalSeconds;
+                double dataChangesPerSec = info.IngressDataChanges / info.IngestionDuration.TotalSeconds;
+                double valueChangesPerSecLastMin = _messageTrigger.ValueChangesCountLastMinute / Math.Min(totalSeconds, 60d);
+                double dataChangesPerSecLastMin = _messageTrigger.DataChangesCountLastMinute / Math.Min(totalSeconds, 60d);
+                double messageSizeAveragePercent = Math.Round(info.EncoderAvgIoTMessageBodySize / _maxEncodedMessageSize * 100);
+                string messageSizeAveragePercentFormatted = $"({messageSizeAveragePercent}%)";
 
-            _logger.Debug("Identity {deviceId}; {moduleId}", _identity.DeviceId, _identity.ModuleId);
+                _logger.Debug("Identity {deviceId}; {moduleId}", _identity.DeviceId, _identity.ModuleId);
 
-            var diagInfo = new StringBuilder();
-            diagInfo.AppendLine("\n  DIAGNOSTICS INFORMATION for          : {host}");
-            diagInfo.AppendLine("  # Ingestion duration                 : {duration,14:dd\\:hh\\:mm\\:ss} (dd:hh:mm:ss)");
-            string dataChangesPerSecFormatted = info.IngressDataChanges > 0 && info.IngestionDuration.TotalSeconds > 0
-                ? $"(All time ~{dataChangesPerSec:0.##}/s; {_messageTrigger.DataChangesCountLastMinute.ToString("D2")} in last 60s ~{dataChangesPerSecLastMin:0.##}/s)"
-                : "";
-            diagInfo.AppendLine("  # Ingress DataChanges (from OPC)     : {dataChangesCount,14:n0} {dataChangesPerSecFormatted}");
-            string valueChangesPerSecFormatted = info.IngressValueChanges > 0 && info.IngestionDuration.TotalSeconds > 0
-                ? $"(All time ~{valueChangesPerSec:0.##}/s; {_messageTrigger.ValueChangesCountLastMinute.ToString("D2")} in last 60s ~{valueChangesPerSecLastMin:0.##}/s)"
-                : "";
-            diagInfo.AppendLine("  # Ingress ValueChanges (from OPC)    : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
+                var diagInfo = new StringBuilder();
+                diagInfo.AppendLine("\n  DIAGNOSTICS INFORMATION for          : {host}");
+                diagInfo.AppendLine("  # Ingestion duration                 : {duration,14:dd\\:hh\\:mm\\:ss} (dd:hh:mm:ss)");
+                string dataChangesPerSecFormatted = info.IngressDataChanges > 0 && info.IngestionDuration.TotalSeconds > 0
+                    ? $"(All time ~{dataChangesPerSec:0.##}/s; {_messageTrigger.DataChangesCountLastMinute.ToString("D2")} in last 60s ~{dataChangesPerSecLastMin:0.##}/s)"
+                    : "";
+                diagInfo.AppendLine("  # Ingress DataChanges (from OPC)     : {dataChangesCount,14:n0} {dataChangesPerSecFormatted}");
+                string valueChangesPerSecFormatted = info.IngressValueChanges > 0 && info.IngestionDuration.TotalSeconds > 0
+                    ? $"(All time ~{valueChangesPerSec:0.##}/s; {_messageTrigger.ValueChangesCountLastMinute.ToString("D2")} in last 60s ~{valueChangesPerSecLastMin:0.##}/s)"
+                    : "";
+                diagInfo.AppendLine("  # Ingress ValueChanges (from OPC)    : {valueChangesCount,14:n0} {valueChangesPerSecFormatted}");
 
-            diagInfo.AppendLine("  # Ingress BatchBlock buffer size     : {batchDataSetMessageBlockOutputCount,14:0}");
-            diagInfo.AppendLine("  # Encoding Block input/output size   : {encodingBlockInputCount,14:0} | {encodingBlockOutputCount:0}");
-            diagInfo.AppendLine("  # Encoder Notifications processed    : {notificationsProcessedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder Notifications dropped      : {notificationsDroppedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder IoT Messages processed     : {messagesProcessedCount,14:n0}");
-            diagInfo.AppendLine("  # Encoder avg Notifications/Message  : {notificationsPerMessage,14:0}");
-            diagInfo.AppendLine("  # Encoder avg IoT Message body size  : {messageSizeAverage,14:n0} {messageSizeAveragePercentFormatted}");
-            diagInfo.AppendLine("  # Encoder avg IoT Chunk (4 KB) usage : {chunkSizeAverage,14:0.#}");
-            diagInfo.AppendLine("  # Estimated IoT Chunks (4 KB) per day: {estimatedMsgChunksPerDay,14:n0}");
-            diagInfo.AppendLine("  # Outgress Batch Block buffer size   : {batchNetworkMessageBlockOutputCount,14:0}");
-            diagInfo.AppendLine("  # Outgress input buffer count        : {sinkBlockInputCount,14:n0}");
-            diagInfo.AppendLine("  # Outgress input buffer dropped      : {sinkBlockInputDroppedCount,14:n0}");
+                diagInfo.AppendLine("  # Ingress BatchBlock buffer size     : {batchDataSetMessageBlockOutputCount,14:0}");
+                diagInfo.AppendLine("  # Encoding Block input/output size   : {encodingBlockInputCount,14:0} | {encodingBlockOutputCount:0}");
+                diagInfo.AppendLine("  # Encoder Notifications processed    : {notificationsProcessedCount,14:n0}");
+                diagInfo.AppendLine("  # Encoder Notifications dropped      : {notificationsDroppedCount,14:n0}");
+                diagInfo.AppendLine("  # Encoder IoT Messages processed     : {messagesProcessedCount,14:n0}");
+                diagInfo.AppendLine("  # Encoder avg Notifications/Message  : {notificationsPerMessage,14:0}");
+                diagInfo.AppendLine("  # Encoder avg IoT Message body size  : {messageSizeAverage,14:n0} {messageSizeAveragePercentFormatted}");
+                diagInfo.AppendLine("  # Encoder avg IoT Chunk (4 KB) usage : {chunkSizeAverage,14:0.#}");
+                diagInfo.AppendLine("  # Estimated IoT Chunks (4 KB) per day: {estimatedMsgChunksPerDay,14:n0}");
+                diagInfo.AppendLine("  # Outgress Batch Block buffer size   : {batchNetworkMessageBlockOutputCount,14:0}");
+                diagInfo.AppendLine("  # Outgress input buffer count        : {sinkBlockInputCount,14:n0}");
+                diagInfo.AppendLine("  # Outgress input buffer dropped      : {sinkBlockInputDroppedCount,14:n0}");
 
-            string sentMessagesPerSecFormatted = info.OutgressIoTMessageCount > 0 && info.IngestionDuration.TotalSeconds > 0 ? $"({info.SentMessagesPerSec:0.##}/s)" : "";
-            diagInfo.AppendLine("  # Outgress IoT message count         : {messageSinkSentMessagesCount,14:n0} {sentMessagesPerSecFormatted}");
-            diagInfo.AppendLine("  # Connection retries                 : {connectionRetries,14:0}");
-            diagInfo.AppendLine("  # Opc endpoint connected?            : {isConnectionOk,14:0}");
-            diagInfo.AppendLine("  # Monitored Opc nodes succeeded count: {goodNodes,14:0}");
-            diagInfo.AppendLine("  # Monitored Opc nodes failed count   : {badNodes,14:0}");
+                string sentMessagesPerSecFormatted = info.OutgressIoTMessageCount > 0 && info.IngestionDuration.TotalSeconds > 0 ? $"({info.SentMessagesPerSec:0.##}/s)" : "";
+                diagInfo.AppendLine("  # Outgress IoT message count         : {messageSinkSentMessagesCount,14:n0} {sentMessagesPerSecFormatted}");
+                diagInfo.AppendLine("  # Connection retries                 : {connectionRetries,14:0}");
+                diagInfo.AppendLine("  # Opc endpoint connected?            : {isConnectionOk,14:0}");
+                diagInfo.AppendLine("  # Monitored Opc nodes succeeded count: {goodNodes,14:0}");
+                diagInfo.AppendLine("  # Monitored Opc nodes failed count   : {badNodes,14:0}");
 
-            _logger.Information(diagInfo.ToString(),
-                info.Id,
-                info.IngestionDuration,
-                info.IngressDataChanges, dataChangesPerSecFormatted,
-                info.IngressValueChanges, valueChangesPerSecFormatted,
-                info.IngressBatchBlockBufferSize,
-                info.EncodingBlockInputSize, info.EncodingBlockOutputSize,
-                info.EncoderNotificationsProcessed,
-                info.EncoderNotificationsDropped,
-                info.EncoderIoTMessagesProcessed,
-                info.EncoderAvgNotificationsMessage,
-                info.EncoderAvgIoTMessageBodySize, messageSizeAveragePercentFormatted,
-                info.EncoderAvgIoTChunkUsage,
-                info.EstimatedIoTChunksPerDay,
-                info.OutgressBatchBlockBufferSize,
-                info.OutgressInputBufferCount,
-                info.OutgressInputBufferDropped,
-                info.OutgressIoTMessageCount, sentMessagesPerSecFormatted,
-                info.ConnectionRetries,
-                info.OpcEndpointConnected,
-                info.MonitoredOpcNodesSucceededCount,
-                info.MonitoredOpcNodesFailedCount);
+                _logger.Information(diagInfo.ToString(),
+                    info.Id,
+                    info.IngestionDuration,
+                    info.IngressDataChanges, dataChangesPerSecFormatted,
+                    info.IngressValueChanges, valueChangesPerSecFormatted,
+                    info.IngressBatchBlockBufferSize,
+                    info.EncodingBlockInputSize, info.EncodingBlockOutputSize,
+                    info.EncoderNotificationsProcessed,
+                    info.EncoderNotificationsDropped,
+                    info.EncoderIoTMessagesProcessed,
+                    info.EncoderAvgNotificationsMessage,
+                    info.EncoderAvgIoTMessageBodySize, messageSizeAveragePercentFormatted,
+                    info.EncoderAvgIoTChunkUsage,
+                    info.EstimatedIoTChunksPerDay,
+                    info.OutgressBatchBlockBufferSize,
+                    info.OutgressInputBufferCount,
+                    info.OutgressInputBufferDropped,
+                    info.OutgressIoTMessageCount, sentMessagesPerSecFormatted,
+                    info.ConnectionRetries,
+                    info.OpcEndpointConnected,
+                    info.MonitoredOpcNodesSucceededCount,
+                    info.MonitoredOpcNodesFailedCount);
 
-            string deviceId = _identity.DeviceId ?? "";
-            string moduleId = _identity.ModuleId ?? "";
-            kDataChangesCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.IngressDataChanges);
-            kDataChangesPerSecond.WithLabels(deviceId, moduleId, Name)
-                .Set(dataChangesPerSec);
-            kDataChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
-                .Set(dataChangesPerSecLastMin);
-            kValueChangesCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.IngressValueChanges);
-            kValueChangesPerSecond.WithLabels(deviceId, moduleId, Name)
-                .Set(valueChangesPerSec);
-            kValueChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
-                .Set(valueChangesPerSecLastMin);
-            kNotificationsProcessedCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderNotificationsProcessed);
-            kNotificationsDroppedCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderNotificationsDropped);
-            kMessagesProcessedCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderIoTMessagesProcessed);
-            kNotificationsPerMessageAvg.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderAvgNotificationsMessage);
-            kMessageSizeAvg.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderAvgIoTMessageBodySize);
-            kIoTHubQueueBuffer.WithLabels(deviceId, moduleId, Name)
-                .Set(info.OutgressInputBufferCount);
-            kIoTHubQueueBufferDroppedCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.OutgressInputBufferDropped);
-            kSentMessagesCount.WithLabels(deviceId, moduleId, Name)
-                .Set(info.OutgressIoTMessageCount);
-            kSentMessagesPerSecond.WithLabels(deviceId, moduleId, Name)
-                .Set(info.SentMessagesPerSec);
-            kNumberOfConnectionRetries.WithLabels(deviceId, moduleId, Name)
-                .Set(info.ConnectionRetries);
-            kIsConnectionOk.WithLabels(deviceId, moduleId, Name)
-                .Set(info.OpcEndpointConnected ? 1 : 0);
-            kNumberOfGoodNodes.WithLabels(deviceId, moduleId, Name)
-                .Set(info.MonitoredOpcNodesSucceededCount);
-            kNumberOfBadNodes.WithLabels(deviceId, moduleId, Name)
-                .Set(info.MonitoredOpcNodesFailedCount);
-            kChunkSizeAvg.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EncoderAvgIoTChunkUsage);
-            kEstimatedMsgChunksPerday.WithLabels(deviceId, moduleId, Name)
-                .Set(info.EstimatedIoTChunksPerDay);
+                string deviceId = _identity.DeviceId ?? "";
+                string moduleId = _identity.ModuleId ?? "";
+                kDataChangesCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.IngressDataChanges);
+                kDataChangesPerSecond.WithLabels(deviceId, moduleId, Name)
+                    .Set(dataChangesPerSec);
+                kDataChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
+                    .Set(dataChangesPerSecLastMin);
+                kValueChangesCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.IngressValueChanges);
+                kValueChangesPerSecond.WithLabels(deviceId, moduleId, Name)
+                    .Set(valueChangesPerSec);
+                kValueChangesPerSecondLastMin.WithLabels(deviceId, moduleId, Name)
+                    .Set(valueChangesPerSecLastMin);
+                kNotificationsProcessedCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderNotificationsProcessed);
+                kNotificationsDroppedCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderNotificationsDropped);
+                kMessagesProcessedCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderIoTMessagesProcessed);
+                kNotificationsPerMessageAvg.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderAvgNotificationsMessage);
+                kMessageSizeAvg.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderAvgIoTMessageBodySize);
+                kIoTHubQueueBuffer.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.OutgressInputBufferCount);
+                kIoTHubQueueBufferDroppedCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.OutgressInputBufferDropped);
+                kSentMessagesCount.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.OutgressIoTMessageCount);
+                kSentMessagesPerSecond.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.SentMessagesPerSec);
+                kNumberOfConnectionRetries.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.ConnectionRetries);
+                kIsConnectionOk.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.OpcEndpointConnected ? 1 : 0);
+                kNumberOfGoodNodes.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.MonitoredOpcNodesSucceededCount);
+                kNumberOfBadNodes.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.MonitoredOpcNodesFailedCount);
+                kChunkSizeAvg.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EncoderAvgIoTChunkUsage);
+                kEstimatedMsgChunksPerday.WithLabels(deviceId, moduleId, Name)
+                    .Set(info.EstimatedIoTChunksPerDay);
+            }
+            catch (Exception ex) {
+                _logger.Error(ex, "Error in diagnostics output.");
+            }
         }
 
         /// <summary>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/StandaloneJobOrchestratorTests.cs
@@ -586,6 +586,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.Engine {
         [InlineData("Engine/pn_assets_with_optional_fields.json")]
         [InlineData("Engine/publishednodes.json")]
         [InlineData("Engine/publishednodeswithoptionalfields.json")]
+        [InlineData("Engine/publishednodes_with_duplicates.json")]
         [InlineData("Controller/DmApiPayloadCollection.json")]
         [InlineData("Controller/DmApiPayloadTwoEndpoints.json")]
         public async Task Test_AddOrUpdateEndpoints_RemoveEndpoints(string publishedNodesFile) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/publishednodes_with_duplicates.json
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Engine/publishednodes_with_duplicates.json
@@ -1,0 +1,35 @@
+[
+    {
+        "EndpointUrl": "opc.tcp://10.0.0.1:59412",
+        "UseSecurity": false,
+        "OpcAuthenticationMode": "UsernamePassword",
+        "OpcAuthenticationUsername": "user",
+        "OpcAuthenticationPassword": "passwd",
+        "OpcNodes": [
+            {
+                "Id": "ns=2;s=Variable1.Line1.Power",
+                "DisplayName": "Variable1_Power",
+                "OpcSamplingInterval": 60000,
+                "OpcPublishingInterval": 60000,
+                "HeartbeatInterval": 3343,
+                "SkipFirst": false
+            },
+            {
+                "Id": "ns=2;s=Variable1.Line1.Speed",
+                "DisplayName": "Variable1_Line1_Speed",
+                "OpcSamplingInterval": 900000,
+                "OpcPublishingInterval": 900000,
+                "HeartbeatInterval": 3465,
+                "SkipFirst": false
+            },
+            {
+                "Id": "ns=2;s=Variable1.Line1.Power",
+                "DisplayName": "Variable1_Line1_Power",
+                "OpcSamplingInterval": 60000,
+                "OpcPublishingInterval": 60000,
+                "HeartbeatInterval": 3343,
+                "SkipFirst": false
+            }
+        ]
+    }
+]

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher/tests/Microsoft.Azure.IIoT.OpcUa.Edge.Publisher.Tests.csproj
@@ -59,6 +59,9 @@
     <None Update="Engine\pn_assets_with_optional_fields.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Engine\publishednodes_with_duplicates.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Engine\publishednodeswithoptionalfields.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Microsoft.Azure.IIoT.OpcUa.Protocol.csproj
@@ -36,26 +36,13 @@
       <Visitor>False</Visitor>
     </Antlr4>
   </ItemGroup>
-  <Choose>
-    <When Condition="'$(Configuration)'=='Release'">
-      <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.370.12" />
-      </ItemGroup>
-    </When>
-    <Otherwise>
-      <ItemGroup>
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core.Debug" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration.Debug" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server.Debug" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.Debug" Version="1.4.370.12" />
-        <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes.Debug" Version="1.4.370.12" />
-      </ItemGroup>
-    </Otherwise>
-  </Choose>
+  <ItemGroup>
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.4.371.50" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Configuration" Version="1.4.371.50" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.4.371.50" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.4.371.50" />
+    <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.4.371.50" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\common\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft\src\Microsoft.Azure.IIoT.Serializers.NewtonSoft.csproj" />
   </ItemGroup>

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/DefaultSessionManager.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
                 if (!_sessions.TryGetValue(key, out var wrapper)) {
                     return;
                 }
-                if (onlyIfEmpty && wrapper._subscriptions.Count == 0) {
+                if (onlyIfEmpty && wrapper._subscriptions.IsEmpty) {
                     wrapper.State = SessionState.Disconnect;
                     TriggerKeepAlive();
                 }
@@ -699,13 +699,13 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
         /// </summary>
         /// <param name="session"></param>
         /// <param name="e"></param>
-        private void Session_Notification(Session session, NotificationEventArgs e) {
+        private void Session_Notification(ISession session, NotificationEventArgs e) {
             try {
                 _logger.Debug("Notification for session '{id}', subscription '{displayName}' - sequence# {sequence}-{publishTime}",
                     session?.Handle is SessionWrapper wrapper ? wrapper?.Id : session?.SessionName,
                     e.Subscription?.DisplayName, e?.NotificationMessage?.SequenceNumber,
                     e.NotificationMessage?.PublishTime);
-                if (e.NotificationMessage.IsEmpty || e.NotificationMessage.NotificationData.Count() == 0) {
+                if (e.NotificationMessage.IsEmpty || e.NotificationMessage.NotificationData.Count == 0) {
                     var keepAlive = new DataChangeNotification() {
                         MonitoredItems = new MonitoredItemNotificationCollection() {
                         new MonitoredItemNotification() {
@@ -728,7 +728,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
         /// </summary>
         /// <param name="session"></param>
         /// <param name="e"></param>
-        private void Session_KeepAlive(Session session, KeepAliveEventArgs e) {
+        private void Session_KeepAlive(ISession session, KeepAliveEventArgs e) {
             try {
                 if (session?.Handle is SessionWrapper wrapper) {
 

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/SubscriptionServices.cs
@@ -1126,7 +1126,7 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             /// <summary>
             /// Create new stack monitored item
             /// </summary>
-            internal void Create(Session session, IVariantEncoder codec, bool activate) {
+            internal void Create(ISession session, IVariantEncoder codec, bool activate) {
                 Item = new MonitoredItem {
                     Handle = this,
                     DisplayName = Template.DisplayName,

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/JsonDecoderEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/JsonDecoderEx.cs
@@ -566,13 +566,16 @@ namespace Opc.Ua.Encoders {
             if (enumType == null) {
                 throw new ArgumentNullException(nameof(enumType));
             }
+            if (!enumType.IsEnum) {
+                throw new ArgumentException("Not an enum type", nameof(enumType));
+            }
             if (!TryGetToken(property, out var token)) {
                 return (Enum)Enum.ToObject(enumType, 0); // or null?
             }
             if (token.Type == JTokenType.String) {
                 var val = (string)token;
                 var index = val.LastIndexOf('_');
-                if (index != -1 && int.TryParse(val.Substring(index + 1),
+                if (index != -1 && int.TryParse(val.AsSpan(index + 1),
                     out var numeric)) {
                     return (Enum)Enum.ToObject(enumType, numeric);
                 }
@@ -587,7 +590,7 @@ namespace Opc.Ua.Encoders {
         /// <summary>
         /// Reads an array with the specified valueRank and the specified BuiltInType
         /// </summary>
-        public object ReadArray(string fieldName, int valueRank, BuiltInType builtInType, ExpandedNodeId nodeId) {
+        public Array ReadArray(string fieldName, int valueRank, BuiltInType builtInType, Type systemType, ExpandedNodeId nodeId) {
             if (valueRank == ValueRanks.OneDimension) {
                 switch (builtInType) {
                     case BuiltInType.Boolean:
@@ -660,57 +663,57 @@ namespace Opc.Ua.Encoders {
 
                 switch (builtInType) {
                     case BuiltInType.Boolean:
-                        return new Matrix(elements.Cast<bool>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<bool>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.SByte:
-                        return new Matrix(elements.Cast<sbyte>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<sbyte>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Byte:
-                        return new Matrix(elements.Cast<byte>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<byte>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Int16:
-                        return new Matrix(elements.Cast<Int16>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Int16>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.UInt16:
-                        return new Matrix(elements.Cast<UInt16>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<UInt16>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Int32:
-                        return new Matrix(elements.Cast<Int32>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Int32>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.UInt32:
-                        return new Matrix(elements.Cast<UInt32>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<UInt32>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Int64:
-                        return new Matrix(elements.Cast<Int64>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Int64>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.UInt64:
-                        return new Matrix(elements.Cast<UInt64>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<UInt64>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Float:
-                        return new Matrix(elements.Cast<float>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<float>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Double:
-                        return new Matrix(elements.Cast<double>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<double>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.String:
-                        return new Matrix(elements.Cast<string>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<string>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.DateTime:
-                        return new Matrix(elements.Cast<DateTime>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<DateTime>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Guid:
-                        return new Matrix(elements.Cast<Uuid>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Uuid>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.ByteString:
-                        return new Matrix(elements.Cast<byte[]>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<byte[]>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.XmlElement:
-                        return new Matrix(elements.Cast<XmlElement>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<XmlElement>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.NodeId:
-                        return new Matrix(elements.Cast<NodeId>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<NodeId>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.ExpandedNodeId:
-                        return new Matrix(elements.Cast<ExpandedNodeId>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<ExpandedNodeId>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.StatusCode:
-                        return new Matrix(elements.Cast<StatusCode>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<StatusCode>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.QualifiedName:
-                        return new Matrix(elements.Cast<QualifiedName>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<QualifiedName>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.LocalizedText:
-                        return new Matrix(elements.Cast<LocalizedText>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<LocalizedText>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.DataValue:
-                        return new Matrix(elements.Cast<DataValue>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<DataValue>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Enumeration:
-                        return new Matrix(elements.Cast<Int32>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Int32>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.Variant:
-                        return new Matrix(elements.Cast<Variant>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<Variant>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.ExtensionObject:
-                        return new Matrix(elements.Cast<ExtensionObject>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<ExtensionObject>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                     case BuiltInType.DiagnosticInfo:
-                        return new Matrix(elements.Cast<DiagnosticInfo>().ToArray(), builtInType, dimensions.ToArray());
+                        return new Matrix(elements.Cast<DiagnosticInfo>().ToArray(), builtInType, dimensions.ToArray()).ToArray();
                 }
             }
             return null;
@@ -1755,7 +1758,7 @@ namespace Opc.Ua.Encoders {
         /// <param name="o"></param>
         /// <param name="properties"></param>
         /// <returns></returns>
-        private bool HasAnyOf(JObject o, params string[] properties) {
+        private static bool HasAnyOf(JObject o, params string[] properties) {
             foreach (var property in properties) {
                 if (o.TryGetValue(property,
                     StringComparison.InvariantCultureIgnoreCase, out _)) {
@@ -1915,7 +1918,7 @@ namespace Opc.Ua.Encoders {
                     }
                     if (!hasInnerArray) {
                         // read array from one dimension
-                        var part = ReadArray(null, ValueRanks.OneDimension, builtInType, null) as System.Collections.IList;
+                        var part = ReadArray(null, ValueRanks.OneDimension, builtInType, null, null) as System.Collections.IList;
                         if (part != null && part.Count > 0) {
                             // add part elements to final list
                             foreach (var item in part) {

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/JsonEncoderEx.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/JsonEncoderEx.cs
@@ -962,15 +962,25 @@ namespace Opc.Ua.Encoders {
         }
 
         /// <inheritdoc/>
-        public void WriteEnumeratedArray(string property, Array values, Type systemType) {
-            if (values == null || values.Length == 0) {
+        public void WriteEnumeratedArray(string property, Array values, Type enumType) {
+            if (values == null) {
                 WriteNull(property);
             }
             else {
                 PushArray(property, values.Length);
                 // encode each element in the array.
-                foreach (Enum value in values) {
-                    WriteEnumerated(null, value);
+                if (enumType.IsEnum) {
+                    foreach (Enum value in values) {
+                        WriteEnumerated(null, value);
+                    }
+                }
+                else if (enumType == typeof(int)) {
+                    foreach (int value in values) {
+                        WriteInt32(null, value);
+                    }
+                }
+                else {
+                    throw new ArgumentException("Not an enum type", nameof(enumType));
                 }
                 PopArray();
             }

--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/ModelDecoder.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Stack/Encoders/ModelDecoder.cs
@@ -333,8 +333,8 @@ namespace Opc.Ua.Encoders {
         }
 
         /// <inheritdoc />
-        public object ReadArray(string fieldName, int valueRank, BuiltInType builtInType, ExpandedNodeId nodeId) {
-            return _wrapped.ReadArray(fieldName, valueRank, builtInType);
+        public Array ReadArray(string fieldName, int valueRank, BuiltInType builtInType, Type type, ExpandedNodeId nodeId) {
+            return _wrapped.ReadArray(fieldName, valueRank, builtInType, type, nodeId);
         }
 
         /// <summary>

--- a/deploy/helm/azure-industrial-iot/Chart.yaml
+++ b/deploy/helm/azure-industrial-iot/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: azure-industrial-iot
-version: 0.4.4-rc
+version: 0.4.5-rc
 description: Azure Industrial IoT allows plant operators to discover OPC UA enabled servers in a factory network and register them in Azure IoT Hub.
 type: application
 keywords:

--- a/deploy/scripts/default.yml
+++ b/deploy/scripts/default.yml
@@ -3,18 +3,18 @@ services:
   opcserver0:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51200
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51200:51200"
   opcserver1:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51201    
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51201:51201"
   opcserver2:
     image: mcr.microsoft.com/iotedge/opc-plc:2.2.0
     restart: always
-    command: --aa -pn 51202
+    command: --aa -pn 51200 -fn 50 -fr 1 -sn 250 -sr 10
     ports:
       - "51202:51202"

--- a/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
+++ b/deploy/src/Microsoft.Azure.IIoT.Deployment/Microsoft.Azure.IIoT.Deployment.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Graph" Version="3.35.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.7" />
 
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.48.1" />
 
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="6.0.0" />
@@ -37,10 +37,10 @@
 
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
 
-    <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
 
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/release-announcement.md
+++ b/docs/release-announcement.md
@@ -1,37 +1,59 @@
 # Release announcement
 
+## Azure Industrial IoT Platform Release 2.8.5
+
+We are pleased to announce the release of version 2.8.5 of our Industrial IoT Platform components as latest patch update of the 2.8 Long-Term Support (LTS) release. This release contains important security updates fixes, performance optimizations and bugfixes.
+
+### Changes in this release
+
+- [All] Update to latest dependencies.
+- [All] Use latest OPC UA .net stack 371.
+- [OPC Publisher] Fix a crash in the diagnostics output timer in orchestrated mode when endpoint url is reported null. (#1955)
+
 ## Azure Industrial IoT Platform Release 2.8.4
 
 We are pleased to announce the release of version 2.8.4 of our Industrial IoT Platform components as latest patch update of the 2.8 Long-Term Support (LTS) release. This release contains important security updates fixes, performance optimizations and bugfixes.
 
 ### IMPORTANT - PLEASE READ
 
-- IoT Edge 1.1 LTS is out of support, please [update your IoT Edge gateways to IoT Edge 1.4 LTS](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-update-iot-edge) **ahead of deploying this release**.
-    > To continue deploying the 1.1 LTS modules until 1.4 is deployed, add a tag to your gateway device's twin with the name `use_1_1_LTS` and remove it once you have upgraded your edge gateway to 1.4 LTS. This operation can be automated using the az CLI.  See [here](./deploy/howto-install-iot-edge.md) for more information.
+- IoT Edge 1.1 LTS will be going out of support on 12/13/2022, please [update your IoT Edge gateways to IoT Edge 1.4 LTS](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-update-iot-edge).
+
+  > To continue deploying the 1.1 LTS modules to your environment follow [these instructions](./deploy/howto-install-iot-edge.md).
+
 - Windows container images are no longer supported in IoT Edge 1.4 and consequentially have been removed from this release. Please use [IoT Edge for Linux on Windows (EFLOW) 1.4](https://learn.microsoft.com/en-us/windows/iot/iot-enterprise/azure-iot-edge-for-linux-on-windows) as your IoT Edge environment on Windows.  
-  > IoT Edge 1.4 LTS EFLOW is supported as Preview Feature in this release. 
+
+  > IoT Edge 1.4 LTS EFLOW is supported as a Preview Feature in this release.
+
   - You must update your Windows based IoT Edge environment to EFLOW **ahead of deploying the platform**.  
   - Simulation deployed as part of the ./deploy.ps1 script now deploys EFLOW on a Windows VM Host (Preview Feature).  This requires nested virtualization.  The Azure subscription and chosen region must support Standard_D4_v4 VM which supports nested virtualization or deployment of simulated Windows gateway will be skipped.
   - Network scanning on IoT Edge 1.4 LTS EFLOW using OPC Discovery is not supported yet. This applies to the deployed [simulation environment](./deploy/howto-deploy-all-in-one.md) and [engineering tool](./services/engineeringtool.md) experience. You can register servers using a discovery url using the [registry service's registration REST API](./services/registry.md).
 
 ### Changes in this release
 
-- Updated .net to .net 6.0 LTS from .net 3.1 LTS which is EOL December 2022.
+- Updated .net to .net 6.0 LTS from .net core 3.1 LTS which will be going out of support on 12/13/2022.
 - Updated nuget dependencies to their .net 6 counterpart or to their latest compatible release.
-- [All IoT Edge modules] Updated IoT Edge dependency to IoT Edge 1.4 LTS from 1.1 LTS which is EOL December 2022.
+- [All IoT Edge modules] Updated IoT Edge dependency to IoT Edge 1.4 LTS from 1.1 LTS which will be going out of support on 12/13/2022.
 - [All IoT Edge modules] (Preview) Support for [IoT Edge EFLOW 1.4 LTS](https://learn.microsoft.com/en-us/windows/iot/iot-enterprise/azure-iot-edge-for-linux-on-windows)
 - [OPC Publisher] Fix for orchestrator infinite loop on publisher worker document update (#1870)
 - [OPC Publisher] Rate limit OPC Publisher orchestrator requests.
+- [OPC Publisher] More explicit error logs in orchestrated mode, also showing transient exceptions in logs for better troubleshooting.
 - [OPC Publisher] Add --bi / --batchtriggerinterval command line option to define interval in milliseconds. (#1893)
 - [Deployment] IAI: Upgraded Kubernetes version in AKS from 1.22.6 to 1.23.12. (#1885)
 - [Deployment] Increased proxy-connect-timeout of NGINX from default 5 seconds to 30. (#1871)
 - [OPC Publisher] (Preview) User can set the Data change trigger value of the Data change filter type either as a default for all or per subscription (#1830).
 - [OPC Publisher] (Preview) Allow comment in OpcPublisher Configuration when Validation is used (#1892)
 - [All IoT Edge modules] Add a configuration option to set security option RejectUnknownRevocationStatus (#1777)
-- [All IoT Edge modules] Add mandatory field for edgeHub in the base deployment template to support cloning deployments (#1764
+- [All IoT Edge modules] Add mandatory field for edgeHub in the base deployment template to support cloning deployments (#1764)
 - [OPC Discovery] Ensure duplicate discovery urls override previous url instead of causing exception (#1903, #1902)
+- [OPC Discovery] Enginering tool ad hoc discovery fails with "capacity must be non negative" error found during bug bash. (#1907)
+- [OPC Twin] Fix sessions in Twin are not closed when endpoint is deactivated. (#1910)
 
 For features that are marked as Preview, please report any issues through GitHub issues.
+
+### Known issues
+
+- Under EFLOW, by default the Application instance certificate is generated by each module and not automatically shared. To work around this, configure EFLOW and modules deployed manually to use a [shared host volume](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-share-windows-folder-to-vm?view=iotedge-2018-06) to map the pki folders.
+- Discovering using IP Address and port ranges is not supported on EFLOW.
 
 ## Azure Industrial IoT Platform Release 2.8.3
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.8.4",
+  "version": "2.8.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
* Set main version to 2.8.5 (#1906)
* Aligning number of fast and slow nodes in simulation OPC PLCs. (#1908)
* Release announcement update (#1201 
* Update to latest OPC UA stack release (371) (#1919)
* Fix publisher module crashing due to null pointer exception. Catch any errors in the diagnostics output. 
---------
Co-authored-by: Karapet Kostandyan <kakostan@microsoft.com>