### PR TITLE
Share OPC UA server across tests via IClassFixture to avoid Windows host crash

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
@@ -17,26 +17,17 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class MqttConfigurationIntegrationTests : PublisherIntegrationTestBase
+    public class MqttConfigurationIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ITestOutputHelper _output;
         private readonly ReferenceServer _fixture;
 
-        public MqttConfigurationIntegrationTests(ITestOutputHelper output)
+        public MqttConfigurationIntegrationTests(ReferenceServer fixture, ITestOutputHelper output)
             : base(output)
         {
             _output = output;
-            _fixture = new ReferenceServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Theory]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttPubSubIntegrationTests.cs
@@ -17,25 +17,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class MqttPubSubIntegrationTests : PublisherIntegrationTestBase
+    public class MqttPubSubIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ReferenceServer _fixture;
         private readonly ITestOutputHelper _output;
 
-        public MqttPubSubIntegrationTests(ITestOutputHelper output) : base(output)
+        public MqttPubSubIntegrationTests(ReferenceServer fixture, ITestOutputHelper output) : base(output)
         {
             _output = output;
-            _fixture = new ReferenceServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Fact]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttUnifiedNamespaceTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttUnifiedNamespaceTests.cs
@@ -15,25 +15,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class MqttUnifiedNamespaceTests : PublisherIntegrationTestBase
+    public class MqttUnifiedNamespaceTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ReferenceServer _fixture;
         private readonly ITestOutputHelper _output;
 
-        public MqttUnifiedNamespaceTests(ITestOutputHelper output) : base(output)
+        public MqttUnifiedNamespaceTests(ReferenceServer fixture, ITestOutputHelper output) : base(output)
         {
             _output = output;
-            _fixture = new ReferenceServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Fact]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Isa95Jobs/BasicPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Isa95Jobs/BasicPubSubIntegrationTests.cs
@@ -14,7 +14,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Isa95Jobs
     using Xunit;
     using Xunit.Abstractions;
 
-    public class BasicPubSubIntegrationTests : PublisherIntegrationTestBase
+    public class BasicPubSubIntegrationTests : PublisherIntegrationTestBase, IClassFixture<Isa95JobsServer>
     {
         internal const string EventId = "EventId";
         internal const string Message = "Message";
@@ -25,21 +25,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Isa95Jobs
         private readonly ITestOutputHelper _output;
         private readonly Isa95JobsServer _fixture;
 
-        public BasicPubSubIntegrationTests(ITestOutputHelper output)
+        public BasicPubSubIntegrationTests(Isa95JobsServer fixture, ITestOutputHelper output)
             : base(output)
         {
             _output = output;
-            _fixture = new Isa95JobsServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Fact]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicPubSubIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class BasicPubSubIntegrationTests : PublisherIntegrationTestBase
+    public class BasicPubSubIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         internal const string EventId = "EventId";
         internal const string Message = "Message";
@@ -29,21 +29,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         private readonly ITestOutputHelper _output;
         private readonly ReferenceServer _fixture;
 
-        public BasicPubSubIntegrationTests(ITestOutputHelper output)
+        public BasicPubSubIntegrationTests(ReferenceServer fixture, ITestOutputHelper output)
             : base(output)
         {
             _output = output;
-            _fixture = new ReferenceServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Fact]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicSamplesIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicSamplesIntegrationTests.cs
@@ -23,7 +23,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class BasicSamplesIntegrationTests : PublisherIntegrationTestBase
+    public class BasicSamplesIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private const string kEventId = "EventId";
         private const string kMessage = "Message";
@@ -32,21 +32,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         private readonly ITestOutputHelper _output;
         private readonly ReferenceServer _fixture;
 
-        public BasicSamplesIntegrationTests(ITestOutputHelper output)
+        public BasicSamplesIntegrationTests(ReferenceServer fixture, ITestOutputHelper output)
             : base(output)
         {
             _output = output;
-            _fixture = new ReferenceServer();
+            _fixture = fixture;
             EndpointUrl = _fixture.EndpointUrl;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            if (disposing)
-            {
-                _fixture.Dispose();
-            }
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Migrates six integration-test classes from per-test `_fixture = new ReferenceServer()` (or `new Isa95JobsServer()`) construction to xUnit's `IClassFixture<TFixture>` pattern, which is what the rest of the test tree already uses. The result: one OPC UA server per test class instead of one per `[Fact]`/`[Theory]` row.

Addresses the recurring Windows test-host crash family seen in [internal ADO build 167281436](https://msazure.visualstudio.com/b32aa71e-8ed2-41b2-9d77-5bc261222004/_apis/build/builds/167281436) (`test_windows_Release 2`):

```
The active test run was aborted. Reason: Test host process crashed
##[error]Error: The process 'C:\__t\dotnet\dotnet.exe' failed with exit code 1
Test running when the crash occurred:
Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer.
  MqttConfigurationIntegrationTests.CanSendDataItemToTopicConfiguredWithMethod2Async
```

Same family as the disposal-order bug fixed in #2456, but in a different anti-pattern that PR didn't cover.

## Root cause

Six test classes did this:

```csharp
public class MqttConfigurationIntegrationTests : PublisherIntegrationTestBase
{
    private readonly ReferenceServer _fixture;
    public MqttConfigurationIntegrationTests(ITestOutputHelper output) : base(output)
    {
        _fixture = new ReferenceServer();   // ← per-[Fact] / per-[Theory] row
        EndpointUrl = _fixture.EndpointUrl;
    }
    protected override void Dispose(bool disposing)
    {
        base.Dispose(disposing);
        if (disposing) { _fixture.Dispose(); }
    }
    ...
}
```

xUnit creates a fresh instance of the test class for every `[Fact]` and every `[Theory]`/`[InlineData]` row, so each test paid the full cost of constructing a real OPC UA server:

- `NextPort()` + TCP listener bind on a new ephemeral port
- self-signed application certificate generation (Windows native crypto, BCrypt/Crypt32)
- PKI/trusted-peer store I/O under `%TEMP%` (writes 3+ cert files per server)
- `ServerConsoleHost` initialisation including the .NET 10 `SafeHandle` chain
- ...then the symmetric teardown on `_fixture.Dispose()`

For a class with N tests we paid that N times — typically dozens per class. On Windows the cumulative churn surfaces as an unmanaged SEH that takes down `testhost.exe` with exit code 1 — same signature as the previous fix in #2456. The actual crash dump was not included in the build's failure artifact (`drop_test_windows_Release 2_failed_1` contains only `.artifactignore`, 275 bytes — apparently filtered by OneBranch policy), so this is fixed on circumstantial evidence — the same approach used successfully for #2456.

## Fix

Use xUnit's `IClassFixture<TFixture>` pattern, which is already the dominant pattern across the test tree (dozens of `Controller/**` and `Sdk/**` classes — e.g. `Controller/Alarms/Json/NodeServicesTests.cs`):

```csharp
public class MqttConfigurationIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
{
    private readonly ReferenceServer _fixture;
    public MqttConfigurationIntegrationTests(ReferenceServer fixture, ITestOutputHelper output)
        : base(output)
    {
        _fixture = fixture;                  // ← injected by xUnit, constructed once per class
        EndpointUrl = _fixture.EndpointUrl;
    }
    // Dispose override removed — IClassFixture<> owns the fixture lifetime
    ...
}
```

`ReferenceServer` and `Isa95JobsServer` both have parameterless `public T() : base(...)` ctors and expose only read-only OPC UA data; no test in these classes mutates the server state through the API, so sharing across tests in a class is safe.

The Publisher under test is still created per-test by `PublisherIntegrationTestBase.StartPublisher(...)` and torn down per-test by `await StopPublisherAsync()` in each test's `finally`, so the publisher-first-then-server disposal order from #2456 is preserved (publisher dies in the test's `finally`, OPC UA server dies in xUnit's class-fixture teardown, which runs last).

## Files changed

| File | Fixture |
|---|---|
| `Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs` ← crashed in build 167281436 | `ReferenceServer` |
| `Mqtt/ReferenceServer/MqttPubSubIntegrationTests.cs` | `ReferenceServer` |
| `Mqtt/ReferenceServer/MqttUnifiedNamespaceTests.cs` | `ReferenceServer` |
| `Sdk/ReferenceServer/BasicSamplesIntegrationTests.cs` | `ReferenceServer` |
| `Sdk/ReferenceServer/BasicPubSubIntegrationTests.cs` | `ReferenceServer` |
| `Sdk/Isa95Jobs/BasicPubSubIntegrationTests.cs` | `Isa95JobsServer` |

`+18 / -72` lines (each file: same +3/-12 transform).

## Verification

- Repo-wide grep `_fixture = new (ReferenceServer\|Isa95JobsServer)\(\)` → 0 matches after the change.
- `dotnet build src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj -c Release` → `Build succeeded. 175 Warning(s), 0 Error(s)` (all warnings pre-existing analyzer noise).
- Pattern alignment: the new shape matches `Controller/Alarms/Json/NodeServicesTests.cs` and the rest of the test tree.

## Risk

- **Sharing assumption.** Tests in each affected class do not mutate `_fixture` (only read `EndpointUrl` once in the ctor). Verified by `grep -n '_fixture\.'` — only `EndpointUrl` reads and the now-removed `Dispose()` calls. If a future test introduces a server-side mutation it must either (a) be in a new class or (b) explicitly opt out of the fixture sharing.
- **Crash dump not available.** Fix is circumstantial; if Windows nightly runs continue to crash in *different* tests, we'll need to invest in artifact policy to actually retain the `.dmp` so we can root-cause the next instance directly.
- **No production code touched.**
