### PR TITLE
Fix Windows test-host crash: synchronize Alarms ConditionRefresh

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/SourceState.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/SourceState.cs
@@ -94,62 +94,70 @@ namespace Alarms
         /// <param name="includeChildren">Whether to recursively report events for the children.</param>
         public override void ConditionRefresh(ISystemContext context, List<IFilterTarget> events, bool includeChildren)
         {
-            // need to check if this source has already been processed during this refresh operation.
-            for (var ii = 0; ii < events.Count; ii++)
+            // The condition refresh worker can run on a background thread that does
+            // not hold the node manager lock, while OnAlarmChanged (driven by the
+            // simulation) concurrently mutates _alarms/_branches under that lock.
+            // Enumerating these dictionaries without synchronization races with those
+            // mutations and corrupts the heap. Take the same lock to serialize access.
+            lock (_nodeManager.Lock)
             {
-                if (events[ii] is InstanceStateSnapshot e && ReferenceEquals(e.Handle, this))
+                // need to check if this source has already been processed during this refresh operation.
+                for (var ii = 0; ii < events.Count; ii++)
                 {
-                    return;
+                    if (events[ii] is InstanceStateSnapshot e && ReferenceEquals(e.Handle, this))
+                    {
+                        return;
+                    }
                 }
-            }
 
-            // report the dialog.
-            if (_dialog != null)
-            {
-                // do not refresh dialogs that are not active.
-                if (_dialog.Retain.Value)
+                // report the dialog.
+                if (_dialog != null)
                 {
+                    // do not refresh dialogs that are not active.
+                    if (_dialog.Retain.Value)
+                    {
+                        // create a snapshot.
+                        var e = new InstanceStateSnapshot();
+                        e.Initialize(context, _dialog);
+
+                        // set the handle of the snapshot to check for duplicates.
+                        e.Handle = this;
+
+                        events.Add(e);
+                    }
+                }
+
+                // the alarm objects act as a cache for the last known state and are used to generate refresh events.
+                foreach (var alarm in _alarms.Values)
+                {
+                    // do not refresh alarms that are not in an interesting state.
+                    if (!alarm.Retain.Value)
+                    {
+                        continue;
+                    }
+
                     // create a snapshot.
                     var e = new InstanceStateSnapshot();
-                    e.Initialize(context, _dialog);
+                    e.Initialize(context, alarm);
 
                     // set the handle of the snapshot to check for duplicates.
                     e.Handle = this;
 
                     events.Add(e);
                 }
-            }
 
-            // the alarm objects act as a cache for the last known state and are used to generate refresh events.
-            foreach (var alarm in _alarms.Values)
-            {
-                // do not refresh alarms that are not in an interesting state.
-                if (!alarm.Retain.Value)
+                // report any active branches.
+                foreach (var alarm in _branches.Values)
                 {
-                    continue;
+                    // create a snapshot.
+                    var e = new InstanceStateSnapshot();
+                    e.Initialize(context, alarm);
+
+                    // set the handle of the snapshot to check for duplicates.
+                    e.Handle = this;
+
+                    events.Add(e);
                 }
-
-                // create a snapshot.
-                var e = new InstanceStateSnapshot();
-                e.Initialize(context, alarm);
-
-                // set the handle of the snapshot to check for duplicates.
-                e.Handle = this;
-
-                events.Add(e);
-            }
-
-            // report any active branches.
-            foreach (var alarm in _branches.Values)
-            {
-                // create a snapshot.
-                var e = new InstanceStateSnapshot();
-                e.Initialize(context, alarm);
-
-                // set the handle of the snapshot to check for duplicates.
-                e.Handle = this;
-
-                events.Add(e);
             }
         }
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
## Problem

Follow-up to #2478. Build [168461277](https://msazure.visualstudio.com/One/_build/results?buildId=168461277) — which **included #2478** — still failed `test_windows_Release 2` with a native test-host crash (~801 tests in).

## Root cause (from the captured first-chance dump)

WinDbg analysis showed the same `Opc.Ua.ConditionState.IsBranch` access violation, **but** `Alarms.GuardedExclusiveDeviationAlarmState.GetRetainState` (added in #2478) was already in the stack — so the `GetRetainState`/`CreateBranch` locks were not the (only) race.

Disassembly of the faulting instruction showed `IsBranch` dereferencing a **null `BranchId`** on an otherwise-valid alarm — i.e. **GC heap corruption**, not a branch-dictionary torn read. The dump also showed a concurrent `SubscriptionManager.ConditionRefreshWorkerAsync` thread.

The real race: **`SourceState.ConditionRefresh` enumerates `_alarms`/`_branches` without the node manager lock**, while `OnAlarmChanged` (driven by the alarm simulation timer) concurrently **adds/removes** entries in those dictionaries *under* that lock. The async condition-refresh worker runs the refresh off the lock, so the unsynchronized enumeration races with the mutations → heap corruption → a random null-field AV on another thread (here, the Alarms server still being constructed).

## Fix

Serialize `SourceState.ConditionRefresh` on the same `_nodeManager.Lock` that every alarm mutation (`OnAlarmChanged`/`UpdateAlarm`) already takes. Contained to the test server; behavior unchanged. Applies to all `SourceState` instances, so it also covers the shared ReferenceServer whose refresh-vs-simulation race was the heap-corruption source.

## Validation

- Clean build of `Testing.Servers` + `Module.Tests` (0 errors).
- `PendingConditions` tests (which subscribe to conditions and trigger ConditionRefresh during the running simulation): **9/9 passed** locally.

Tracking the upstream SDK thread-safety issue in #2479.