### PR TITLE
Fix testhost hang from concurrent TestDataGenerator random corruption

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Utils/TestDataGenerator.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Utils/TestDataGenerator.cs
@@ -98,7 +98,7 @@ namespace Opc.Ua.Test
             MaxDateTimeValue = new DateTime(2100, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             NamespaceUris = new NamespaceTable();
             ServerUris = new StringTable();
-            _random = random ?? new RandomSource();
+            _random = new ThreadSafeRandomSource(random ?? new RandomSource());
             _boundaryValues = [];
             for (var i = 0; i < kAvailableBoundaryValues.Length; i++)
             {
@@ -958,6 +958,44 @@ namespace Opc.Ua.Test
             new BoundaryValues(typeof(byte[]), Array.Empty<byte>()),
             new BoundaryValues(typeof(StatusCode), 0u, 1073741824u, 2147483648u)
         ];
+
+        /// <summary>
+        /// The OPC UA SDK <see cref="RandomSource"/> wraps a non thread-safe
+        /// <see cref="System.Random"/>. Test servers build their address spaces
+        /// concurrently (one server per xUnit class fixture), so several
+        /// generators end up driving the same underlying random source in
+        /// parallel. Concurrent use corrupts its internal state, after which
+        /// NextInt32 keeps returning 0 and the array-length loop in
+        /// <see cref="GetRandom(NodeId, int, IList{uint}, ITypeTable)"/> spins
+        /// forever, hanging the test host. Serialize every access on a
+        /// process-wide lock to keep the generator state consistent.
+        /// </summary>
+        private sealed class ThreadSafeRandomSource : IRandomSource
+        {
+            public ThreadSafeRandomSource(IRandomSource source)
+            {
+                _source = source;
+            }
+
+            public void NextBytes(byte[] bytes, int offset, int count)
+            {
+                lock (kLock)
+                {
+                    _source.NextBytes(bytes, offset, count);
+                }
+            }
+
+            public int NextInt32(int max)
+            {
+                lock (kLock)
+                {
+                    return _source.NextInt32(max);
+                }
+            }
+
+            private static readonly object kLock = new();
+            private readonly IRandomSource _source;
+        }
 
         private readonly IRandomSource _random;
         private readonly SortedDictionary<string, object[]> _boundaryValues;


### PR DESCRIPTION
## Summary

Fixes the recurring `Azure.IIoT.OpcUa.Publisher.Module.Tests` **test host process crashed** failures on both Windows and Linux (e.g. internal builds 168199739 / 168208297 / 168212488). The previous mitigations (#2456, #2458, #2467) targeted finalizer/native-handle pressure, but the real cause is a **deadlock-style hang**, not a memory crash.

## Root cause (from the Linux hang dump)

The test host does not crash — it **hangs**, and vstest's `--blame-hang` 10‑minute inactivity timeout then aborts the run (which surfaces as "Test host process crashed").

Analysis of the hang dump showed multiple worker threads — each constructing a **different** `TestDataServer` / `BaseServerFixture` in parallel (one server per xUnit class fixture) — all spinning in `System.Random.Next`, reached via `TestDataSystem.ReadValue → TestDataGenerator.GetRandom`.

Heap statistics were conclusive: **6 `Opc.Ua.Test.RandomSource` instances but only one `System.Random+CompatSeedImpl`**, with 4+ threads executing inside it. The SDK's `RandomSource` wraps a **non‑thread‑safe `System.Random` that ends up shared** across the concurrently‑constructed generators. Concurrent access corrupts its internal state, after which `NextInt32(100)` returns `0` indefinitely, so the array‑length loop in `TestDataGenerator.GetRandom`:

```csharp
while (array[i] == 0)
{
    array[i] = _random.NextInt32(MaxArrayLength);
}
```

never terminates → the fixture constructor never returns → no test completes for 10 minutes → blame-hang aborts the host.

This became observable as `IClassFixture`-based server sharing increased the amount of concurrent fixture construction.

## Fix

Wrap the random source in a process‑wide thread‑safe `IRandomSource` decorator inside `TestDataGenerator`, serializing every `NextInt32` / `NextBytes` call. This keeps the shared generator's state consistent under concurrent construction while preserving the SDK's exact value semantics (no behavioural change to generated data).

## Validation

- `dotnet build Azure.IIoT.OpcUa.Publisher.Testing.Servers.csproj` — clean (0 errors).
- The hang is timing/parallelism dependent; full validation is the internal PR pipeline run of `Azure.IIoT.OpcUa.Publisher.Module.Tests` on Windows and Linux.
