### PR TITLE
Fix e2e KeyVault deploy: replace removed -EnableRbacAuthorization (Az.KeyVault 6.x)

### DIFF
--- a/tools/e2etesting/DeployStandalone.ps1
+++ b/tools/e2etesting/DeployStandalone.ps1
@@ -102,10 +102,14 @@ $keyVault = Get-AzKeyVault -ResourceGroupName $ResourceGroupName -VaultName $key
 
 if (!$keyVault) {
     Write-Host "Creating Key Vault $($keyVaultName)"
-    $keyVault = New-AzKeyVault -ResourceGroupName $ResourceGroupName -VaultName $keyVaultName -Location $resourceGroup.Location -EnableRbacAuthorization
+    # Az.KeyVault 6.x removed -EnableRbacAuthorization; new vaults are
+    # RBAC-enabled by default, so the switch is simply omitted here.
+    $keyVault = New-AzKeyVault -ResourceGroupName $ResourceGroupName -VaultName $keyVaultName -Location $resourceGroup.Location
 }
 else {
-    $keyVault | Update-AzKeyVault -EnableRbacAuthorization
+    # Enable RBAC on a pre-existing vault. Az.KeyVault 6.x exposes only
+    # -DisableRbacAuthorization, so :$false turns RBAC authorization on.
+    $keyVault | Update-AzKeyVault -DisableRbacAuthorization:$false
 }
 
 if ($ServicePrincipalId) {


### PR DESCRIPTION
## Summary

The `Industrial-IoT-E2E-Standalone` ADO pipeline fails in the **Deploy standalone resources** step while provisioning the Key Vault:

```
Creating Key Vault e2etestingkeyVault17332
##[error]A parameter cannot be found that matches parameter name 'EnableRbacAuthorization'.
##[error]PowerShell exited with code '1'.
```

(Internal ADO build [168077000](https://msazure.visualstudio.com/b32aa71e-8ed2-41b2-9d77-5bc261222004/_apis/build/builds/168077000/logs/53).)

## Root cause

`tools/e2etesting/DeployStandalone.ps1` (introduced in #2454) calls `New-AzKeyVault` / `Update-AzKeyVault` with `-EnableRbacAuthorization`. **Az.KeyVault 6.x removed that parameter** from `New-AzKeyVault` — newly created vaults are RBAC-enabled by default, and the only remaining switch is `-DisableRbacAuthorization`. The pipeline's container ships Az.KeyVault 6.x, so the call fails with a parameter-binding error.

Verified by introspecting Az.KeyVault 6.0.0 locally: `New-AzKeyVault` has no `-EnableRbacAuthorization`; both `New-AzKeyVault` and `Update-AzKeyVault` expose `-DisableRbacAuthorization`.

## Fix

- **Create path:** drop `-EnableRbacAuthorization` — RBAC is the default for new vaults in Az.KeyVault 6.x.
- **Existing-vault path:** use `Update-AzKeyVault -DisableRbacAuthorization:$false` to enable RBAC authorization.

`tools/e2etesting/VerifyDeployment.ps1` only *reads* the `EnableRbacAuthorization` property of the returned vault object, so it is unaffected.

## Validation

- Script parses cleanly (`[Parser]::ParseFile` — 0 syntax errors).
- No remaining `-EnableRbacAuthorization` cmdlet usages in the repo.
- Full deployment behaviour is exercised by the next `Industrial-IoT-E2E-Standalone` pipeline run.
