### PR TITLE
Share ReverseConnect ReferenceServer instances via IClassFixture

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/ReverseConnectIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/ReverseConnectIntegrationTests.cs
@@ -7,7 +7,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
 {
     using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
     using Azure.IIoT.OpcUa.Publisher.Testing.Fixtures;
-    using Neovolve.Logging.Xunit;
     using System;
     using System.Linq;
     using System.Text.Json;
@@ -15,13 +14,37 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
-    public class ReverseConnectIntegrationTests : PublisherIntegrationTestBase
+    /// <summary>
+    /// Owns one direct and one reverse-connect <see cref="ReferenceServer"/>
+    /// shared by the parameterized tests in this file. Sharing the servers
+    /// via <see cref="IClassFixture{TFixture}"/> avoids cumulative
+    /// ServerConsoleHost / PKI / cert teardown churn that surfaced as a
+    /// testhost SEH crash on the Windows pipeline (see PRs #2456 and #2458).
+    /// </summary>
+    public sealed class ReverseConnectServerFixture : IDisposable
     {
-        private readonly ITestOutputHelper _output;
+        public ReferenceServer Direct { get; } = new ReferenceServer();
+        public ReferenceServer ReverseConnect { get; } = new ReferenceServer(useReverseConnect: true);
 
-        public ReverseConnectIntegrationTests(ITestOutputHelper output) : base(output)
+        public ReferenceServer Get(bool useReverseConnect)
+            => useReverseConnect ? ReverseConnect : Direct;
+
+        public void Dispose()
         {
-            _output = output;
+            Direct.Dispose();
+            ReverseConnect.Dispose();
+        }
+    }
+
+    public class ReverseConnectIntegrationTests : PublisherIntegrationTestBase,
+        IClassFixture<ReverseConnectServerFixture>
+    {
+        private readonly ReverseConnectServerFixture _fixture;
+
+        public ReverseConnectIntegrationTests(ReverseConnectServerFixture fixture,
+            ITestOutputHelper output) : base(output)
+        {
+            _fixture = fixture;
         }
 
         [Theory]
@@ -29,7 +52,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         [InlineData(false)]
         public async Task RegisteredReadTestAsync(bool useReverseConnect)
         {
-            using var server = ReferenceServer.Create(LogFactory.Create(_output, Logging.Config), useReverseConnect);
+            var server = _fixture.Get(useReverseConnect);
             EndpointUrl = server.EndpointUrl;
 
             var name = nameof(RegisteredReadTestAsync) + (useReverseConnect ? "WithReverseConnect" : "NoReverseConnect");
@@ -64,9 +87,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         [InlineData(false)]
         public async Task KeepAliveTestAsync(bool useReverseConnect)
         {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-            using var server = ReferenceServer.Create(LogFactory.Create(_output, Logging.Config), useReverseConnect);
-#pragma warning restore CA2000 // Dispose objects before losing scope
+            var server = _fixture.Get(useReverseConnect);
             EndpointUrl = server.EndpointUrl;
 
             var name = nameof(KeepAliveTestAsync) + (useReverseConnect ? "WithReverseConnect" : "NoReverseConnect");

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/ReferenceServer.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/ReferenceServer.cs
@@ -45,6 +45,15 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Fixtures
         {
         }
 
+        /// <summary>
+        /// Create reference server with the default logger factory.
+        /// </summary>
+        /// <param name="useReverseConnect"></param>
+        public ReferenceServer(bool useReverseConnect)
+            : base(Reference, null, useReverseConnect)
+        {
+        }
+
         /// <inheritdoc/>
         private ReferenceServer(ILoggerFactory loggerFactory,
             bool useReverseConnect)


### PR DESCRIPTION
## Summary

Follow-up to #2458. `ReverseConnectIntegrationTests` was still constructing
(and disposing) a fresh `ReferenceServer` — and its reverse-connect
variant — for every parameterized Theory row, which keeps the
ServerConsoleHost / PKI / cert teardown churn that #2456 + #2458 mitigated
elsewhere alive on this last test file.

This change moves it to the same `IClassFixture<TFixture>` shared-server
pattern the rest of the test tree uses.

## Changes

- New `ReverseConnectServerFixture : IDisposable` owns one `Direct` and one
  `ReverseConnect` `ReferenceServer` for the lifetime of the test class
  and exposes them via `Get(bool useReverseConnect)`.
- `ReverseConnectIntegrationTests` now implements
  `IClassFixture<ReverseConnectServerFixture>` and the four Theory rows
  (`RegisteredReadTestAsync`, `KeepAliveTestAsync` × `{true, false}`)
  resolve their server via `_fixture.Get(useReverseConnect)` instead of
  `ReferenceServer.Create(...)`.
- Restores the `public ReferenceServer(bool useReverseConnect)` constructor
  so the fixture can request a reverse-connect server inline without going
  through the logger-factory factory method.

## Validation

Built locally with `dotnet build -c Release`. All four Theory cases pass
under `dotnet test --filter "FullyQualifiedName~ReverseConnectIntegrationTests"`
(50 s total).

## Related

- #2456 — disposes publisher before OPC UA server (root SEH crash fix).
- #2458 — moved six other integration-test classes to `IClassFixture`.
