### PR TITLE
Fix testhost crash: drain in-flight node-cache work before disposing OPC UA session

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSession.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSession.cs
@@ -148,6 +148,18 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
 
             if (disposing)
             {
+                // Cancel and drain in-flight session work (notably the complex
+                // type system load, which browses the address space through the
+                // node cache) BEFORE tearing the session down. Otherwise a
+                // background LruNodeCache reference fetch can construct an
+                // Opc.Ua.Client.Browser against the now-disposed session and
+                // crash the process with a native access violation.
+                _cts.Cancel();
+                if (_complexTypeSystem != null)
+                {
+                    Try.Op(() => _complexTypeSystem.Wait(TimeSpan.FromSeconds(5)));
+                }
+
                 NodeCache?.Clear();
                 LruNodeCache.Clear();
 
@@ -174,11 +186,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
 
                 try
                 {
-                    _cts.Cancel();
-                    if (_complexTypeSystem != null)
-                    {
-                        Try.Op(() => _complexTypeSystem.Wait(TimeSpan.FromSeconds(5)));
-                    }
                     _logger.SessionDisposed(sessionName);
                 }
                 finally


### PR DESCRIPTION
## Root cause (Windows first-chance AV dump, cdb !analyze -v)%0A%0AThe `test_windows_Release 2` Module.Tests job kept aborting with **Test host process crashed**. After fixing the earlier hang (#2469) and FileSystemWatcher AV (#2474), a third native crash remained. With the pipeline tuned to capture the **first-chance access violation**, the dump gave the exact faulting stack:%0A%0A\\\%0Acmp qword ptr [rcx],rax   ds:0000000000000000   <- rcx (session) = NULL%0ACLRStub[VSD_DispatchStub]                                  <- interface call on null%0AOpc.Ua.Client.Browser..ctor(Opc.Ua.ISessionClient, BrowserOptions)+0x4f%0AOpc.Ua.Client.NodeCacheContext.FetchReferencesAsync(...)%0AOpc.Ua.Client.LruNodeCache.GetOrAddReferencesAsync(...)   (BitFaster async cache)%0AAzure.IIoT...OpcUaSession ... node cache browse%0A\\\%0A%0A**`Opc.Ua.Client.Browser` is constructed with a null session and immediately calls an interface method on it -> native AV.** This is a **use-after-dispose race**: `OpcUaSession.Dispose` cleared the node cache and called `base.Dispose()` (tearing the session down) **before** cancelling `_cts` and draining the in-flight complex-type-system load. So a background `LruNodeCache` reference fetch could build a `Browser` against the just-disposed session. The integration suite's rapid session create/dispose churn triggers it (Windows; the in-flight victim test varied every run; `verifyheap` was clean, confirming a native AV rather than managed heap corruption).%0A%0A## Fix%0A%0AMove `_cts.Cancel()` and the `_complexTypeSystem` drain to **before** the node-cache clear and `base.Dispose()`, so in-flight node-cache work is cancelled/finished before the session is torn down. This is a real production disposal race, not just test flakiness.%0A%0A## Validation%0A`dotnet build Azure.IIoT.OpcUa.Publisher.csproj` clean (0 errors). Full validation is the next vs2026 Windows Module.Tests run.%0A%0A## Diagnostics scaffolding to revert after a green run%0A- #2473 (TestHostDiagnostics), #2471 (parallelism cap), and the vs2026 WER/ProcDump capture were the tools that made this root cause possible; they can be reverted once confirmed.