### PR TITLE
Fix broken link.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ Our releases are tagged following semantic versioning (“semver”) conventions
 | 2.5                                         | 2.5.5                      | 12/1/2021      | 2.8  (LTS) (>= 2.8.2) | [Migration Path](docs/opc-publisher/migrationpath.md) |
 | 2.7                                         | 2.7.206                    | 1/15/2022      | 2.8  (LTS) (>= 2.8.0) | N/A                                                       |
 | 2.8 (LTS)                                   | [2.8.6](https://github.com/Azure/Industrial-IoT/tree/release/2.8.6) | 7/15/2023      | 2.9                   | N/A                                                       |
-| [2.9](https://github.com/Azure/Industrial-IoT)| 2.9.0-preview3             | N/A            | 2.10 (LTS)            | [Migration Path](docs/opc-publisher/migrationpath.mdd) |
+| [2.9](https://github.com/Azure/Industrial-IoT)| 2.9.0-preview3             | N/A            | 2.10 (LTS)            | [Migration Path](docs/opc-publisher/migrationpath.md) |
 
 We only support the latest patch version of a release which per semantic versioning convention is identified by the 3rd part of the version string. Preview releases are only supported through GitHub issues. If you are using a container image with a major.minor version tag that is supported per above table, but a patch version lower than the latest patch version, you need to update your images to the latest version to ensure secure operation and take advantage of the latest fixes. If you unexpectedly encounter bugs and require help, please ensure you are running the latest patch release as we might already have addressed the issue you are seeing. If you are not, please update first and try to reproduce the issue on the latest patch version.
 


### PR DESCRIPTION
The migration path link in the version table had the wrong file name.

previously:

`docs/opc-publisher/migrationpath.mdd`

corrected to:

`docs/opc-publisher/migrationpath.md`