### PR TITLE
Reduce Module.Tests parallelism to avoid CI test-host crash

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Properties/AssemblyInfo.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Properties/AssemblyInfo.cs
@@ -5,5 +5,9 @@
 
 #if !DEBUG
 using Xunit;
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, MaxParallelThreads = 4)]
+// MaxParallelThreads is intentionally capped low: each integration-test fixture
+// spins up an OPC UA server, an in-process MQTT broker and a publisher host, so
+// running many in parallel peaks native handle / memory usage and crashes the
+// test host on the resource-constrained CI build containers. Keep this at 2.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, MaxParallelThreads = 2)]
 #endif


### PR DESCRIPTION
Each integration-test fixture starts an OPC UA server, an in-process MQTT broker and a publisher host. With `MaxParallelThreads=4` up to four run concurrently, peaking native handle/memory usage and crashing the test host on the resource-constrained OneBranch **Windows** build container (observed: `Test host process crashed` after ~1155 tests, during a heavy MQTT pending-conditions test, with **no managed fault and no dump** — i.e. an external/OOM-style kill).%0A%0AThe crash does **not** reproduce locally (full suite runs with flat handle counts ~2700 and ample RAM), confirming it is specific to the constrained container.%0A%0ALower `MaxParallelThreads` to **2** to halve peak concurrent fixture load, continuing the resource-reduction strategy of #2456/#2458. A complementary pipeline change adds ProcDump/WER dump capture so any future crash is analyzable.