### PR TITLE
Do not restart heartbeat timer countdown on subscription synchronization

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Heartbeat.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Heartbeat.cs
@@ -200,7 +200,17 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                     else
                     {
                         Debug.Assert(AttachedToSubscription);
-                        EnableHeartbeatTimer();
+                        //
+                        // Ensure the timer is armed but do not restart a
+                        // running countdown: TryCompleteChanges is invoked
+                        // for every item on every subscription
+                        // synchronization, and subscriptions that contain
+                        // permanently failing items re-synchronize every
+                        // InvalidMonitoredItemRetryDelay (default 5 minutes).
+                        // Restarting the countdown here starves heartbeats
+                        // with intervals longer than the resync period (#2357).
+                        //
+                        EnableHeartbeatTimer(restart: false);
                     }
                 }
                 return result;
@@ -355,9 +365,18 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
             }
 
             /// <summary>
-            /// Enable timer
+            /// Enable timer. When <paramref name="restart"/> is false and
+            /// the timer is already running with the same interval, the
+            /// current countdown is left untouched so that periodic
+            /// heartbeats can elapse regardless of how often the owning
+            /// subscription synchronizes. Restart semantics are only
+            /// intended for the watchdog data path, which re-arms the
+            /// watchdog whenever a value arrives. Note that re-assigning
+            /// <see cref="TimerEx.Interval"/> always restarts the countdown,
+            /// even when the value did not change.
             /// </summary>
-            private void EnableHeartbeatTimer()
+            /// <param name="restart"></param>
+            private void EnableHeartbeatTimer(bool restart = true)
             {
                 lock (_timerLock)
                 {
@@ -373,6 +392,13 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                         };
                         _heartbeatTimer.Elapsed += SendHeartbeatNotifications;
                         _logger.HeartbeatTimerEnabled();
+                    }
+                    else if (!restart && TimerEnabled &&
+                        _heartbeatTimer.Interval == _heartbeatInterval)
+                    {
+                        // Already armed with the desired interval - keep
+                        // the running countdown.
+                        return;
                     }
                     _heartbeatTimer.Interval = _heartbeatInterval;
                     _heartbeatTimer.Enabled = true;


### PR DESCRIPTION
## Summary

Fixes #2357 — heartbeats never fire when the owning subscription synchronizes more often than the heartbeat interval.

Full root-cause analysis with production evidence (85,686 nodes / 4 endpoints against KEPServerEX, reproduced on 2.9.11 and 2.9.17): https://github.com/Azure/Industrial-IoT/issues/2357#issuecomment-4886509679

Mechanism in short:

1. Every synchronization pass invokes `TryCompleteChanges` for **every** monitored item (`OpcUaSubscription.SynchronizeMonitoredItemsAsync`, second pass over `desiredMonitoredItems.Concat(remove)`).
2. For heartbeat items this called `EnableHeartbeatTimer()`, which re-assigns `TimerEx.Interval`. The `TimerEx.Interval` setter always calls `ITimer.Change(...)` — even when the value is unchanged — which restarts the running countdown (unlike `TimerEx.Enabled`/`AutoReset`, which no-op on unchanged values).
3. Subscriptions containing permanently failing items (e.g. `BadNodeIdUnknown` for node ids currently absent on the server — normal at plant scale) re-synchronize every `InvalidMonitoredItemRetryDelay` (default **300 s**).

Net effect: any heartbeat interval longer than the effective resync period can never elapse. This matches the reported symptoms exactly: fine with 3–4 nodes (no bad items → no periodic resync), `Generated Heartbeat Notifications: 0` at scale with all heartbeat items armed, and partial coverage limited to sessions without failing items.

## Change

`Heartbeat.TryCompleteChanges` now *ensures* the timer is armed without restarting a running countdown: `EnableHeartbeatTimer(restart: false)` returns early when the timer is already enabled with the same interval.

- The watchdog data path (`ProcessMonitoredItemNotification` / `TryGetMonitoredItemNotifications`) keeps restart semantics — re-arming on every received value is the intended watchdog behavior and is unaffected.
- Heartbeat interval changes applied via `MergeWith` still take effect: the guard falls through when the configured interval differs from the timer's current interval.
- Items moved between (partitioned) subscriptions are cloned and get a fresh timer; unaffected.

## Testing

- The failure chain was verified in production at 85,686 nodes on 2.9.11 and 2.9.17: with default retry delays, DB-verified static tags configured with `PeriodicLKV` / `HeartbeatIntervalTimespan=01:00:00` never produced a heartbeat over multiple hours while the diagnostics showed all items armed, and only sessions without failing items produced (a trickle of) heartbeat notifications — consistent with the countdown-reset chain removed by this patch.
- I could not run the .NET 10 test suite locally. Happy to add a `FakeTimeProvider`-based regression test (synchronize every 5 simulated minutes, assert a 1 h `PeriodicLKV` heartbeat still fires) next to `tests/Stack/OpcUaMonitoredItemTests.cs` if that is the preferred location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
