### PR TITLE
Fix test-host SEH crash on Windows by disposing publisher before OPC UA server

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/AdvancedPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/AdvancedPubSubIntegrationTests.cs
@@ -60,8 +60,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 
@@ -100,8 +100,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 
@@ -136,8 +136,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 
@@ -201,8 +201,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 
@@ -410,8 +410,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 
@@ -467,8 +467,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
+                server.Dispose();
             }
         }
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/ReverseConnectIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/ReverseConnectIntegrationTests.cs
@@ -29,9 +29,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         [InlineData(false)]
         public async Task RegisteredReadTestAsync(bool useReverseConnect)
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            var server = ReferenceServer.Create(LogFactory.Create(_output, Logging.Config), useReverseConnect);
-#pragma warning restore CA2000 // Dispose objects before losing scope
+            using var server = ReferenceServer.Create(LogFactory.Create(_output, Logging.Config), useReverseConnect);
             EndpointUrl = server.EndpointUrl;
 
             var name = nameof(RegisteredReadTestAsync) + (useReverseConnect ? "WithReverseConnect" : "NoReverseConnect");
@@ -57,7 +55,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
             }
             finally
             {
-                server.Dispose();
                 await StopPublisherAsync();
             }
         }


### PR DESCRIPTION
## Summary

Fixes the intermittent `testhost.exe` crash on the `test_windows_Release` pipeline slice (e.g. build [167149760][1] log 485) that aborts the run with no managed exception:

```
The active test run was aborted. Reason: Test host process crashed
##[error]Error: The process 'C:\__t\dotnet\dotnet.exe' failed with exit code 1
```

[1]: https://msazure.visualstudio.com/One/_build/results?buildId=167149760

## Root cause

Seven test methods across two files were disposing the OPC UA reference-server fixture **before** stopping the Publisher under test:

```csharp
finally
{
    server.Dispose();          // ← server torn down first
    await StopPublisherAsync();// ← publisher (still holding channel/listener) torn down second
}
```

Tearing down the `ServerConsoleHost` (which owns the listener socket and PKI store) while the Publisher's session/channel/transport is still alive lets callbacks on the client side re-enter sockets on a half-torn-down server. On Windows this surfaces as an unmanaged SEH that takes down the test host with exit code 1 (vstest reports "Test host process crashed", with no stack trace because the crash is in the OPC UA stack's TCP cleanup path, not managed code).

The code has been this way since 2023, but the .NET 10 migration in #2444 changed finalizer-thread timing and `SafeHandle` release ordering enough to make this previously-latent race observable on Windows. The two sibling tests already written with the correct order (`KeepAliveTestAsync` in `ReverseConnectIntegrationTests`, `SwitchServerWithDifferentDataTestAsync` in `AdvancedPubSubIntegrationTests`) have never crashed.

## Changes

| File | Sites | Fix |
|---|---|---|
| `ReverseConnectIntegrationTests.cs` | 1 (`RegisteredReadTestAsync`) | Switched to `using var server` to mirror the sibling `KeepAliveTestAsync` in the same file; finally now contains only `await StopPublisherAsync();`. Removed the now-unneeded `#pragma CA2000` lines. |
| `AdvancedPubSubIntegrationTests.cs` | 6 (`RestartServerTestAsync`, `RestartServerWithHeartbeatTestAsync`, `RestartServerWithCyclicReadTestAsync`, `SwitchServerWithSameWriterGroupTestAsync`, `SwitchServerWithDifferentWriterGroupTestAsync`, `SwitchSecuritySettingsTestAsync`) | Swapped the two `finally` lines so `await StopPublisherAsync()` runs before `server.Dispose()`. Minimal swap — kept the existing `var server = new ReferenceServer();` shape so the diff is surgical. |

Diff: `2 files changed, 7 insertions(+), 10 deletions(-)`

## Verification

- Repo-wide search for the anti-pattern after fix → **0 matches**:
  ```
  grep -P 'server\.Dispose\(\);\s*\n\s*await StopPublisherAsync' src/Azure.IIoT.OpcUa.Publisher.Module/tests
  ```
- `dotnet build src/Azure.IIoT.OpcUa.Publisher.Module/tests/...csproj -c Release` → **Build succeeded, 0 Error(s)** (warnings are pre-existing).

## Risk

Behaviour-preserving: the test bodies and assertions are unchanged; only the order of two cleanup statements is reversed. No production code touched. All seven affected tests already passed in the green path on Linux — the swap just removes the cleanup-time race that was the failure mode on Windows.
