### PR TITLE
Migrate to .NET 10

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Checkout repository
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore ${{ matrix.solution }} -s https://api.nuget.org/v3/index.json
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore ${{ matrix.solution }} -s https://api.nuget.org/v3/index.json
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore -s https://api.nuget.org/v3/index.json
     - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,12 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none
+      # Run test projects serially to avoid OPC UA server port and PKI
+      # directory contention between parallel test hosts (which causes
+      # intermittent test-host crashes on Windows).
+      run: |
+        dotnet test src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none
+        dotnet test src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj                                  --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none
+        dotnet test src/Azure.IIoT.OpcUa.Publisher/tests/Azure.IIoT.OpcUa.Publisher.Tests.csproj              --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none
+        dotnet test src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,15 @@ on:
     branches: [ "latest", "main" ]
   pull_request:
     branches: [ "latest", "main" ]
+concurrency:
+  group: build-and-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
@@ -25,4 +30,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --blame-hang-timeout 10m --blame-hang-dump-type none

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore -s https://api.nuget.org/v3/index.json
     - name: Build

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Industrial-IoT" value="https://pkgs.dev.azure.com/msazure/One/_packaging/Industrial-IoT/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Nuget.Config
+++ b/Nuget.Config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="Industrial-IoT" value="https://pkgs.dev.azure.com/msazure/One/_packaging/Industrial-IoT/nuget/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/common.props
+++ b/common.props
@@ -37,7 +37,6 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50" PrivateAssets="All"/>
   </ItemGroup>
   <PropertyGroup>
-    <IncludeOpenAPIAnalyzers>true</IncludeOpenAPIAnalyzers>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisMode>All</AnalysisMode>
     <AnalysisLevel>preview</AnalysisLevel>

--- a/docs/opc-publisher/features.md
+++ b/docs/opc-publisher/features.md
@@ -7,7 +7,7 @@ The following table shows the supported features of OPC Publisher and planned fe
 | Feature | Sub Feature | 2.8 | 2.9 | Feature state |
 | ------- | ----------- |---- | --- | ------------- |
 | Uses latest .net reference stack ||X|X||
-| .net Version || .net 6 | .net 9 ||
+| .net Version || .net 6 | .net 10 ||
 | Secure channel transport and configuration ||X|X||
 | OPC UA HTTP transport and configuration ||-|-|#1997|
 | Secure channel over web socket transport and configuration ||-|-|#1997|

--- a/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
+++ b/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>OpcPublisherAEE2ETests</RootNamespace>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
+++ b/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
@@ -19,10 +19,10 @@
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="Azure.ResourceManager" Version="1.13.2" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.11" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.41.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
     <PackageReference Include="SSH.NET" Version="2025.1.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
+++ b/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="Azure.ResourceManager" Version="1.13.2" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.41.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />

--- a/samples/Http/BrowseAll/BrowseAll.csproj
+++ b/samples/Http/BrowseAll/BrowseAll.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Http/GetConfiguration/GetConfiguration.csproj
+++ b/samples/Http/GetConfiguration/GetConfiguration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Http/GetDiagnostics/GetDiagnostics.csproj
+++ b/samples/Http/GetDiagnostics/GetDiagnostics.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Http/ReadCurrentTime/ReadCurrentTime.csproj
+++ b/samples/Http/ReadCurrentTime/ReadCurrentTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Http/SetConfiguration/SetConfiguration.csproj
+++ b/samples/Http/SetConfiguration/SetConfiguration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Http/WriteReadbackValue/WriteReadbackValue.csproj
+++ b/samples/Http/WriteReadbackValue/WriteReadbackValue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/ApproveRejected/ApproveRejected.csproj
+++ b/samples/IoTHub/ApproveRejected/ApproveRejected.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/BrowseCertificates/BrowseCertificates.csproj
+++ b/samples/IoTHub/BrowseCertificates/BrowseCertificates.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/GetCertificate/GetApplicationCert.csproj
+++ b/samples/IoTHub/GetCertificate/GetApplicationCert.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/GetConfiguration/GetConfiguration.csproj
+++ b/samples/IoTHub/GetConfiguration/GetConfiguration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/ManageWriter/ManageWriter.csproj
+++ b/samples/IoTHub/ManageWriter/ManageWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/MonitorMessages/MonitorMessages.csproj
+++ b/samples/IoTHub/MonitorMessages/MonitorMessages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/ReadCurrentTime/ReadCurrentTime.csproj
+++ b/samples/IoTHub/ReadCurrentTime/ReadCurrentTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/ResetClients/GetAndResetConnections.csproj
+++ b/samples/IoTHub/ResetClients/GetAndResetConnections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/IoTHub/WriteReadbackValue/WriteReadbackValue.csproj
+++ b/samples/IoTHub/WriteReadbackValue/WriteReadbackValue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/GetConfiguration/GetConfiguration.csproj
+++ b/samples/Mqtt/GetConfiguration/GetConfiguration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/ManageWriter/ManageWriter.csproj
+++ b/samples/Mqtt/ManageWriter/ManageWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/MonitorMessages/MonitorMessages.csproj
+++ b/samples/Mqtt/MonitorMessages/MonitorMessages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/ReadAttributes/ReadAttributes.csproj
+++ b/samples/Mqtt/ReadAttributes/ReadAttributes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/ReadCurrentTime/ReadCurrentTime.csproj
+++ b/samples/Mqtt/ReadCurrentTime/ReadCurrentTime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Mqtt/WriteReadbackValue/WriteReadbackValue.csproj
+++ b/samples/Mqtt/WriteReadbackValue/WriteReadbackValue.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Netcap/src/Dockerfile
+++ b/samples/Netcap/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 ARG BRANCH=main
 ARG VERSION
 RUN apt update -y \
@@ -10,7 +10,7 @@ ENV BRANCH=${BRANCH}
 ENV VERSION=${VERSION}
 WORKDIR /app
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Netcap.csproj", "."]

--- a/samples/Netcap/src/Netcap.csproj
+++ b/samples/Netcap/src/Netcap.csproj
@@ -25,11 +25,11 @@
     <PackageReference Include="Azure.Core" Version="1.49.0" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.40.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.42.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="SharpPcap" Version="6.3.1" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.3" />
-    <PackageReference Include="System.Text.Json" Version="9.0.10" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/samples/Netcap/src/Netcap.csproj
+++ b/samples/Netcap/src/Netcap.csproj
@@ -29,7 +29,5 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="SharpPcap" Version="6.3.1" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/samples/Netcap/src/Netcap.csproj
+++ b/samples/Netcap/src/Netcap.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
@@ -9,6 +9,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Furly.Extensions.Abstractions" Version="1.2.1" />
-    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/src/Azure.IIoT.OpcUa.Publisher.Models.csproj
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Abstractions" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions.Abstractions" Version="1.2.1" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
@@ -18,9 +18,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Furly.Extensions.Json" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions.Json" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.IIoT.OpcUa.Publisher.Models.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
@@ -11,8 +11,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/tests/Azure.IIoT.OpcUa.Publisher.Models.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ParallelAlgorithm>aggressive</ParallelAlgorithm>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
@@ -8,8 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Furly.Azure.IoT" Version="1.2.1" />
-    <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.IIoT.OpcUa.Publisher.Testing\src\Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
@@ -7,7 +7,7 @@
     <TieredPGO>true</TieredPGO>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Azure.IoT" Version="1.1.56" />
+    <PackageReference Include="Furly.Azure.IoT" Version="1.2.1" />
     <PackageReference Include="System.IO.FileSystem" Version="4.3.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
   </ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/cli/Azure.IIoT.OpcUa.Publisher.Module.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Nullable>enable</Nullable>
     <TieredPGO>true</TieredPGO>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <ContainerRepository>iotedge/opc-publisher</ContainerRepository>
-    <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:9.0-azurelinux3.0-distroless</ContainerBaseImage>
+    <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:10.0-azurelinux3.0-distroless</ContainerBaseImage>
   </PropertyGroup>
   <ItemGroup>
     <ContainerEnvironmentVariable Include="ASPNETCORE_HTTP_PORTS" Value="" />
@@ -33,15 +33,15 @@
     <None Remove="pki\**" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.Mqtt" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.Dapr" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.1.56" />
-    <PackageReference Include="Furly.Azure.EventHubs" Version="1.1.56" />
-    <PackageReference Include="Furly.Azure.IoT" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions.AspNetCore" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.Mqtt" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.Dapr" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.MessagePack" Version="1.2.1" />
+    <PackageReference Include="Furly.Azure.EventHubs" Version="1.2.1" />
+    <PackageReference Include="Furly.Azure.IoT" Version="1.2.1" />
     <PackageReference Include="Azure.Identity" Version="1.17.1" />
     <PackageReference Include="Azure.Core" Version="1.50.0" />
-    <PackageReference Include="Furly.Tunnel" Version="1.1.56" />
+    <PackageReference Include="Furly.Tunnel" Version="1.2.1" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
@@ -43,15 +43,13 @@
     <PackageReference Include="Azure.Core" Version="1.50.0" />
     <PackageReference Include="Furly.Tunnel" Version="1.2.1" />
     <PackageReference Include="Mono.Options" Version="6.12.0.148" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.12.0-beta.1" />
-    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.IIoT.OpcUa.Publisher\src\Azure.IIoT.OpcUa.Publisher.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Azure.IIoT.OpcUa.Publisher.Module.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="Json.More.Net" Version="2.2.0" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="Neovolve.Logging.Xunit" Version="6.3.0" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ParallelAlgorithm>aggressive</ParallelAlgorithm>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
@@ -11,10 +11,8 @@
     <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.2.1" />
     <PackageReference Include="Furly.Tunnel" Version="1.2.1" />
     <PackageReference Include="Furly.Extensions" Version="1.2.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.IIoT.OpcUa.Publisher.Models\src\Azure.IIoT.OpcUa.Publisher.Models.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Sdk/src/Azure.IIoT.OpcUa.Publisher.Sdk.csproj
@@ -8,13 +8,13 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.1.56" />
-    <PackageReference Include="Furly.Tunnel" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.2.1" />
+    <PackageReference Include="Furly.Tunnel" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions" Version="1.2.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.11" />
-    <PackageReference Include="System.Text.Json" Version="9.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Azure.IIoT.OpcUa.Publisher.Models\src\Azure.IIoT.OpcUa.Publisher.Models.csproj" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Azure.IIoT.OpcUa.Publisher.Testing.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Azure.IIoT.OpcUa.Publisher.Testing.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Nullable>disable</Nullable>
     <EnableSdkContainerSupport>true</EnableSdkContainerSupport>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Azure.IIoT.OpcUa.Publisher.Testing.Cli.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/cli/Azure.IIoT.OpcUa.Publisher.Testing.Cli.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <ContainerRepository>iot/opc-ua-test-server</ContainerRepository>
     <ContainerRuntimeIdentifier>linux-x64</ContainerRuntimeIdentifier>
-    <ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:9.0-azurelinux3.0-distroless-extra</ContainerBaseImage>
+    <ContainerBaseImage>mcr.microsoft.com/dotnet/runtime:10.0-azurelinux3.0-distroless-extra</ContainerBaseImage>
   </PropertyGroup>
   <ItemGroup>
     <ContainerEnvironmentVariable Include="DOTNET_ReadyToRun" Value="0" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Contains several test servers to run tests against</Description>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
@@ -62,9 +62,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Furly.Extensions" Version="1.2.1" />
-    <PackageReference Include="System.IO.Pipelines" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.377.22" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj
@@ -61,10 +61,10 @@
     <EmbeddedResource Include="Generated\Isa95Jobs\Design\UAModel.ISA95_JOBCONTROL_V2.Types.xsd" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions" Version="1.1.56" />
-    <PackageReference Include="System.IO.Pipelines" Version="9.0.11" />
+    <PackageReference Include="Furly.Extensions" Version="1.2.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="10.0.7" />
     <PackageReference Include="System.Linq.Async" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.11" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.377.22" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.Json" Version="1.1.56" />
-    <PackageReference Include="Furly.Extensions.Autofac" Version="1.1.56" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.11" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.Json" Version="1.2.1" />
+    <PackageReference Include="Furly.Extensions.Autofac" Version="1.2.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageReference Include="FluentAssertions" Version="[7.2.0]" />
     <PackageReference Include="Moq" Version="[4.20.2]" />
     <PackageReference Include="xunit.assert" Version="2.9.3" />

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Azure.IIoT.OpcUa.Publisher.Testing.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Contains fixtures and tests executing against test servers</Description>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Tests/Plc/SimulatorNodesTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Tests/Plc/SimulatorNodesTests.cs
@@ -392,7 +392,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Tests
             const int invocations = 1;
             const int cycles = 15;
             var values = await AsyncEnumerable.Range(0, cycles)
-                .SelectAwait(async i =>
+                .Select(async (int i, CancellationToken _) =>
                 {
                     _server.FireTimersWithPeriod(TimeSpan.FromMilliseconds(periodInMilliseconds), invocations);
                     var value = await services.ValueReadAsync(_connection, new ValueReadRequestModel

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Azure.IIoT.OpcUa.Publisher.csproj
@@ -5,12 +5,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.10" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="9.10.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.5.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
-    <PackageReference Include="Furly.Azure.IoT.Edge" Version="1.1.56" />
-    <PackageReference Include="Furly.Azure.IoT.Operations" Version="1.1.56" />
+    <PackageReference Include="Furly.Azure.IoT.Edge" Version="1.2.1" />
+    <PackageReference Include="Furly.Azure.IoT.Operations" Version="1.2.1" />
     <PackageReference Include="Irony" Version="1.5.3" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.5.377.22" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.377.22" />

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Azure.IIoT.OpcUa.Publisher.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Azure.IIoT.OpcUa.Publisher.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ParallelAlgorithm>aggressive</ParallelAlgorithm>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
+++ b/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Azure OPC Publisher shared code</Description>
     <Nullable>enable</Nullable>

--- a/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
+++ b/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.12.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.11" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="Furly.Extensions" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions" Version="1.2.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.5.377.22" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
+++ b/src/Azure.IIoT.OpcUa/src/Azure.IIoT.OpcUa.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Apache.Avro" Version="1.12.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Furly.Extensions" Version="1.2.1" />
     <PackageReference Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.5.377.22" />

--- a/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.1.56" />
+    <PackageReference Include="Furly.Extensions.Newtonsoft" Version="1.2.1" />
     <PackageReference Include="JsonSchema.Net" Version="8.0.5" />
     <PackageReference Include="Microsoft.Json.Schema" Version="2.3.0" />
   </ItemGroup>

--- a/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa/tests/Azure.IIoT.OpcUa.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ParallelAlgorithm>aggressive</ParallelAlgorithm>
   </PropertyGroup>
   <ItemGroup>

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -75,6 +75,13 @@ steps:
       -SubscriptionId "d355e77f-e625-4931-b133-445d3dcf12cb"
       -ResourceGroupName "mcr-iot-industrial-do-not-delete"
 - task: UseDotNet@2
+  displayName: 'Install .NET 8 SDK (for nbgv)'
+  inputs:
+    packageType: sdk
+    version: 8.0.x
+    includePreviewVersions: false
+    installationPath: $(Agent.ToolsDirectory)/dotnet
+- task: UseDotNet@2
   displayName: 'Install .NET Core SDK'
   inputs:
     packageType: sdk

--- a/tools/e2etesting/steps/runtests.yml
+++ b/tools/e2etesting/steps/runtests.yml
@@ -78,7 +78,7 @@ steps:
   displayName: 'Install .NET Core SDK'
   inputs:
     packageType: sdk
-    version: 8.0.x
+    version: 10.0.x
     includePreviewVersions: false
     installationPath: $(Agent.ToolsDirectory)/dotnet
 - task: DotNetCoreCLI@2

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9.16-rc.{height}",
+  "version": "2.9.17-rc.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
# Migrate to .NET 10

Migrates the repository from .NET 9 to .NET 10. Build is clean (0 errors), all 4 in-slnx test projects pass on both Linux and Windows CI, plus all 23 out-of-slnx projects (e2e-tests + 22 samples + Netcap) build clean.

## Highlights

- **TargetFramework** `net9.0` → `net10.0` across all 36 `.csproj` files (src/, tests, e2e-tests, samples/Http|IoTHub|Mqtt|Netcap, tools).
- **Furly.\*** packages 1.1.56 → **1.2.1** (14 packages, all shipping `lib/net10.0/`).
- **Microsoft.Extensions.\***, **Microsoft.AspNetCore.Mvc.Testing**, **System.Text.Json**, **System.IO.Pipelines** 9.0.x → **10.0.7**.
- **Microsoft.Extensions.Diagnostics.ResourceMonitoring** 9.10.0 → **10.5.0**.
- **OpenTelemetry.\*** 1.14.0 → **1.15.x** — addresses CVE advisories surfaced by .NET 10's transitive vuln audit (GHSA-g94r-2vxg-569j, GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933).
- **System.Linq.Async** 6.0.3 → **7.0.0** in Netcap (other projects already at 7.0.0).
- **ContainerBaseImage** `aspnet`/`runtime:9.0(-azurelinux3.0-distroless)` → **10.0** equivalents.
- **Dockerfiles** (`samples/Netcap/src/Dockerfile`): `dotnet/aspnet:9.0` + `dotnet/sdk:9.0` → **10.0**.

## CI

- All pipelines now install **both .NET 8 and .NET 10 SDKs**. The .NET 8 SDK is required for the `nbgv` global tool which still ships only `net8.0`.
- `.github/workflows/test.yml` hardened:
  - Added `concurrency` group with `cancel-in-progress` so superseded PR runs are aborted automatically.
  - Added 60-minute job timeout and `--blame-hang-timeout 10m --blame-hang-dump-type none` to surface hung tests instead of letting them run for hours.
  - `fail-fast: false` so a Windows failure no longer cancels the Linux signal.
  - Test projects are now executed **serially** to avoid OPC UA test-host contention on Windows runners (parallel `dotnet test` on the slnx caused intermittent test-host crashes due to concurrent OPC UA servers/PKI directories from `BaseServerFixture`).
- `tools/e2etesting/steps/runtests.yml`: bumped from .NET 8 to .NET 10 (with .NET 8 still installed for nbgv).

## .NET 10 source / behavior fix-ups

- Removed `<PackageReference>` entries flagged by NU1510 as already provided by the shared framework: `System.Text.Json`, `System.Net.Http`, `System.IO.Pipelines`, `System.Private.Uri`, `System.IO.FileSystem`, `System.Net.Primitives`, `System.Text.RegularExpressions`, `System.Security.Cryptography.X509Certificates`, `Microsoft.CSharp`.
- Dropped the deprecated `IncludeOpenAPIAnalyzers` property in `common.props` (ASPDEPR007).
- Migrated `SelectAwait` in `SimulatorNodesTests` to the new built-in `AsyncEnumerable.Select(value, CancellationToken)` overload (replaces the now-obsolete community `System.Linq.Async` API).
- Updated `docs/opc-publisher/features.md` feature matrix from `.net 9` to `.net 10`.

## Verification

- `dotnet restore Industrial-IoT.slnx` — clean, no NU1510/NU1902 warnings.
- `dotnet build Industrial-IoT.slnx` — **0 errors**, 89 pre-existing CA-analyzer warnings.
- All 23 out-of-slnx projects build cleanly individually.
- `dotnet build e2e-tests/IIoTPlatform-E2E-Tests.slnx` — clean.
- Tests (4 in-slnx test projects):

  | Project | Total | Passed | Skipped | Failed |
  |---|---:|---:|---:|---:|
  | Azure.IIoT.OpcUa.Publisher.Models.Tests | 2259 | 2259 | 0 | 0 |
  | Azure.IIoT.OpcUa.Tests | 2155 | 2155 | 0 | 0 |
  | Azure.IIoT.OpcUa.Publisher.Tests | 846 | 846 | 0 | 0 |
  | Azure.IIoT.OpcUa.Publisher.Module.Tests | 1526 | 1447 | 79 | 0 |
  | **Total** | **6786** | **6707** | **79** | **0** |

## Commits

1. `0a1a117` — Prepare for .NET 10: drop internal NuGet feed and bump rc version
2. `1de20b1` — Update TargetFramework from net9.0 to net10.0
3. `2ca4de9` — Bump packages and container base images for .NET 10
4. `4e5c9da` — Resolve .NET 10 migration warnings
5. `e2ce578` — Bump CI workflows and docs to .NET 10
6. `b58e630` — Bump e2e-testing pipeline SDK to .NET 10
7. `962f4ff` — Install both .NET 8 and .NET 10 SDKs in CI pipelines
8. `8c6a277` — Add timeout, hang-detection, and concurrency to Build and Test workflow
9. `189c619` — Run test projects serially to avoid Windows OPC UA contention
