### PR TITLE
Log direct method call failures so they surface in support bundles

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Controllers/ConfigurationController.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Controllers/ConfigurationController.cs
@@ -42,7 +42,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
     [Authorize]
     [Produces(ContentMimeType.Json, ContentMimeType.MsgPack)]
     [Consumes(ContentMimeType.Json, ContentMimeType.MsgPack)]
-    public partial class ConfigurationController : ControllerBase, IMethodController
+    public class ConfigurationController : ControllerBase, IMethodController
     {
         /// <summary>
         /// Create publisher methods controller
@@ -293,11 +293,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
             CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
-            if (_logger != null)
-            {
-                ConfigurationOperationInvoked(_logger, nameof(AddOrUpdateEndpointsAsync),
-                    "<multiple>", request.Count);
-            }
+            _logger?.ConfigurationOperationInvoked(nameof(AddOrUpdateEndpointsAsync),
+                "<multiple>", request.Count);
             await _configServices.AddOrUpdateEndpointsAsync(request, ct).ConfigureAwait(false);
             return new PublishedNodesResponseModel();
         }
@@ -440,20 +437,25 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
         /// <param name="request"></param>
         private void LogEntryOperation(string operation, PublishedNodesEntryModel? request)
         {
-            if (_logger != null)
-            {
-                ConfigurationOperationInvoked(_logger, operation,
-                    request?.EndpointUrl ?? "<none>", request?.OpcNodes?.Count ?? 0);
-            }
+            _logger?.ConfigurationOperationInvoked(operation,
+                request?.EndpointUrl ?? "<none>", request?.OpcNodes?.Count ?? 0);
         }
-
-        [LoggerMessage(EventId = 1, Level = LogLevel.Information,
-            Message = "Configuration operation {Operation} invoked for endpoint " +
-                "{EndpointUrl} with {NodeCount} node(s).")]
-        static partial void ConfigurationOperationInvoked(ILogger logger,
-            string operation, string endpointUrl, int nodeCount);
 
         private readonly IPublishedNodesServices _configServices;
         private readonly ILogger<ConfigurationController>? _logger;
+    }
+
+    /// <summary>
+    /// Source-generated logging extensions for ConfigurationController
+    /// </summary>
+    internal static partial class ConfigurationControllerLogging
+    {
+        private const int EventClass = 20;
+
+        [LoggerMessage(EventId = EventClass + 1, Level = LogLevel.Information,
+            Message = "Configuration operation {Operation} invoked for endpoint " +
+                "{EndpointUrl} with {NodeCount} node(s).")]
+        public static partial void ConfigurationOperationInvoked(this ILogger logger,
+            string operation, string endpointUrl, int nodeCount);
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Controllers/ConfigurationController.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Controllers/ConfigurationController.cs
@@ -13,6 +13,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
@@ -41,15 +42,18 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
     [Authorize]
     [Produces(ContentMimeType.Json, ContentMimeType.MsgPack)]
     [Consumes(ContentMimeType.Json, ContentMimeType.MsgPack)]
-    public class ConfigurationController : ControllerBase, IMethodController
+    public partial class ConfigurationController : ControllerBase, IMethodController
     {
         /// <summary>
         /// Create publisher methods controller
         /// </summary>
         /// <param name="configServices"></param>
-        public ConfigurationController(IPublishedNodesServices configServices)
+        /// <param name="logger"></param>
+        public ConfigurationController(IPublishedNodesServices configServices,
+            ILogger<ConfigurationController>? logger = null)
         {
             _configServices = configServices;
+            _logger = logger;
         }
 
         /// <summary>
@@ -196,6 +200,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
             [FromBody][Required] PublishedNodesEntryModel request, CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
+            LogEntryOperation(nameof(PublishNodesAsync), request);
             await _configServices.PublishNodesAsync(request, ct).ConfigureAwait(false);
             return new PublishedNodesResponseModel();
         }
@@ -227,6 +232,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
             [FromBody][Required] PublishedNodesEntryModel request, CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
+            LogEntryOperation(nameof(UnpublishNodesAsync), request);
             await _configServices.UnpublishNodesAsync(request, ct).ConfigureAwait(false);
             return new PublishedNodesResponseModel();
         }
@@ -255,6 +261,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
         public async Task<PublishedNodesResponseModel> UnpublishAllNodesAsync(
             [FromBody] PublishedNodesEntryModel? request, CancellationToken ct = default)
         {
+            LogEntryOperation(nameof(UnpublishAllNodesAsync), request);
             await _configServices.UnpublishAllNodesAsync(request, ct).ConfigureAwait(false);
             return new PublishedNodesResponseModel();
         }
@@ -286,6 +293,11 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
             CancellationToken ct = default)
         {
             ArgumentNullException.ThrowIfNull(request);
+            if (_logger != null)
+            {
+                ConfigurationOperationInvoked(_logger, nameof(AddOrUpdateEndpointsAsync),
+                    "<multiple>", request.Count);
+            }
             await _configServices.AddOrUpdateEndpointsAsync(request, ct).ConfigureAwait(false);
             return new PublishedNodesResponseModel();
         }
@@ -418,6 +430,30 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Controllers
             return await _configServices.GetDiagnosticInfoAsync(ct).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Log the invocation of a configuration operation together with the
+        /// endpoint and node count so that control-plane activity (and the
+        /// context of any subsequent failure) is captured in the module logs
+        /// and support bundles.
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="request"></param>
+        private void LogEntryOperation(string operation, PublishedNodesEntryModel? request)
+        {
+            if (_logger != null)
+            {
+                ConfigurationOperationInvoked(_logger, operation,
+                    request?.EndpointUrl ?? "<none>", request?.OpcNodes?.Count ?? 0);
+            }
+        }
+
+        [LoggerMessage(EventId = 1, Level = LogLevel.Information,
+            Message = "Configuration operation {Operation} invoked for endpoint " +
+                "{EndpointUrl} with {NodeCount} node(s).")]
+        static partial void ConfigurationOperationInvoked(ILogger logger,
+            string operation, string endpointUrl, int nodeCount);
+
         private readonly IPublishedNodesServices _configServices;
+        private readonly ILogger<ConfigurationController>? _logger;
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
@@ -29,7 +29,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     /// for an easier parsing.
     /// @see https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/filters
     /// </summary>
-    public sealed partial class ControllerExceptionFilterAttribute : ExceptionFilterAttribute
+    public sealed class ControllerExceptionFilterAttribute : ExceptionFilterAttribute
     {
         /// <inheritdoc />
         public override void OnException(ExceptionContext context)
@@ -209,12 +209,20 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                     or (int)HttpStatusCode.TooManyRequests
                     or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
                 : LogLevel.Debug;
-            RequestFailed(logger, level, status, exception.GetType().Name, exception);
+            logger.RequestFailed(level, status, exception.GetType().Name, exception);
         }
+    }
 
-        [LoggerMessage(EventId = 1,
+    /// <summary>
+    /// Source-generated logging extensions for ControllerExceptionFilterAttribute
+    /// </summary>
+    internal static partial class ControllerExceptionFilterAttributeLogging
+    {
+        private const int EventClass = 10;
+
+        [LoggerMessage(EventId = EventClass + 1,
             Message = "API request failed with status {Status} ({ExceptionType}).")]
-        static partial void RequestFailed(ILogger logger, LogLevel level,
+        public static partial void RequestFailed(this ILogger logger, LogLevel level,
             int status, string exceptionType, Exception exception);
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
@@ -13,6 +13,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     using Microsoft.AspNetCore.Mvc.Filters;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Diagnostics.ExceptionSummarization;
+    using Microsoft.Extensions.Logging;
     using System;
     using System.IO;
     using System.Net;
@@ -28,7 +29,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     /// for an easier parsing.
     /// @see https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/filters
     /// </summary>
-    public sealed class ControllerExceptionFilterAttribute : ExceptionFilterAttribute
+    public sealed partial class ControllerExceptionFilterAttribute : ExceptionFilterAttribute
     {
         /// <inheritdoc />
         public override void OnException(ExceptionContext context)
@@ -54,8 +55,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                 }
             }
 
-            var summarizer = context.HttpContext?.RequestServices?
-                .GetService<IExceptionSummarizer>();
+            var services = context.HttpContext?.RequestServices;
+            var summarizer = services?.GetService<IExceptionSummarizer>();
+            var logger = services?.GetService<ILoggerFactory>()?.CreateLogger(
+                "Azure.IIoT.OpcUa.Publisher.Module.MethodCalls");
             switch (context.Exception)
             {
                 case ResourceNotFoundException:
@@ -138,6 +141,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                         context.Exception, summarizer);
                     break;
             }
+            LogFailure(logger, context.Result, context.Exception);
         }
 
         /// <inheritdoc />
@@ -178,5 +182,39 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                 StatusCode = (int)code
             };
         }
+
+        /// <summary>
+        /// Surface the failure so it is captured in logs and support bundles.
+        /// Server side (5xx) failures are logged as errors, throttling and
+        /// timeouts as warnings and expected client (4xx) failures at debug.
+        /// </summary>
+        /// <param name="logger"></param>
+        /// <param name="result"></param>
+        /// <param name="exception"></param>
+        private static void LogFailure(ILogger? logger, IActionResult? result,
+            Exception exception)
+        {
+            if (logger == null)
+            {
+                return;
+            }
+            var status = result switch
+            {
+                ObjectResult { StatusCode: { } code } => code,
+                ObjectResult { Value: ProblemDetails { Status: { } s } } => s,
+                _ => (int)HttpStatusCode.InternalServerError
+            };
+            var level = status >= 500 ? LogLevel.Error
+                : status is (int)HttpStatusCode.RequestTimeout
+                    or (int)HttpStatusCode.TooManyRequests
+                    or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
+                : LogLevel.Debug;
+            RequestFailed(logger, level, status, exception.GetType().Name, exception);
+        }
+
+        [LoggerMessage(EventId = 1,
+            Message = "API request failed with status {Status} ({ExceptionType}).")]
+        static partial void RequestFailed(ILogger logger, LogLevel level,
+            int status, string exceptionType, Exception exception);
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/ControllerExceptionFilterAttribute.cs
@@ -209,7 +209,15 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                     or (int)HttpStatusCode.TooManyRequests
                     or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
                 : LogLevel.Debug;
-            logger.RequestFailed(level, status, exception.GetType().Name, exception);
+            try
+            {
+                logger.RequestFailed(level, status, exception.GetType().Name, exception);
+            }
+            catch
+            {
+                // Diagnostics must never break exception-to-status mapping, e.g.
+                // if a logging provider throws or has already been disposed.
+            }
         }
     }
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
@@ -8,6 +8,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     using Azure.IIoT.OpcUa.Exceptions;
     using Furly.Exceptions;
     using Furly.Tunnel.Router;
+    using Microsoft.Extensions.Logging;
     using System;
     using System.IO;
     using System.Net;
@@ -19,10 +20,38 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     /// Convert all the exceptions returned by the module controllers to a
     /// status code.
     /// </summary>
-    public sealed class RouterExceptionFilterAttribute : ExceptionFilterAttribute
+    public sealed partial class RouterExceptionFilterAttribute : ExceptionFilterAttribute
     {
+        /// <summary>
+        /// Configure the logger used to surface direct method call failures.
+        /// Direct method invocations do not flow through the ASP.NET request
+        /// pipeline, so this filter is the single choke point through which all
+        /// their exceptions pass. The filter is instantiated by the router via
+        /// reflection and therefore cannot receive a logger by dependency
+        /// injection; the module host wires one up once during startup instead.
+        /// </summary>
+        /// <param name="loggerFactory"></param>
+        public static void SetLogger(ILoggerFactory loggerFactory)
+        {
+            ArgumentNullException.ThrowIfNull(loggerFactory);
+            _logger = loggerFactory.CreateLogger(
+                "Azure.IIoT.OpcUa.Publisher.Module.MethodCalls");
+        }
+
         /// <inheritdoc />
         public override Exception Filter(Exception exception, out int status)
+        {
+            var result = Map(exception, out status);
+            Log(status, result);
+            return result;
+        }
+
+        /// <summary>
+        /// Map an exception to the status code returned to the caller.
+        /// </summary>
+        /// <param name="exception"></param>
+        /// <param name="status"></param>
+        private static Exception Map(Exception exception, out int status)
         {
             switch (exception)
             {
@@ -30,13 +59,13 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                     var root = ae.GetBaseException();
                     if (root is not AggregateException ae2)
                     {
-                        return Filter(root, out status);
+                        return Map(root, out status);
                     }
                     status = (int)HttpStatusCode.InternalServerError;
                     Exception? result = null;
                     foreach (var ex in ae2.InnerExceptions)
                     {
-                        result = Filter(ex, out status);
+                        result = Map(ex, out status);
                         if (status != (int)HttpStatusCode.InternalServerError)
                         {
                             break;
@@ -119,5 +148,34 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
             }
             return exception;
         }
+
+        /// <summary>
+        /// Surface the failure so it is captured in logs and support bundles.
+        /// Server side (5xx) failures are logged as errors, throttling and
+        /// timeouts as warnings and expected client (4xx) failures at debug.
+        /// </summary>
+        /// <param name="status"></param>
+        /// <param name="exception"></param>
+        private static void Log(int status, Exception exception)
+        {
+            var logger = _logger;
+            if (logger == null)
+            {
+                return;
+            }
+            var level = status >= 500 ? LogLevel.Error
+                : status is (int)HttpStatusCode.RequestTimeout
+                    or (int)HttpStatusCode.TooManyRequests
+                    or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
+                : LogLevel.Debug;
+            MethodCallFailed(logger, level, status, exception.GetType().Name, exception);
+        }
+
+        [LoggerMessage(EventId = 1,
+            Message = "Direct method call failed with status {Status} ({ExceptionType}).")]
+        static partial void MethodCallFailed(ILogger logger, LogLevel level,
+            int status, string exceptionType, Exception exception);
+
+        private static ILogger? _logger;
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
@@ -168,7 +168,15 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                     or (int)HttpStatusCode.TooManyRequests
                     or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
                 : LogLevel.Debug;
-            logger.MethodCallFailed(level, status, exception.GetType().Name, exception);
+            try
+            {
+                logger.MethodCallFailed(level, status, exception.GetType().Name, exception);
+            }
+            catch
+            {
+                // Diagnostics must never break exception-to-status mapping, e.g.
+                // if a logging provider throws or has already been disposed.
+            }
         }
 
         private static ILogger? _logger;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Filters/RouterExceptionFilterAttribute.cs
@@ -20,7 +20,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
     /// Convert all the exceptions returned by the module controllers to a
     /// status code.
     /// </summary>
-    public sealed partial class RouterExceptionFilterAttribute : ExceptionFilterAttribute
+    public sealed class RouterExceptionFilterAttribute : ExceptionFilterAttribute
     {
         /// <summary>
         /// Configure the logger used to surface direct method call failures.
@@ -168,14 +168,22 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Filters
                     or (int)HttpStatusCode.TooManyRequests
                     or (int)HttpStatusCode.PreconditionFailed ? LogLevel.Warning
                 : LogLevel.Debug;
-            MethodCallFailed(logger, level, status, exception.GetType().Name, exception);
+            logger.MethodCallFailed(level, status, exception.GetType().Name, exception);
         }
 
-        [LoggerMessage(EventId = 1,
-            Message = "Direct method call failed with status {Status} ({ExceptionType}).")]
-        static partial void MethodCallFailed(ILogger logger, LogLevel level,
-            int status, string exceptionType, Exception exception);
-
         private static ILogger? _logger;
+    }
+
+    /// <summary>
+    /// Source-generated logging extensions for RouterExceptionFilterAttribute
+    /// </summary>
+    internal static partial class RouterExceptionFilterAttributeLogging
+    {
+        private const int EventClass = 0;
+
+        [LoggerMessage(EventId = EventClass + 1,
+            Message = "Direct method call failed with status {Status} ({ExceptionType}).")]
+        public static partial void MethodCallFailed(this ILogger logger, LogLevel level,
+            int status, string exceptionType, Exception exception);
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Startup.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Startup.cs
@@ -122,6 +122,11 @@ namespace Azure.IIoT.OpcUa.Publisher.Module
         public void Configure(IApplicationBuilder app, IHostApplicationLifetime appLifetime)
 #pragma warning restore CA1822 // Mark members as static
         {
+            // Surface direct method call failures (which bypass the ASP.NET
+            // request pipeline) into the module logs and support bundles.
+            Filters.RouterExceptionFilterAttribute.SetLogger(
+                app.ApplicationServices.GetRequiredService<ILoggerFactory>());
+
             app.UseRouting();
 
             // app.UseHsts();

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Filters/ExceptionFilterLoggingTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Filters/ExceptionFilterLoggingTests.cs
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
 
+#nullable enable
+
 namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Filters
 {
     using Azure.IIoT.OpcUa.Exceptions;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Filters/ExceptionFilterLoggingTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Filters/ExceptionFilterLoggingTests.cs
@@ -1,0 +1,176 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Filters
+{
+    using Azure.IIoT.OpcUa.Exceptions;
+    using Azure.IIoT.OpcUa.Publisher;
+    using Azure.IIoT.OpcUa.Publisher.Models;
+    using Azure.IIoT.OpcUa.Publisher.Module.Controllers;
+    using Azure.IIoT.OpcUa.Publisher.Module.Filters;
+    using Furly.Exceptions;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Abstractions;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// Verifies the direct-method / HTTP exception filters preserve their status
+    /// mapping and surface failures into the logs (so they are captured in
+    /// support bundles).
+    /// </summary>
+    public sealed class ExceptionFilterLoggingTests
+    {
+        [Theory]
+        [InlineData(typeof(ResourceNotFoundException), (int)HttpStatusCode.NotFound)]
+        [InlineData(typeof(ResourceInvalidStateException), (int)HttpStatusCode.Forbidden)]
+        [InlineData(typeof(ResourceConflictException), (int)HttpStatusCode.Conflict)]
+        [InlineData(typeof(UnauthorizedAccessException), (int)HttpStatusCode.Unauthorized)]
+        [InlineData(typeof(BadRequestException), (int)HttpStatusCode.BadRequest)]
+        [InlineData(typeof(TimeoutException), (int)HttpStatusCode.RequestTimeout)]
+        [InlineData(typeof(NotImplementedException), (int)HttpStatusCode.NotImplemented)]
+        [InlineData(typeof(ServerBusyException), (int)HttpStatusCode.TooManyRequests)]
+        [InlineData(typeof(InvalidOperationException), (int)HttpStatusCode.InternalServerError)]
+        public void RouterFilterPreservesStatusMapping(Type exceptionType, int expected)
+        {
+            var filter = new RouterExceptionFilterAttribute();
+            var exception = (Exception)Activator.CreateInstance(exceptionType, "boom")!;
+
+            filter.Filter(exception, out var status);
+
+            Assert.Equal(expected, status);
+        }
+
+        [Fact]
+        public void ControllerFilterLogsServerErrorAsError()
+        {
+            var (logger, entries) = CreateLogger();
+            var context = CreateExceptionContext(new InvalidOperationException("boom"), logger);
+
+            new ControllerExceptionFilterAttribute().OnException(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal((int)HttpStatusCode.InternalServerError, result.StatusCode);
+            var entry = Assert.Single(entries);
+            Assert.Equal(LogLevel.Error, entry.Level);
+            Assert.NotNull(entry.Exception);
+        }
+
+        [Fact]
+        public void ControllerFilterLogsNotFoundAtDebug()
+        {
+            var (logger, entries) = CreateLogger();
+            var context = CreateExceptionContext(
+                new ResourceNotFoundException("nope"), logger);
+
+            new ControllerExceptionFilterAttribute().OnException(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal((int)HttpStatusCode.NotFound, result.StatusCode);
+            Assert.Equal(LogLevel.Debug, Assert.Single(entries).Level);
+        }
+
+        [Fact]
+        public void ControllerFilterLogsTimeoutAsWarning()
+        {
+            var (logger, entries) = CreateLogger();
+            var context = CreateExceptionContext(new TimeoutException("slow"), logger);
+
+            new ControllerExceptionFilterAttribute().OnException(context);
+
+            var result = Assert.IsType<ObjectResult>(context.Result);
+            Assert.Equal((int)HttpStatusCode.RequestTimeout, result.StatusCode);
+            Assert.Equal(LogLevel.Warning, Assert.Single(entries).Level);
+        }
+
+        [Fact]
+        public async Task ConfigurationControllerLogsUnpublishAllInvocationAsync()
+        {
+            var (loggerFactory, entries) = CreateLogger();
+            var services = new Mock<IPublishedNodesServices>();
+            services
+                .Setup(s => s.UnpublishAllNodesAsync(
+                    It.IsAny<PublishedNodesEntryModel?>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+            var controller = new ConfigurationController(services.Object,
+                loggerFactory.CreateLogger<ConfigurationController>());
+
+            await controller.UnpublishAllNodesAsync(
+                new PublishedNodesEntryModel { EndpointUrl = "opc.tcp://server:50000" });
+
+            var entry = Assert.Single(entries);
+            Assert.Equal(LogLevel.Information, entry.Level);
+            Assert.Contains("UnpublishAllNodesAsync", entry.Message, StringComparison.Ordinal);
+            Assert.Contains("opc.tcp://server:50000", entry.Message, StringComparison.Ordinal);
+        }
+
+        private static (RecordingLoggerFactory, IReadOnlyList<LogEntry>) CreateLogger()
+        {
+            var factory = new RecordingLoggerFactory();
+            return (factory, factory.Entries);
+        }
+
+        private static ExceptionContext CreateExceptionContext(Exception exception,
+            RecordingLoggerFactory loggerFactory)
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                RequestServices = new ServiceCollection()
+                    .AddSingleton<ILoggerFactory>(loggerFactory)
+                    .BuildServiceProvider()
+            };
+            var actionContext = new ActionContext(httpContext, new RouteData(),
+                new ActionDescriptor());
+            return new ExceptionContext(actionContext, new List<IFilterMetadata>())
+            {
+                Exception = exception
+            };
+        }
+
+        internal sealed record LogEntry(LogLevel Level, string Message, Exception? Exception);
+
+        internal sealed class RecordingLoggerFactory : ILoggerFactory
+        {
+            public List<LogEntry> Entries { get; } = [];
+            private readonly object _lock = new();
+
+            public void Add(LogEntry entry)
+            {
+                lock (_lock)
+                {
+                    Entries.Add(entry);
+                }
+            }
+
+            public ILogger CreateLogger(string categoryName) => new RecordingLogger(this);
+            public void AddProvider(ILoggerProvider provider) { }
+            public void Dispose() { }
+        }
+
+        private sealed class RecordingLogger : ILogger
+        {
+            private readonly RecordingLoggerFactory _factory;
+            public RecordingLogger(RecordingLoggerFactory factory) => _factory = factory;
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                _factory.Add(new LogEntry(logLevel, formatter(state, exception), exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Investigation of a customer incident (`UnpublishAllNodes_V1` returning HTTP 500) found that when a direct method call fails, **the failure is effectively invisible in the module logs and support bundles**. Direct method invocations bypass the ASP.NET request pipeline, and the Furly router only logs their exceptions via `MethodCallError` at **`LogLevel.Trace`** — which is never enabled in production. As a result, support bundles contained no trace of the failing call or its exception, making root-cause analysis impossible.

This PR adds durable, visible logging at the exception-filter choke points so future issues in this area are captured going forward.

## Changes

- **`RouterExceptionFilterAttribute`** (direct-method path — the single choke point every direct-method exception passes through): extracted the exception→status logic into a `Map` helper and added visible failure logging. The log level is derived from the mapped status: **≥500 → Error, 408/429/412 → Warning, other 4xx → Debug**. The filter is instantiated by the router via reflection (no DI), so the module host wires up a logger once during startup. **Status mapping is unchanged** (logging is additive).
- **`Startup.Configure`**: initializes the filter logger from `ILoggerFactory`.
- **`ControllerExceptionFilterAttribute`** (HTTP path): symmetric failure logging using the per-request DI logger already available via `HttpContext.RequestServices`.
- **`ConfigurationController`**: optional injected `ILogger<ConfigurationController>`; logs each configuration mutation (`PublishNodes`, `UnpublishNodes`, `UnpublishAllNodes`, `AddOrUpdateEndpoints`) at Information with the endpoint and node count, so control-plane activity — and the context of any subsequent failure — is recorded. The constructor parameter is optional, so existing call sites are unaffected.
- **Tests** (`tests/Filters/ExceptionFilterLoggingTests.cs`): 13 tests covering router status-mapping preservation, controller-filter level selection (500→Error, 404→Debug, 408→Warning), and ConfigurationController invocation logging.

## Validation

- `dotnet build -c Release` — module source and tests build with 0 errors.
- New tests: 13/13 passed.
- Existing controller suite: 781 passed / 0 failed (27 skipped) — no regressions.

## Notes / follow-ups (not in this PR)

- The behavioral hardening for `UnpublishAllNodes` (treat null/empty/whitespace `EndpointUrl` as "purge all") is already on `main` via #2477; backporting it to `release/2.9` is recommended separately.
- Optional future enhancement: a `Meter` counter for direct-method failures to surface them in Prometheus / the periodic diagnostics block.
