### PR TITLE
Fix dapr configuration checks

### DIFF
--- a/docs/opc-publisher/commandline.md
+++ b/docs/opc-publisher/commandline.md
@@ -18,8 +18,7 @@ When both environment variable and CLI argument are provided, the command line o
 ██║   ██║██╔═══╝ ██║         ██╔═══╝ ██║   ██║██╔══██╗██║     ██║╚════██║██╔══██║██╔══╝  ██╔══██╗
 ╚██████╔╝██║     ╚██████╗    ██║     ╚██████╔╝██████╔╝███████╗██║███████║██║  ██║███████╗██║  ██║
  ╚═════╝ ╚═╝      ╚═════╝    ╚═╝      ╚═════╝ ╚═════╝ ╚══════╝╚═╝╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝
-                                                                         2.9.3-rc.12+8d0d6f8e36
-
+                                                                         2.9.3
 
 General
 -------
@@ -763,6 +762,11 @@ Diagnostic options
                                Also can be set using `DiagnosticsInterval`
                                environment variable in the form of a duration
                                string in the form `[d.]hh:mm:ss[.fffffff]`".
+      --pd, --publishdiagnostics, --PublishDiagnosticsEvents[=VALUE]
+                             Send writer group diagnostics information at the
+                               configured interval as events to the event topic
+                               template instead of the console.
+                               Default: `disabled`.
       --ll, --loglevel, --LogLevel=VALUE
                              The loglevel to use.
                                Allowed values:

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/CommandLine.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/CommandLine.cs
@@ -426,7 +426,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
                     "Shows publisher diagnostic information at this specified interval in seconds in the OPC Publisher log (need log level info). `-1` disables remote diagnostic log and diagnostic output.\nDefault:60000 (60 seconds).\nAlso can be set using `DiagnosticsInterval` environment variable in the form of a duration string in the form `[d.]hh:mm:ss[.fffffff]`\".\n",
                     (int i) => this[PublisherConfig.DiagnosticsIntervalKey] = TimeSpan.FromSeconds(i).ToString() },
                 { $"pd|publishdiagnostics:|{PublisherConfig.PublishDiagnosticsEventsKey}:",
-                    "Send writer group diagnostics information as events to the event topic template.\nDefault: `disabled`.\n",
+                    "Send writer group diagnostics information at the configured interval as events to the event topic template instead of the console.\nDefault: `disabled`.\n",
                     (bool? b) => this[PublisherConfig.PublishDiagnosticsEventsKey] = b?.ToString() ?? "True" },
                 { $"ll|loglevel=|{Configuration.Logging.LogLevelKey}=",
                     $"The loglevel to use.\nAllowed values:\n    `{string.Join("`\n    `", Enum.GetNames(typeof(LogLevel)))}`\nDefault: `{LogLevel.Information}`.\n",

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
@@ -168,7 +168,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
         {
             var daprOptions = new DaprOptions();
             new Dapr(configuration).Configure(daprOptions);
-            if (daprOptions.PubSubComponent != null)
+            if (!string.IsNullOrWhiteSpace(daprOptions.PubSubComponent))
             {
                 builder.AddDaprPubSubClient();
                 builder.RegisterType<Dapr>()
@@ -186,7 +186,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
         {
             var daprOptions = new DaprOptions();
             new Dapr(configuration).Configure(daprOptions);
-            if (daprOptions.StateStoreName != null)
+            if (!string.IsNullOrWhiteSpace(daprOptions.StateStoreName))
             {
                 builder.AddDaprStateStoreClient();
                 builder.RegisterType<Dapr>()
@@ -521,8 +521,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
                 var daprConnectionString = GetStringOrDefault(DaprConnectionStringKey);
                 if (daprConnectionString != null)
                 {
-                    options.PubSubComponent = string.Empty;
-                    options.StateStoreName = string.Empty;
+                    options.PubSubComponent = null;
+                    options.StateStoreName = null;
 
                     var properties = ToDictionary(daprConnectionString);
                     if (properties.TryGetValue(PubSubComponentKey, out var component))


### PR DESCRIPTION
Must check against empty or null string of pubsubname and storename before enabling clientts. Set values to null instead of empty string to be explicit.