### PR TITLE
Fix Windows test-host crash: serialize alarm condition branch access

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/GuardedAlarmStates.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/GuardedAlarmStates.cs
@@ -1,0 +1,211 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Alarms
+{
+    using Opc.Ua;
+
+    /// <summary>
+    /// The OPC UA stack stores condition branches in a plain, non thread-safe
+    /// <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/> that is
+    /// both enumerated (<c>ConditionState.GetRetainState</c>,
+    /// <c>ConditionState.ConditionRefresh</c>) and mutated
+    /// (<c>CreateBranch</c>, <c>ReplaceBranchEvent</c>, <c>RemoveBranchEvent</c>)
+    /// without any synchronization. When the alarm simulation drives state
+    /// changes on background threads while the dictionary is concurrently read,
+    /// the enumeration can observe a torn entry and dereference it, crashing the
+    /// process with a native access violation in <c>ConditionState.IsBranch</c>.
+    /// The guarded alarm states below serialize all branch access on the owning
+    /// node manager lock - the same lock every alarm mutation in this server
+    /// already takes - and propagate that lock to branches created by the stack.
+    /// </summary>
+    internal interface IBranchGuarded
+    {
+        /// <summary>
+        /// Lock guarding access to the condition branch dictionary.
+        /// </summary>
+        object BranchLock { get; }
+    }
+
+    /// <summary>
+    /// Guarded <see cref="AlarmConditionState"/>.
+    /// </summary>
+    internal sealed class GuardedAlarmConditionState : AlarmConditionState, IBranchGuarded
+    {
+        /// <inheritdoc/>
+        public object BranchLock { get; }
+
+        /// <summary>
+        /// Create the original condition with the owning node manager lock.
+        /// </summary>
+        public GuardedAlarmConditionState(NodeState parent, object branchLock)
+            : base(parent)
+        {
+            BranchLock = branchLock ?? new object();
+        }
+
+        /// <summary>
+        /// Used by the stack when creating branches via reflection - inherit the
+        /// lock from the originating condition passed as the parent.
+        /// </summary>
+        public GuardedAlarmConditionState(NodeState parent)
+            : this(parent, (parent as IBranchGuarded)?.BranchLock)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override bool GetRetainState()
+        {
+            lock (BranchLock)
+            {
+                return base.GetRetainState();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ConditionState CreateBranch(ISystemContext context, NodeId branchId)
+        {
+            lock (BranchLock)
+            {
+                return base.CreateBranch(context, branchId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Guarded <see cref="ExclusiveDeviationAlarmState"/>.
+    /// </summary>
+    internal sealed class GuardedExclusiveDeviationAlarmState : ExclusiveDeviationAlarmState, IBranchGuarded
+    {
+        /// <inheritdoc/>
+        public object BranchLock { get; }
+
+        /// <summary>
+        /// Create the original condition with the owning node manager lock.
+        /// </summary>
+        public GuardedExclusiveDeviationAlarmState(NodeState parent, object branchLock)
+            : base(parent)
+        {
+            BranchLock = branchLock ?? new object();
+        }
+
+        /// <summary>
+        /// Used by the stack when creating branches via reflection - inherit the
+        /// lock from the originating condition passed as the parent.
+        /// </summary>
+        public GuardedExclusiveDeviationAlarmState(NodeState parent)
+            : this(parent, (parent as IBranchGuarded)?.BranchLock)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override bool GetRetainState()
+        {
+            lock (BranchLock)
+            {
+                return base.GetRetainState();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ConditionState CreateBranch(ISystemContext context, NodeId branchId)
+        {
+            lock (BranchLock)
+            {
+                return base.CreateBranch(context, branchId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Guarded <see cref="NonExclusiveLevelAlarmState"/>.
+    /// </summary>
+    internal sealed class GuardedNonExclusiveLevelAlarmState : NonExclusiveLevelAlarmState, IBranchGuarded
+    {
+        /// <inheritdoc/>
+        public object BranchLock { get; }
+
+        /// <summary>
+        /// Create the original condition with the owning node manager lock.
+        /// </summary>
+        public GuardedNonExclusiveLevelAlarmState(NodeState parent, object branchLock)
+            : base(parent)
+        {
+            BranchLock = branchLock ?? new object();
+        }
+
+        /// <summary>
+        /// Used by the stack when creating branches via reflection - inherit the
+        /// lock from the originating condition passed as the parent.
+        /// </summary>
+        public GuardedNonExclusiveLevelAlarmState(NodeState parent)
+            : this(parent, (parent as IBranchGuarded)?.BranchLock)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override bool GetRetainState()
+        {
+            lock (BranchLock)
+            {
+                return base.GetRetainState();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ConditionState CreateBranch(ISystemContext context, NodeId branchId)
+        {
+            lock (BranchLock)
+            {
+                return base.CreateBranch(context, branchId);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Guarded <see cref="TripAlarmState"/>.
+    /// </summary>
+    internal sealed class GuardedTripAlarmState : TripAlarmState, IBranchGuarded
+    {
+        /// <inheritdoc/>
+        public object BranchLock { get; }
+
+        /// <summary>
+        /// Create the original condition with the owning node manager lock.
+        /// </summary>
+        public GuardedTripAlarmState(NodeState parent, object branchLock)
+            : base(parent)
+        {
+            BranchLock = branchLock ?? new object();
+        }
+
+        /// <summary>
+        /// Used by the stack when creating branches via reflection - inherit the
+        /// lock from the originating condition passed as the parent.
+        /// </summary>
+        public GuardedTripAlarmState(NodeState parent)
+            : this(parent, (parent as IBranchGuarded)?.BranchLock)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override bool GetRetainState()
+        {
+            lock (BranchLock)
+            {
+                return base.GetRetainState();
+            }
+        }
+
+        /// <inheritdoc/>
+        public override ConditionState CreateBranch(ISystemContext context, NodeId branchId)
+        {
+            lock (BranchLock)
+            {
+                return base.CreateBranch(context, branchId);
+            }
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/SourceState.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/SourceState.cs
@@ -303,7 +303,7 @@ namespace Alarms
             {
                 case "HighAlarm":
                     {
-                        var node2 = new ExclusiveDeviationAlarmState(this);
+                        var node2 = new GuardedExclusiveDeviationAlarmState(this, _nodeManager.Lock);
                         node = node2;
                         node2.HighLimit = new PropertyState<double>(node2);
                         break;
@@ -311,7 +311,7 @@ namespace Alarms
 
                 case "HighLowAlarm":
                     {
-                        var node2 = new NonExclusiveLevelAlarmState(this);
+                        var node2 = new GuardedNonExclusiveLevelAlarmState(this, _nodeManager.Lock);
                         node = node2;
 
                         node2.HighHighLimit = new PropertyState<double>(node2);
@@ -329,13 +329,13 @@ namespace Alarms
 
                 case "TripAlarm":
                     {
-                        node = new TripAlarmState(this);
+                        node = new GuardedTripAlarmState(this, _nodeManager.Lock);
                         break;
                     }
 
                 default:
                     {
-                        node = new AlarmConditionState(this);
+                        node = new GuardedAlarmConditionState(this, _nodeManager.Lock);
                         break;
                     }
             }


### PR DESCRIPTION
## Problem

The Windows `test_windows_Release 2` job (Module.Tests) intermittently failed with a **native access violation** that crashed the test host. WinDbg `!analyze -v` on a first-chance dump pinned the fault to `Opc.Ua.ConditionState.IsBranch` dereferencing a **null reference**, reached during alarm condition processing in the **Alarms test server**.

## Root cause

The OPC UA stack (`OPCFoundation.NetStandard.Opc.Ua.Core` 1.5.378.145) stores condition branches in a plain, **non thread-safe `Dictionary`** (`m_branches`). It is:

- **enumerated** in `ConditionState.GetRetainState` (via `UpdateRetainState`) and `ConditionState.ConditionRefresh`, and
- **mutated** in `CreateBranch` / `ReplaceBranchEvent` / `RemoveBranchEvent`

with **no synchronization**. The Alarms server runs a live simulation that drives alarm state changes on background `Timer` threads. When the branch dictionary is enumerated while a concurrent mutation is in flight, the enumeration observes a torn entry and dereferences it → native AV. This only reproduces under the slow, constrained CI Windows container.

## Fix

We instantiate the alarm condition types in `SourceState.CreateAlarm`, so we can subclass them and serialize all branch access. `GuardedAlarmStates.cs` adds guarded subclasses of the four types we create (`AlarmConditionState`, `ExclusiveDeviationAlarmState`, `NonExclusiveLevelAlarmState`, `TripAlarmState`) that:

- lock `GetRetainState` and `CreateBranch` on the **owning node manager `Lock`** — the same lock every alarm mutation in this server already takes (re-entrant, no new lock ordering), and
- **propagate that lock to branches** the stack creates via `Activator.CreateInstance(GetType(), this)`.

Contained entirely to the test server; the address space and alarm behavior are unchanged (base logic is still invoked, just serialized).

## Validation

- `dotnet build` of `Azure.IIoT.OpcUa.Publisher.Testing.Servers` and `Azure.IIoT.OpcUa.Publisher.Module.Tests` — 0 errors.
- Ran the alarm/branch tests locally (branches are exercised by "pending conditions"): **9/9 passed** across JSON / MsgPack / MQTT / device-method variants (`CanSendPendingConditions*`).

This is the 4th distinct native-AV root-caused in the Module.Tests Windows job; prior fixes: #2469, #2474, #2476.