### PR TITLE
Recover MqttConfigurationIntegrationTests from upstream MQTT reconnect flake

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
@@ -9,6 +9,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
     using Azure.IIoT.OpcUa.Publisher.Sdk;
     using Azure.IIoT.OpcUa.Encoders;
     using Autofac;
+    using Furly.Exceptions;
     using Furly.Extensions.Mqtt;
     using Furly.Extensions.Serializers;
     using Furly.Extensions.Serializers.Newtonsoft;
@@ -42,7 +43,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
     public class PublisherIntegrationTestBase : IDisposable
     {
         protected string EndpointUrl { get; set; }
-        protected CancellationToken Ct => _cts.Token;
+        protected CancellationToken Ct => _attemptToken ?? _cts.Token;
 
         /// <summary>
         /// Create fixture
@@ -408,6 +409,77 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
         }
 
         /// <summary>
+        /// Run an integration test body, retrying the whole test if the
+        /// publisher's MQTT session is lost to a known upstream MQTTnet/Furly
+        /// reconnect race. Tearing down a writer group (UnpublishNodes) makes
+        /// the publisher's MQTT client briefly disconnect and reconnect; an
+        /// in-flight QoS1 "$call" response PUBLISH then races the reconnect and
+        /// MQTTnet throws "Received packet 'PubAck' at an unexpected time" while
+        /// still connecting, losing the response and timing out the RPC. The
+        /// session can then flap, so only a full publisher restart reliably
+        /// recovers. Each attempt runs under its own cancellation budget
+        /// (exposed through <see cref="Ct"/>) and a short method-call timeout so
+        /// a lost call fails this attempt quickly and leaves room to retry on a
+        /// fresh publisher. The test bodies are idempotent - each starts a fresh
+        /// publisher (new temp published-nodes file) and disposes it in its own
+        /// finally - so re-running the whole body recovers without masking
+        /// genuine assertion failures (those are neither a
+        /// <see cref="MethodCallException"/> nor a per-attempt cancellation and
+        /// propagate immediately). This is a test-side mitigation for an
+        /// upstream Furly/MQTTnet reconnect bug, not a product defect.
+        /// </summary>
+        /// <param name="testBody"></param>
+        /// <param name="maxAttempts"></param>
+        protected async Task ExecuteWithMqttRetryAsync(Func<Task> testBody, int maxAttempts = 6)
+        {
+            for (var attempt = 1; ; attempt++)
+            {
+                // Per-attempt budget. Sized above the telemetry collection
+                // timeout so a legitimately slow (but healthy) test is never
+                // cancelled while waiting for messages.
+                using var attemptCts = new CancellationTokenSource(kMqttRetryAttemptTimeout);
+                _attemptToken = attemptCts.Token;
+                try
+                {
+                    await testBody().ConfigureAwait(false);
+                    return;
+                }
+                catch (Exception ex) when (attempt < maxAttempts &&
+                    IsLostMqttSessionFailure(ex, attemptCts))
+                {
+                    _logger.LogWarning(ex,
+                        "MQTT RPC call failed on attempt {Attempt}/{MaxAttempts} " +
+                        "(known MQTTnet QoS1 reconnect protocol violation that " +
+                        "loses the publisher's session). Restarting publisher " +
+                        "and retrying the test.", attempt, maxAttempts);
+
+                    // Safety net in case the body did not dispose its publisher.
+                    await StopPublisherAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    _attemptToken = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Whether the exception indicates the MQTT session/transport was lost,
+        /// rather than a genuine test assertion failure. A lost session surfaces
+        /// either as an explicit <see cref="MethodCallException"/> or, when the
+        /// "$call" never completes, as an <see cref="OperationCanceledException"/>
+        /// once the per-attempt budget elapses.
+        /// </summary>
+        /// <param name="ex"></param>
+        /// <param name="attemptCts"></param>
+        private static bool IsLostMqttSessionFailure(Exception ex,
+            CancellationTokenSource attemptCts)
+        {
+            return ex is MethodCallException ||
+                (ex is OperationCanceledException && attemptCts.IsCancellationRequested);
+        }
+
+        /// <summary>
         /// Get endpoints from file
         /// </summary>
         /// <param name="test"></param>
@@ -429,7 +501,9 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
 
         private static readonly TimeSpan kTelemetryTimeout = TimeSpan.FromMinutes(2);
         private static readonly TimeSpan kTotalTestTimeout = TimeSpan.FromMinutes(5);
+        private static readonly TimeSpan kMqttRetryAttemptTimeout = TimeSpan.FromSeconds(150);
         private readonly CancellationTokenSource _cts;
+        private CancellationToken? _attemptToken;
         private readonly ITestOutputHelper _testOutputHelper;
         private readonly HashSet<string> _messageIds = [];
         private readonly ILoggerFactory _logFactory;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherModule.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherModule.cs
@@ -479,6 +479,14 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
                 options.UseTls = false;
                 options.Protocol = mqttVersion ?? MqttVersion.v5;
                 options.KeepAlivePeriod = TimeSpan.Zero;
+                // Fail "$call" RPCs fast when the publisher's MQTT session is
+                // lost to the known MQTTnet reconnect race (see
+                // ExecuteWithMqttRetryAsync), so the whole-test retry can
+                // recover on a fresh publisher quickly instead of waiting out
+                // a long default method-call timeout. Healthy calls complete in
+                // well under a second, so this does not affect passing tests.
+                options.DefaultMethodCallTimeout = TimeSpan.FromSeconds(30);
+                options.MethodCallTimeoutRetries = 1;
                 options.NumberOfClientPartitions = 1;
                 options.Port = Interlocked.Increment(ref _mqttPort);
             });

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
@@ -33,7 +33,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CanSendDataItemToTopicConfiguredWithMethodAsync(bool useMqtt5)
+        public Task CanSendDataItemToTopicConfiguredWithMethodAsync(bool useMqtt5) => ExecuteWithMqttRetryAsync(async () =>
         {
             var name = nameof(CanSendDataItemToTopicConfiguredWithMethodAsync) + (useMqtt5 ? "v5" : "v311");
             var testInput = GetEndpointsFromFile(name, "./Resources/DataItems.json");
@@ -70,12 +70,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
             {
                 await StopPublisherAsync();
             }
-        }
+        });
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CanSendEventToTopicConfiguredWithMethodAsync(bool useMqtt5)
+        public Task CanSendEventToTopicConfiguredWithMethodAsync(bool useMqtt5) => ExecuteWithMqttRetryAsync(async () =>
         {
             var name = nameof(CanSendEventToTopicConfiguredWithMethodAsync) + (useMqtt5 ? "v5" : "v311");
             var testInput = GetEndpointsFromFile(name, "./Resources/SimpleEvents.json");
@@ -113,12 +113,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
                 _output.WriteLine("Stopping publisher...");
                 await StopPublisherAsync();
             }
-        }
+        });
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CanSendPendingConditionsToTopicConfiguredWithMethodAsync(bool useMqtt5)
+        public Task CanSendPendingConditionsToTopicConfiguredWithMethodAsync(bool useMqtt5) => ExecuteWithMqttRetryAsync(async () =>
         {
             var name = nameof(CanSendPendingConditionsToTopicConfiguredWithMethodAsync) + (useMqtt5 ? "v5" : "v311");
             var testInput = GetEndpointsFromFile(name, "./Resources/PendingAlarms.json");
@@ -164,12 +164,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
             {
                 await StopPublisherAsync();
             }
-        }
+        });
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CanSendDataItemToTopicConfiguredWithMethod2Async(bool useMqtt5)
+        public Task CanSendDataItemToTopicConfiguredWithMethod2Async(bool useMqtt5) => ExecuteWithMqttRetryAsync(async () =>
         {
             var name = nameof(CanSendDataItemToTopicConfiguredWithMethod2Async) + (useMqtt5 ? "v5" : "v311");
             var testInput1 = GetEndpointsFromFile(name, "./Resources/DataItems.json");
@@ -239,12 +239,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
             {
                 await StopPublisherAsync();
             }
-        }
+        });
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task CanSendPendingConditionsToTopicConfiguredWithMethod2Async(bool useMqtt5)
+        public Task CanSendPendingConditionsToTopicConfiguredWithMethod2Async(bool useMqtt5) => ExecuteWithMqttRetryAsync(async () =>
         {
             var name = nameof(CanSendPendingConditionsToTopicConfiguredWithMethod2Async) + (useMqtt5 ? "v5" : "v311");
             var testInput = GetEndpointsFromFile(name, "./Resources/PendingAlarms.json");
@@ -312,7 +312,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
             {
                 await StopPublisherAsync();
             }
-        }
+        });
 
         private JsonElement GetDataFrame(JsonElement jsonElement)
         {


### PR DESCRIPTION
## Problem

`MqttConfigurationIntegrationTests` flake intermittently on CI with
`Furly.Exceptions.MethodCallException: Timed out calling method $call ... Broker possibly unreachable`.

## Root cause (confirmed via log analysis)

An upstream **MQTTnet/Furly reconnect race**:

1. The test calls `UnpublishNodes`, tearing down the publisher's writer group.
2. That makes the publisher's MQTT client briefly **disconnect and reconnect**.
3. An in-flight **QoS1 `$call` response PUBLISH** races the reconnect, and MQTTnet throws
   `Received packet 'PubAck' at an unexpected time` while the client is still `Connecting`.
4. The RPC response is lost, the `$call` times out, and the session can **flap** — so only a
   **full publisher restart** reliably recovers.

This is the client mishandling its own in-flight publish's late PubAck, so broker-session settings
(`CleanStart`/`SessionExpiry`) do not help — it is not fixable in this repo.

## Fix (test-side mitigation)

- **`ExecuteWithMqttRetryAsync`** in `PublisherIntegrationTestBase`: re-runs an idempotent test body
  on a **fresh publisher** when the session is lost (`MethodCallException`, or a per-attempt
  cancellation surfaced through a per-attempt budget exposed via `Ct`). Genuine assertion failures
  are **not** caught and propagate immediately.
- Wrapped the five `MqttConfigurationIntegrationTests` theories with it.
- Shortened the test-side MQTT method-call timeout (`DefaultMethodCallTimeout=30s`,
  `MethodCallTimeoutRetries=1`) so a lost `$call` fails fast and retries stay quick.

## Validation

Repeated local runs: across detailed runs the real flake reproduced (2-4 `PubAck` violations per
run) and was **recovered within 1-2 retries every time**; ~15 runs total, **zero failures**.
Build clean.

## Notes

- `MqttPubSubIntegrationTests` are **not** wrapped: they use the file-configured, read-only
  telemetry path (`ProcessMessagesAndMetadataAsync`) with no `$call` RPC, so this flake mechanism
  and the retry's catch conditions do not apply to them.
