### PR TITLE
Serialize MQTT broker integration tests to fix MaxParallelThreads=4 Linux test-host hang

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttConfigurationIntegrationTests.cs
@@ -17,6 +17,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
+    [Collection(MqttReferenceServerCollection.Name)]
     public class MqttConfigurationIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ITestOutputHelper _output;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttPubSubIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttPubSubIntegrationTests.cs
@@ -17,6 +17,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
+    [Collection(MqttReferenceServerCollection.Name)]
     public class MqttPubSubIntegrationTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ReferenceServer _fixture;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttReferenceServerCollection.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttReferenceServerCollection.cs
@@ -1,0 +1,24 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
+{
+    using Xunit;
+
+    /// <summary>
+    /// Groups the MQTT broker integration tests so they run serialized. The in-process
+    /// MQTT broker/client is sensitive to CPU contention; at higher MaxParallelThreads the
+    /// concurrent collections starve it and an RPC/telemetry wait can stall until the
+    /// 10-minute blame-hang inactivity timeout aborts the whole run (observed on the Linux
+    /// CI shard once parallelism was restored to 4). DisableParallelization runs these tests
+    /// in xUnit's non-parallel phase - one at a time with no competing load - while the rest
+    /// of the assembly keeps full parallelism.
+    /// </summary>
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class MqttReferenceServerCollection
+    {
+        public const string Name = "MqttReferenceServerIntegration";
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttUnifiedNamespaceTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Mqtt/ReferenceServer/MqttUnifiedNamespaceTests.cs
@@ -15,6 +15,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Mqtt.ReferenceServer
     using Xunit;
     using Xunit.Abstractions;
 
+    [Collection(MqttReferenceServerCollection.Name)]
     public class MqttUnifiedNamespaceTests : PublisherIntegrationTestBase, IClassFixture<ReferenceServer>
     {
         private readonly ReferenceServer _fixture;


### PR DESCRIPTION
## Problem
After restoring `MaxParallelThreads = 4` for `Azure.IIoT.OpcUa.Publisher.Module.Tests` (PR #2486), the **Linux** CI shard intermittently failed with a 10-minute blame **hang** (inactivity timeout aborting the whole run), e.g. build 168980872. The hung test was `Mqtt.ReferenceServer.MqttConfigurationIntegrationTests.CanSendDataItemToTopicConfiguredWithMethod2Async`.

This is **not** the test-host crash fixed in #2486 (that was the in-process container kill-timer). It is the long-standing flakiness of the in-process MQTT broker/client integration tests (cf. #2485): under 4 concurrent collections the broker/client is starved of CPU and an RPC/telemetry wait stalls until the inactivity timeout. At `MaxParallelThreads = 2` these tests were green; only `= 4` triggers it. The broker port is unique per fixture (`Interlocked.Increment`), so it is load-induced, not a port clash.

## Fix
Group the three MQTT `ReferenceServer` integration test classes (`MqttConfigurationIntegrationTests`, `MqttPubSubIntegrationTests`, `MqttUnifiedNamespaceTests`) into a new `[CollectionDefinition(..., DisableParallelization = true)]` collection so they run in xUnit's non-parallel phase (one at a time, no competing load), while the rest of the assembly keeps full `MaxParallelThreads = 4` parallelism.

Test-only change; no product code affected.