### PR TITLE
Fix Windows test-host crash: guard alarm retain-state against null BranchId

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/GuardedAlarmStates.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Alarms/GuardedAlarmStates.cs
@@ -30,6 +30,27 @@ namespace Alarms
     }
 
     /// <summary>
+    /// Helpers for the guarded alarm states.
+    /// </summary>
+    internal static class BranchGuard
+    {
+        /// <summary>
+        /// The stack's retain-state evaluation dereferences BranchId (via IsBranch)
+        /// and EnabledState. Under heavy CI load these have been observed to be null
+        /// on a condition that is otherwise in use, which crashes the test host with
+        /// a native access violation. Skip the evaluation in that case - an
+        /// uninitialized condition is treated as not retained - rather than crash.
+        /// In normal operation BranchId/EnabledState are always present, so behavior
+        /// is unchanged.
+        /// </summary>
+        /// <param name="condition"></param>
+        public static bool IsInitialized(ConditionState condition)
+        {
+            return condition.BranchId != null && condition.EnabledState?.Id != null;
+        }
+    }
+
+    /// <summary>
     /// Guarded <see cref="AlarmConditionState"/>.
     /// </summary>
     internal sealed class GuardedAlarmConditionState : AlarmConditionState, IBranchGuarded
@@ -60,7 +81,7 @@ namespace Alarms
         {
             lock (BranchLock)
             {
-                return base.GetRetainState();
+                return BranchGuard.IsInitialized(this) && base.GetRetainState();
             }
         }
 
@@ -105,7 +126,7 @@ namespace Alarms
         {
             lock (BranchLock)
             {
-                return base.GetRetainState();
+                return BranchGuard.IsInitialized(this) && base.GetRetainState();
             }
         }
 
@@ -150,7 +171,7 @@ namespace Alarms
         {
             lock (BranchLock)
             {
-                return base.GetRetainState();
+                return BranchGuard.IsInitialized(this) && base.GetRetainState();
             }
         }
 
@@ -195,7 +216,7 @@ namespace Alarms
         {
             lock (BranchLock)
             {
-                return base.GetRetainState();
+                return BranchGuard.IsInitialized(this) && base.GetRetainState();
             }
         }
 


### PR DESCRIPTION
## Problem

Follow-up to #2478, #2480 and #2481. Build [168527043](https://msazure.visualstudio.com/One/_build/results?buildId=168527043) — which included **all three** prior fixes — still failed `test_windows_Release 2` with the same native test-host crash.

## What the dump showed

- **#2481 worked**: the dump showed only a **single** `BaseServerFixture..ctor` (no concurrent construction), confirming server construction is now serialized.
- But the fault persisted at **exactly the same point across all five failing builds**: `Opc.Ua.ConditionState.IsBranch` dereferencing a **null `BranchId`**, reached from `AlarmConditionState.GetRetainState` during the alarm server's construction (`SourceState..ctor → Refresh → … → SetEnableState → GetRetainState`).
- The concurrent `ConditionRefreshWorkerAsync` thread was **blocked/waiting** (correctly serialized by #2480), and no other thread was an obvious heap corruptor.
- Inspecting the faulting condition: a valid object whose `BranchId` is null while `EnabledState` is populated (so the retain logic runs, then crashes on `IsBranch`). The exact cause of the transient null `BranchId` couldn't be pinned — the .NET 10 DAC won't load for SOS — but the fault point is 100% consistent.

## Fix

Guard the retain-state evaluation in the guarded alarm states (`GuardedAlarmStates.cs`): if `BranchId` or `EnabledState` is not present, treat the condition as **not retained** instead of dereferencing null and crashing the test host. In normal operation both are always present, so behavior is unchanged.

This is a targeted defensive guard at the single, consistent fault point, on top of the structural fixes in #2478/#2480/#2481. Test-only.

## Validation

- Clean build of `Testing.Servers` + `Module.Tests` (0 errors).
- `PendingConditions` (exercise retained alarm conditions): **9/9 passed** locally — guard does not change behavior.

Upstream SDK thread-safety tracked in #2479.