### PR TITLE
Fix roundtrip double encoding in JsonEncoder

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
@@ -584,7 +584,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
                 {
                     if (Enum.TryParse<TransportOption>(GetStringOrDefault(HubTransport),
                             out var transport) ||
-                        Enum.TryParse<TransportOption>(GetStringOrDefault(UpstreamProtocol),
+                        Enum.TryParse(GetStringOrDefault(UpstreamProtocol),
                             out transport))
                     {
                         options.Transport = transport;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicPubSubIntegrationTests.cs
@@ -7,7 +7,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
 {
     using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
     using Azure.IIoT.OpcUa.Publisher.Testing.Fixtures;
-    using NuGet.Frameworks;
     using System;
     using System.Linq;
     using System.Text.Json;

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Program.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Program.cs
@@ -7,7 +7,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Cli
 {
     using Azure.IIoT.OpcUa.Publisher.Stack.Services;
     using Furly.Extensions.Logging;
-    using global::Opc.Ua;
+    using Opc.Ua;
     using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Services/NodeServices.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Services/NodeServices.cs
@@ -16,8 +16,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
     using Microsoft.Extensions.Options;
     using Opc.Ua;
     using Opc.Ua.Extensions;
-    using BrowseDirection = OpcUa.Publisher.Models.BrowseDirection;
-    using NodeClass = OpcUa.Publisher.Models.NodeClass;
+    using BrowseDirection = Models.BrowseDirection;
+    using NodeClass = Models.NodeClass;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -225,7 +225,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                 }
                 var targets = new List<NodePathTargetModel>();
                 var requests = new BrowsePathCollection(request.BrowsePaths.Select(p =>
-                    new Opc.Ua.BrowsePath
+                    new BrowsePath
                     {
                         StartingNode = rootId,
                         RelativePath = p.ToRelativePath(context.Session.MessageContext)
@@ -1657,7 +1657,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                 Targets = new List<NodePathTargetModel>()
             };
             var browsepaths = new BrowsePathCollection {
-                new Opc.Ua.BrowsePath {
+                new BrowsePath {
                     StartingNode = rootId,
                     RelativePath = paths.ToRelativePath(session.MessageContext)
                 }

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Extensions/SessionHandleEx.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Extensions/SessionHandleEx.cs
@@ -12,7 +12,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Extensions
     using Furly.Extensions.Serializers;
     using Opc.Ua;
     using Opc.Ua.Extensions;
-    using NodeClass = OpcUa.Publisher.Models.NodeClass;
+    using NodeClass = Publisher.Models.NodeClass;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -1175,16 +1175,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Extensions
         /// <param name="parent"></param>
         /// <param name="parentPath"></param>
         /// <param name="browsePaths"></param>
-        private static List<Opc.Ua.BrowsePath> GetBrowsePathFromNodeState(
+        private static List<BrowsePath> GetBrowsePathFromNodeState(
             this IOpcUaSession session, NodeId rootId, NodeState parent,
-            RelativePath? parentPath, List<Opc.Ua.BrowsePath>? browsePaths = null)
+            RelativePath? parentPath, List<BrowsePath>? browsePaths = null)
         {
-            browsePaths ??= new List<Opc.Ua.BrowsePath>();
+            browsePaths ??= new List<BrowsePath>();
             var children = new List<BaseInstanceState>();
             parent.GetChildren(session.SystemContext, children);
             foreach (var child in children)
             {
-                var browsePath = new Opc.Ua.BrowsePath
+                var browsePath = new BrowsePath
                 {
                     StartingNode = rootId,
                     Handle = child

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Extensions/StackModelsEx.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Extensions/StackModelsEx.cs
@@ -9,7 +9,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack
     using Furly.Extensions.Serializers;
     using Opc.Ua;
     using Opc.Ua.Extensions;
-    using DiagnosticsLevel = OpcUa.Publisher.Models.DiagnosticsLevel;
+    using DiagnosticsLevel = Publisher.Models.DiagnosticsLevel;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/IOpcUaMonitoredItem.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/IOpcUaMonitoredItem.cs
@@ -36,7 +36,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack
         /// Get any changes in the monitoring mode to apply if any.
         /// Otherwise the returned value is null.
         /// </summary>
-        Opc.Ua.MonitoringMode? MonitoringModeChange { get; }
+        MonitoringMode? MonitoringModeChange { get; }
 
         /// <summary>
         /// Monitored item once added to the subscription. Contract:

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Models/SubscriptionModel.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Models/SubscriptionModel.cs
@@ -5,7 +5,6 @@
 
 namespace Azure.IIoT.OpcUa.Publisher.Stack.Models
 {
-    using Furly.Extensions.Serializers;
     using System.Collections.Generic;
 
     /// <summary>

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaClient.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaClient.cs
@@ -611,7 +611,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                                 case SessionState.Connected:
                                     var item = context as ISubscriptionHandle;
                                     Debug.Assert(item != null);
-                                    var diff = ImmutableHashSet.Create<ISubscriptionHandle>(item);
+                                    var diff = ImmutableHashSet.Create(item);
                                     await ApplySubscriptionAsync(diff, cancellationToken: ct).ConfigureAwait(false);
                                     break;
                             }

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.cs
@@ -13,14 +13,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
     using Opc.Ua.Client;
     using Opc.Ua.Client.ComplexTypes;
     using Opc.Ua.Extensions;
-    using MonitoringMode = OpcUa.Publisher.Models.MonitoringMode;
+    using MonitoringMode = Publisher.Models.MonitoringMode;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Threading;
-    using Newtonsoft.Json.Linq;
-    using static System.Collections.Specialized.BitVector32;
 
     /// <summary>
     /// Monitored item
@@ -465,8 +463,7 @@ QueueSize {CurrentQueueSize}/{QueueSize}",
                                 dataType.NodeId);
                             if (types == null || types.Count == 0)
                             {
-                                dataTypes.AddOrUpdate<NodeId, DataTypeDescription>(dataType.NodeId,
-                                    GetDefault(dataType, builtInType));
+                                dataTypes.AddOrUpdate(dataType.NodeId, GetDefault(dataType, builtInType));
                                 break;
                             }
                             foreach (var type in types)
@@ -491,12 +488,12 @@ QueueSize {CurrentQueueSize}/{QueueSize}",
                                             },
                                         _ => GetDefault(dataType, builtInType),
                                     };
-                                    dataTypes.AddOrUpdate<NodeId, DataTypeDescription>(type.Key, description);
+                                    dataTypes.AddOrUpdate(type.Key, description);
                                 }
                             }
                             break;
                         default:
-                            dataTypes.AddOrUpdate<NodeId, DataTypeDescription>(dataTypeId, new SimpleTypeDescription
+                            dataTypes.AddOrUpdate(dataTypeId, new SimpleTypeDescription
                             {
                                 DataTypeId = dataTypeId,
                                 Name = dataType.BrowseName,

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSubscription.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSubscription.cs
@@ -23,7 +23,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using System.Globalization;
 
     /// <summary>
     /// Subscription implementation

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/OpcUaMonitoredItemTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/OpcUaMonitoredItemTests.cs
@@ -9,8 +9,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Stack
     using Azure.IIoT.OpcUa.Publisher.Stack.Models;
     using Azure.IIoT.OpcUa.Publisher.Stack.Services;
     using Opc.Ua;
-    using DeadbandType = OpcUa.Publisher.Models.DeadbandType;
-    using MonitoringMode = OpcUa.Publisher.Models.MonitoringMode;
+    using DeadbandType = Publisher.Models.DeadbandType;
+    using MonitoringMode = Publisher.Models.MonitoringMode;
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Storage/PublishedNodesJobConverterTests.cs
@@ -13,7 +13,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Storage
     using Furly.Extensions.Serializers.Newtonsoft;
     using Microsoft.Extensions.Configuration;
     using Moq;
-    using NuGet.Frameworks;
     using System;
     using System.Collections.Generic;
     using System.IO;

--- a/src/Azure.IIoT.OpcUa/src/Encoders/JsonEncoderEx.cs
+++ b/src/Azure.IIoT.OpcUa/src/Encoders/JsonEncoderEx.cs
@@ -322,7 +322,22 @@ namespace Azure.IIoT.OpcUa.Encoders
                 }
                 _writer?.WritePropertyName(fieldName);
             }
-            _writer?.WriteValue(value);
+            if (float.IsPositiveInfinity(value))
+            {
+                _writer?.WriteValue("Infinity");
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                _writer?.WriteValue("-Infinity");
+            }
+            else if (float.IsNaN(value))
+            {
+                _writer?.WriteValue("NaN");
+            }
+            else
+            {
+                _writer?.WriteRawValue(value.ToString("G9", CultureInfo.InvariantCulture));
+            }
         }
 
         /// <inheritdoc/>
@@ -336,7 +351,22 @@ namespace Azure.IIoT.OpcUa.Encoders
                 }
                 _writer?.WritePropertyName(fieldName);
             }
-            _writer?.WriteValue(value);
+            if (double.IsPositiveInfinity(value))
+            {
+                _writer?.WriteValue("Infinity");
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                _writer?.WriteValue("-Infinity");
+            }
+            else if (double.IsNaN(value))
+            {
+                _writer?.WriteValue("NaN");
+            }
+            else
+            {
+                _writer?.WriteRawValue(value.ToString("G17", CultureInfo.InvariantCulture));
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Azure.IIoT.OpcUa/src/Encoders/JsonEncoderEx.cs
+++ b/src/Azure.IIoT.OpcUa/src/Encoders/JsonEncoderEx.cs
@@ -1559,15 +1559,15 @@ namespace Azure.IIoT.OpcUa.Encoders
             {
                 return new List<T?>();
             }
-          // if (arr.Length == 1) // TODO: Should this not be covered below?
-          // {
-          //     value = arr.GetValue(0);
-          //     if (value?.GetType()?.IsArray ?? false)
-          //     {
-          //         // Recursively unpack an array in array if needed
-          //         return ToTypedArray(value, defaultValue);
-          //     }
-          // }
+            // if (arr.Length == 1) // TODO: Should this not be covered below?
+            // {
+            //     value = arr.GetValue(0);
+            //     if (value?.GetType()?.IsArray ?? false)
+            //     {
+            //         // Recursively unpack an array in array if needed
+            //         return ToTypedArray(value, defaultValue);
+            //     }
+            // }
             var result = new T?[arr.Length];
             for (var index = 0; index < arr.Length; index++)
             {


### PR DESCRIPTION
Fix #1709. We will now use G9 and G17 to roundtrip double/float from OPC UA (JsonEncoderEx). 