### PR TITLE
Fix OPC PLC command configuration to use correct JSON file path

### DIFF
--- a/deploy/docker/with-limits.yaml
+++ b/deploy/docker/with-limits.yaml
@@ -5,7 +5,7 @@ services:
   opcplc:
     command: [
       "--sph",
-      "--spf=/shared/pn.json",
+      "--spf=/shared/opcplc.json",
       "--pn=50000",
       "--fn=1",
       "--sn=0",


### PR DESCRIPTION
Hi i found a mismatch between the with-limits.yaml file and the default docker-compose.yaml.

Pretty sure it would never have worked? 

Thanks