### PR TITLE
Update package versions and switch to DateTimeOffset now

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
@@ -8,6 +8,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Abstractions" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.Abstractions" Version="1.0.58" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
@@ -15,9 +15,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Furly.Extensions.Json" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.Json" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.58" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.IIoT.OpcUa.Publisher.Models.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
@@ -7,8 +7,8 @@
     <TieredPGO>true</TieredPGO>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Azure.IoT" Version="1.0.56" />
-    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.56" />
+    <PackageReference Include="Furly.Azure.IoT" Version="1.0.58" />
+    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.58" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
@@ -33,14 +33,14 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Mqtt" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Dapr" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.56" />
-    <PackageReference Include="Furly.Azure.EventHubs" Version="1.0.56" />
-    <PackageReference Include="Furly.Azure.IoT" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Mqtt" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Dapr" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.58" />
+    <PackageReference Include="Furly.Azure.EventHubs" Version="1.0.58" />
+    <PackageReference Include="Furly.Azure.IoT" Version="1.0.58" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
-    <PackageReference Include="Furly.Tunnel" Version="1.0.56" />
+    <PackageReference Include="Furly.Tunnel" Version="1.0.58" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
@@ -8,9 +8,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.56" />
-    <PackageReference Include="Furly.Tunnel" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.58" />
+    <PackageReference Include="Furly.Tunnel" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions" Version="1.0.58" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk/cli/Azure.IIoT.OpcUa.Publisher.Service.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk/cli/Azure.IIoT.OpcUa.Publisher.Service.Cli.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
-    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.56" />
+    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.58" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk/src/Azure.IIoT.OpcUa.Publisher.Service.Sdk.csproj
@@ -11,10 +11,10 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.6" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Autofac" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Autofac" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions" Version="1.0.58" />
     <PackageReference Include="Nito.Disposables" Version="2.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Service.WebApi/src/Azure.IIoT.OpcUa.Publisher.Service.WebApi.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Service.WebApi/src/Azure.IIoT.OpcUa.Publisher.Service.WebApi.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="8.0.6" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="2.19.1" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="2.20.0" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
@@ -28,9 +28,9 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.56" />
-    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.0.58" />
+    <PackageReference Include="Furly.Azure.KeyVault" Version="1.0.58" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
   </ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Service/src/Azure.IIoT.OpcUa.Publisher.Service.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Service/src/Azure.IIoT.OpcUa.Publisher.Service.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Azure.IoT" Version="1.0.56" />
+    <PackageReference Include="Furly.Azure.IoT" Version="1.0.58" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
@@ -55,7 +55,7 @@
     <EmbeddedResource Include="Generated\Boiler\Design\Boiler.PredefinedNodes.uanodes" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions" Version="1.0.58" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.374.70" />
   </ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Json" Version="1.0.56" />
-    <PackageReference Include="Furly.Extensions.Autofac" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Json" Version="1.0.58" />
+    <PackageReference Include="Furly.Extensions.Autofac" Version="1.0.58" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="8.6.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="Furly.Azure.IoT.Edge" Version="1.0.56" />
+    <PackageReference Include="Furly.Azure.IoT.Edge" Version="1.0.58" />
     <PackageReference Include="Irony" Version="1.5.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.5.374.70" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.374.70" />

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Services/NetworkMessageEncoder.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Services/NetworkMessageEncoder.cs
@@ -119,10 +119,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                         var chunkedMessage = factory()
                             .AddProperty(OpcUa.Constants.MessagePropertySchemaKey,
                                 m.networkMessage.MessageSchema)
-                            .SetTimestamp(_timeProvider.GetUtcNow().UtcDateTime) // TODO: move to offsets
+                            .SetTimestamp(_timeProvider.GetUtcNow())
                             .SetContentEncoding(m.networkMessage.ContentEncoding)
                             .SetContentType(m.networkMessage.ContentType)
-                            .SetTopic(m.queue.QueueName!)
+                            .SetTopic(m.queue.QueueName)
                             .SetRetain(m.queue.Retain ?? false)
                             .SetQoS(m.queue.RequestedDeliveryGuarantee ?? QoS.AtLeastOnce)
                             .AddBuffers(chunks)

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Services/Encoder/NetworkMessage.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Services/Encoder/NetworkMessage.cs
@@ -19,9 +19,9 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Services
 
     public sealed class NetworkMessage : IEvent
     {
-        public DateTime Timestamp { get; private set; }
+        public DateTimeOffset Timestamp { get; private set; }
 
-        public IEvent SetTimestamp(DateTime value)
+        public IEvent SetTimestamp(DateTimeOffset value)
         {
             Timestamp = value;
             return this;

--- a/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
+++ b/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.11.3" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="Furly.Extensions" Version="1.0.56" />
+    <PackageReference Include="Furly.Extensions" Version="1.0.58" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.5.374.70" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa/src/Encoders/AvroFileWriter.cs
+++ b/src/Azure.IIoT.OpcUa/src/Encoders/AvroFileWriter.cs
@@ -54,7 +54,7 @@ namespace Azure.IIoT.OpcUa.Encoders
         }
 
         /// <inheritdoc/>
-        public ValueTask WriteAsync(string fileName, DateTime timestamp,
+        public ValueTask WriteAsync(string fileName, DateTimeOffset timestamp,
             IEnumerable<ReadOnlySequence<byte>> buffers,
             IReadOnlyDictionary<string, string?>? metadata, IEventSchema? schema,
             string contentType, CancellationToken ct = default)

--- a/src/Azure.IIoT.OpcUa/src/Encoders/ConsoleWriter.cs
+++ b/src/Azure.IIoT.OpcUa/src/Encoders/ConsoleWriter.cs
@@ -38,7 +38,7 @@ namespace Azure.IIoT.OpcUa.Encoders
         }
 
         /// <inheritdoc/>
-        public async ValueTask WriteAsync(string fileName, DateTime timestamp,
+        public async ValueTask WriteAsync(string fileName, DateTimeOffset timestamp,
             IEnumerable<ReadOnlySequence<byte>> buffers,
             IReadOnlyDictionary<string, string?> metadata, IEventSchema? schema,
             string contentType, CancellationToken ct = default)

--- a/src/Azure.IIoT.OpcUa/src/Encoders/ZipFileWriter.cs
+++ b/src/Azure.IIoT.OpcUa/src/Encoders/ZipFileWriter.cs
@@ -30,7 +30,7 @@ namespace Azure.IIoT.OpcUa.Encoders
         }
 
         /// <inheritdoc/>
-        public ValueTask WriteAsync(string fileName, DateTime timestamp,
+        public ValueTask WriteAsync(string fileName, DateTimeOffset timestamp,
             IEnumerable<ReadOnlySequence<byte>> buffers,
             IReadOnlyDictionary<string, string?> metadata, IEventSchema? schema,
             string contentType, CancellationToken ct = default)
@@ -107,7 +107,7 @@ namespace Azure.IIoT.OpcUa.Encoders
             /// <param name="timestamp"></param>
             /// <param name="buffers"></param>
             /// <returns></returns>
-            public void Write(DateTime timestamp, IEnumerable<ReadOnlySequence<byte>> buffers)
+            public void Write(DateTimeOffset timestamp, IEnumerable<ReadOnlySequence<byte>> buffers)
             {
                 foreach (var buffer in buffers)
                 {

--- a/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
@@ -14,8 +14,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-	  <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.56" />
-    <PackageReference Include="JsonSchema.Net" Version="7.1.1" />
+	  <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.0.58" />
+    <PackageReference Include="JsonSchema.Net" Version="7.1.2" />
     <PackageReference Include="Microsoft.Json.Schema" Version="2.3.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updated various nuget packages across multiple projects. Switched from DateTime to DateTimeOffset in NetworkMessageEncoder.cs, AvroFileWriter.cs, ConsoleWriter.cs, and ZipFileWriter.cs for better time zone handling.