### PR TITLE
Enabling using DisplayNames defined for the event fields in pn.json as keys in the payload of dataset messages

### DIFF
--- a/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/MonitoredItemWrapper.cs
+++ b/components/opc-ua/src/Microsoft.Azure.IIoT.OpcUa.Protocol/src/Services/MonitoredItemWrapper.cs
@@ -486,34 +486,43 @@ namespace Microsoft.Azure.IIoT.OpcUa.Protocol.Services {
             foreach (var selectClause in eventFilter.SelectClauses) {
                 if (!internalSelectClauses.Any(x => x == selectClause)) {
                     sb.Clear();
-                    for (var i = 0; i < selectClause.BrowsePath?.Count; i++) {
-                        if (i == 0) {
-                            if (selectClause.BrowsePath[i].NamespaceIndex != 0) {
-                                if (selectClause.BrowsePath[i].NamespaceIndex < nodeCache.NamespaceUris.Count) {
-                                    sb.Append(nodeCache.NamespaceUris.GetString(selectClause.BrowsePath[i].NamespaceIndex));
-                                    sb.Append('#');
-                                }
-                                else {
-                                    sb.Append($"{selectClause.BrowsePath[i].NamespaceIndex}:");
+
+                    var definedSelectClause = EventTemplate.EventFilter.SelectClauses?.ElementAtOrDefault(eventFilter.SelectClauses.IndexOf(selectClause));
+                    if (!string.IsNullOrEmpty(definedSelectClause?.DisplayName)) {
+                        sb.Append(definedSelectClause.DisplayName);
+                    }
+                    else {
+                        for (var i = 0; i < selectClause.BrowsePath?.Count; i++) {
+                            if (i == 0) {
+                                if (selectClause.BrowsePath[i].NamespaceIndex != 0) {
+                                    if (selectClause.BrowsePath[i].NamespaceIndex < nodeCache.NamespaceUris.Count) {
+                                        sb.Append(nodeCache.NamespaceUris.GetString(selectClause.BrowsePath[i].NamespaceIndex));
+                                        sb.Append('#');
+                                    }
+                                    else {
+                                        sb.Append($"{selectClause.BrowsePath[i].NamespaceIndex}:");
+                                    }
                                 }
                             }
+                            else {
+                                sb.Append('/');
+                            }
+
+                            sb.Append(selectClause.BrowsePath[i].Name);
                         }
-                        else {
-                            sb.Append('/');
+
+                        if (sb.Length == 0) {
+                            if (selectClause.TypeDefinitionId == ObjectTypeIds.ConditionType &&
+                                selectClause.AttributeId == Attributes.NodeId) {
+                                sb.Append("ConditionId");
+                            }
                         }
-                        sb.Append(selectClause.BrowsePath[i].Name);
                     }
 
-                    if (sb.Length == 0) {
-                        if (selectClause.TypeDefinitionId == ObjectTypeIds.ConditionType &&
-                            selectClause.AttributeId == Attributes.NodeId) {
-                            sb.Append("ConditionId");
-                        }
-                    }
                     Fields.Add((sb.ToString(), Guid.NewGuid()));
                 }
                 else {
-                    // if a field's nameis empty, it's not written to the output
+                    // if a field's name is empty, it's not written to the output
                     Fields.Add((null, Guid.Empty));
                 }
             }


### PR DESCRIPTION
For the “normal” value nodes DisplayNames can be defined in pn.json. These DisplayNames  are then used as keys in the payload of dataset messages. For the events / conditions this possibility is missing. It is though possible to define DisplayNames for event fields in SelectClauses, but they are not used as Keys in the dataset messages. Enabling this possibility would be, on the one hand, logical for reasons of uniformity - the same behavior in the configuration / expected output of data values and events. 
On the other hand, we need it strongly for our processing pipeline. We use for further processing Kafka, and in Kafka we are using the AVRO  format to validate the consumed OPC UA PubSub messages. This format allows unfortunately only letter characters and '_' in keys, no special characters as “/” or “#”, which is the case e.g., when you have BrowsePaths (using as keys) consisting of more than one segment or from custom namespaces. 
