### PR TITLE
Fix Windows test-host crash: serialize OPC UA test server construction

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/BaseServerFixture.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/BaseServerFixture.cs
@@ -160,17 +160,23 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Fixtures
             {
                 try
                 {
-                    serverHost = new ServerConsoleHost(new ServerFactory(
-                        _container.Resolve<ILogger<ServerFactory>>(), TempPath, nodes)
+                    // Serialize server construction/startup: it loads predefined nodes
+                    // and registers types into process-global stack state that is not
+                    // safe to mutate from multiple fixtures concurrently.
+                    lock (kServerStartupLock)
                     {
-                        LogStatus = false
-                    }, _container.Resolve<ILogger<ServerConsoleHost>>())
-                    {
-                        PkiRootPath = options.Value.Security.PkiRootPath,
-                        AutoAccept = true
-                    };
-                    logger.StartingServerHost(serverHost, _port);
-                    serverHost.StartAsync(new int[] { _port }).Wait();
+                        serverHost = new ServerConsoleHost(new ServerFactory(
+                            _container.Resolve<ILogger<ServerFactory>>(), TempPath, nodes)
+                        {
+                            LogStatus = false
+                        }, _container.Resolve<ILogger<ServerConsoleHost>>())
+                        {
+                            PkiRootPath = options.Value.Security.PkiRootPath,
+                            AutoAccept = true
+                        };
+                        logger.StartingServerHost(serverHost, _port);
+                        serverHost.StartAsync(new int[] { _port }).Wait();
+                    }
 
                     //
                     // Test server connection. Sometimes the server has not
@@ -453,6 +459,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Fixtures
         private readonly ConcurrentBag<(ITimer timer,
             EventHandler<FastTimerElapsedEventArgs> handler)> _fastTimers = [];
         private static readonly ConcurrentDictionary<int, bool> kPorts = new();
+        // Serializes OPC UA server bring-up. Constructing/starting a server loads the
+        // predefined node set and registers types, which mutates process-global stack
+        // state (e.g. the shared encodeable type factory). Two fixtures constructing
+        // concurrently race on that shared state and corrupt the managed heap, which
+        // surfaces as a native access violation on an unrelated thread.
+        private static readonly object kServerStartupLock = new();
         private bool _disposedValue;
         private readonly int _port;
         private readonly IContainer _container;


### PR DESCRIPTION
## Problem

Follow-up to #2478 and #2480. Build [168499254](https://msazure.visualstudio.com/One/_build/results?buildId=168499254) — which **included both** prior fixes — still failed `test_windows_Release 2` with the same native test-host crash (~967 tests in).

## Root cause (from the captured first-chance dump)

Same fault as before: `Opc.Ua.ConditionState.IsBranch` dereferencing a **null `BranchId`** on an otherwise-valid alarm (verified by disassembly) → **GC heap corruption**, during the alarm server's construction (`SourceState..ctor → Refresh → … → GetRetainState`).

But scanning **all 35 threads** revealed the real trigger: **two server fixtures were being constructed concurrently** — `BaseServerFixture..ctor` ×2 (`AlarmsServer` + `TestDataServer`), with multiple `CustomNodeManager2.LoadPredefinedNodes` / `AddPredefinedNode` / `CreateAddressSpace` in flight.

Constructing an OPC UA server loads the predefined node set and **registers types into process-global stack state** (e.g. the shared encodeable type factory). Mutating that from two fixtures at once corrupts a shared dictionary → managed-heap corruption → a random null-field AV on whichever server is building. This is why #2478/#2480 (which fixed specific per-server readers) didn't fully resolve it — the corruption is cross-server, during construction.

## Fix

Serialize server construction/startup in `BaseServerFixture` with a process-wide static lock, so only one fixture brings up its server at a time. This matches the repo's existing *"OPC UA servers must run serially"* guidance. Test-only; no product code changes.

## Validation

- Clean build of `Module.Tests` (0 errors).
- `PendingConditions` tests: **9/9 passed** locally (no regression; fixtures still construct/serve correctly).

Tracking the upstream SDK thread-safety in #2479.