### PR TITLE
Fix KV RBAC role assignment SP id resolution and propagation race

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -78,7 +78,7 @@ On the Azure side, the App Registration must have federated credentials for thes
 The federated identity needs:
 
 * **Contributor** on the target subscription (creates resource groups, IoT Hub, KeyVault, VMs, ACI).
-* A KeyVault **access policy** with `get,list,set` on secrets in the deployment-created vaults (the deployment scripts create KeyVaults with access-policy mode, not RBAC; `SetKeyVaultPermissions.ps1` grants the policy automatically).
+* **Key Vault Secrets Officer** on secrets in the deployment-created vaults (the deployment scripts create new KeyVaults in RBAC mode and migrate any pre-existing access-policy vaults; `SetKeyVaultPermissions.ps1` assigns the role automatically).
 
 ### Restoring NuGet packages from runners
 

--- a/tools/e2etesting/DeployStandalone.ps1
+++ b/tools/e2etesting/DeployStandalone.ps1
@@ -110,9 +110,42 @@ else {
 
 if ($ServicePrincipalId) {
     Write-Host "Granting 'Key Vault Secrets Officer' role on Key Vault to Service Principal $($ServicePrincipalId)..."
-    $existing = Get-AzRoleAssignment -ObjectId $ServicePrincipalId -RoleDefinitionName "Key Vault Secrets Officer" -Scope $keyVault.ResourceId -ErrorAction SilentlyContinue
+    # $ServicePrincipalId may be either an App (client) ID or an SP Object ID
+    # depending on caller. The ADO `addSpnToEnvironment: true` task exposes the
+    # App ID via $env:servicePrincipalId, so resolve to the SP Object ID before
+    # calling New-AzRoleAssignment -ObjectId.
+    $spObjectId = $ServicePrincipalId
+    $sp = Get-AzADServicePrincipal -ApplicationId $ServicePrincipalId -ErrorAction SilentlyContinue
+    if (!$sp) {
+        $sp = Get-AzADServicePrincipal -ObjectId $ServicePrincipalId -ErrorAction SilentlyContinue
+    }
+    if ($sp) { $spObjectId = $sp.Id }
+    $existing = Get-AzRoleAssignment -ObjectId $spObjectId -RoleDefinitionName "Key Vault Secrets Officer" -Scope $keyVault.ResourceId -ErrorAction SilentlyContinue
     if (!$existing) {
-        New-AzRoleAssignment -ObjectId $ServicePrincipalId -RoleDefinitionName "Key Vault Secrets Officer" -Scope $keyVault.ResourceId | Out-Null
+        New-AzRoleAssignment -ObjectId $spObjectId -RoleDefinitionName "Key Vault Secrets Officer" -Scope $keyVault.ResourceId | Out-Null
+    }
+}
+
+# Wait briefly for RBAC role propagation before writing secrets. New role
+# assignments typically take 10-60s before the KV data plane accepts the
+# principal; this helper retries the secret write to absorb that delay.
+function Set-KvSecretWithRetry {
+    param(
+        [Parameter(Mandatory)] [string] $VaultName,
+        [Parameter(Mandatory)] [string] $Name,
+        [Parameter(Mandatory)] [System.Security.SecureString] $SecretValue,
+        [int] $MaxAttempts = 12,
+        [int] $DelaySeconds = 10
+    )
+    for ($i = 1; $i -le $MaxAttempts; $i++) {
+        try {
+            Set-AzKeyVaultSecret -VaultName $VaultName -Name $Name -SecretValue $SecretValue -ErrorAction Stop | Out-Null
+            return
+        } catch {
+            if ($i -eq $MaxAttempts) { throw }
+            Write-Host "Set-AzKeyVaultSecret '$Name' attempt $i failed: $($_.Exception.Message). Retrying in ${DelaySeconds}s..."
+            Start-Sleep -Seconds $DelaySeconds
+        }
     }
 }
 
@@ -122,15 +155,15 @@ $SubscriptionId = $context.Subscription.Id
 Write-Host "Adding/Updating KeyVault-Secret 'PCS-IOTHUB-CONNSTRING' with value '***'..."
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 $secret = ConvertTo-SecureString $connectionString.PrimaryConnectionString -AsPlainText -Force
-Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-IOTHUB-CONNSTRING' -SecretValue $secret | Out-Null
+Set-KvSecretWithRetry -VaultName $keyVault.VaultName -Name 'PCS-IOTHUB-CONNSTRING' -SecretValue $secret
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 $secret = ConvertTo-SecureString $TenantId -AsPlainText -Force
-Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-AUTH-TENANT' -SecretValue $secret | Out-Null
+Set-KvSecretWithRetry -VaultName $keyVault.VaultName -Name 'PCS-AUTH-TENANT' -SecretValue $secret
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 $secret = ConvertTo-SecureString $SubscriptionId -AsPlainText -Force
-Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-SUBSCRIPTION-ID' -SecretValue $secret | Out-Null
+Set-KvSecretWithRetry -VaultName $keyVault.VaultName -Name 'PCS-SUBSCRIPTION-ID' -SecretValue $secret
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
 $secret = ConvertTo-SecureString $ResourceGroupName -AsPlainText -Force
-Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name 'PCS-RESOURCE-GROUP' -SecretValue $secret | Out-Null
+Set-KvSecretWithRetry -VaultName $keyVault.VaultName -Name 'PCS-RESOURCE-GROUP' -SecretValue $secret
 
 Write-Host "Deployment finished."


### PR DESCRIPTION
## Summary

Two targeted fixes on top of the RBAC/KeyVault refactor from #2454.

### 1. `DeployStandalone.ps1` — KV role assignment hardening

- **Resolve `$ServicePrincipalId` to an SP object id before `New-AzRoleAssignment -ObjectId`.**
  The ADO `AzureCLI@2` task with `addSpnToEnvironment: true` exposes the SP's **App (client) id** via `$env:servicePrincipalId` (the value forwarded into `-ServicePrincipalId` in `deploystandalone.yml`). `New-AzRoleAssignment -ObjectId` expects the SP's **directory Object id**, which is a different GUID. Passing the App id either failed outright or assigned the role to the wrong principal. The fix looks the value up first via `Get-AzADServicePrincipal -ApplicationId`, falling back to `-ObjectId` for callers that already pass an object id.
- **Add `Set-KvSecretWithRetry` to absorb RBAC role-propagation lag.**
  When the role is granted to a freshly-created RBAC vault, the data plane typically takes 10–60 s to recognise the principal. The four `Set-AzKeyVaultSecret` calls that follow could 403 on the first attempt of a clean deployment. Wrapped them in a small retry helper (12 attempts × 10 s) so first-time deployments succeed without a manual rerun.

### 2. `contributing.md` — doc refresh

Updated the "federated identity needs…" bullet from the legacy access-policy wording to the current RBAC reality (`Key Vault Secrets Officer`), matching the script behaviour introduced in #2454.

## Risk

- Lookup-then-assign is idempotent (skips when the role already exists) and the retry helper is a no-op on success — re-running the script on existing RBs is safe.
- No template / Bicep changes; no test-harness changes.
