### PR TITLE
Set event message TTL only if it is defined.

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher/src/Services/NetworkMessageEncoder.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Services/NetworkMessageEncoder.cs
@@ -122,10 +122,15 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                             .SetContentType(m.networkMessage.ContentType)
                             .SetTopic(m.topic)
                             .SetRetain(m.retain)
-                            .SetTtl(m.ttl)
                             .SetQoS(m.qos)
                             .AddBuffers(chunks)
                             ;
+
+                        if (m.ttl != default)
+                        {
+                            chunkedMessage = chunkedMessage
+                                .SetTtl(m.ttl);
+                        }
 
                         if (m.Schema != null)
                         {


### PR DESCRIPTION
The TTL property of the event message will only be set, if a TTL is defined. If TTL is default(TimeSpan) it wont be set.
This will prevent DAPR to set a expiration.
This will fix issue #2243 