### PR TITLE
Fix Windows test-host crash: use polling file watcher in integration tests

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
@@ -335,10 +335,14 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
                 },
             ];
 
-            if (OperatingSystem.IsLinux())
-            {
-                arguments = [.. arguments, "--pol"];
-            }
+            // Use the polling file-change watcher on all platforms in tests.
+            // The native FileSystemWatcher's change-notification callback can
+            // hit an access violation under the heavy create/modify/delete and
+            // publisher-dispose churn of the integration suite, crashing the
+            // test host (root-caused from a Windows WER dump; Linux already
+            // forced polling). Production is unaffected - it watches a single
+            // long-lived file - so this stays a test-only setting.
+            arguments = [.. arguments, "--pol"];
 
             if (reverseConnectPort != null)
             {


### PR DESCRIPTION
Root cause (from a Windows WER dump)%0A%0AWith the new dump-capture pipeline, the failing `test_windows_Release 2` job finally produced a real **1.2 GB WER crash dump** plus the resource-trend diagnostics. They show:%0A- **Not a resource leak** - handles plateau ~2500-2800, memory oscillates with GC working.%0A- **No managed exception** - none of the `UnhandledException`/`UnobservedTaskException` handlers fired; the process died abruptly (no `ProcessExit`).%0A- The faulting thread is a **native access violation in a `FileSystemWatcher` I/O-completion callback**: %0A  `FileSystemWatcher.ParseEventBufferAndNotifyForEach` -> `NotifyFileSystemEventArgs` -> `FileInfo.get_Exists()` -> `GetFileAttributesEx` (P/Invoke).%0A%0AThe publisher watches the published-nodes file through `PhysicalFileProvider`, which uses the **native `FileSystemWatcher`** unless polling is enabled. The integration suite rapidly creates/modifies/deletes temp published-nodes files and starts/disposes publishers; under that churn the native watcher hits a teardown race and crashes the test host. It was **Windows-only purely because the tests already forced polling on Linux** (`--pol`) but not Windows.%0A%0A## Fix%0A%0AUse the polling file-change watcher on **all platforms** in the integration-test harness (previously Linux-only). This avoids the native watcher entirely under test churn. **Production is unaffected** - it watches a single long-lived file with no churn, so it keeps the efficient native watcher.%0A%0A## Follow-ups%0AOnce a green run confirms the fix, the temporary diagnostics (#2473) and the parallelism cap (#2471) can be reverted.