### PR TITLE
Bump Furly to 1.2.6 to pick up IoT Hub reconnect fix (#2399)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Azure SDK">
-    <PackageVersion Include="Azure.Core" Version="1.59.0" />
+    <PackageVersion Include="Azure.Core" Version="1.60.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.14.0" />
@@ -52,20 +52,20 @@
   </ItemGroup>
 
   <ItemGroup Label="Furly (keep all in lock-step)">
-    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.2" />
-    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.2" />
-    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.2" />
-    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.2" />
-    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.2" />
-    <PackageVersion Include="Furly.Tunnel" Version="1.2.2" />
+    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.6" />
+    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.6" />
+    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.6" />
+    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.6" />
+    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.6" />
+    <PackageVersion Include="Furly.Tunnel" Version="1.2.6" />
   </ItemGroup>
 
   <ItemGroup Label="OpenTelemetry">

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/src/Runtime/Configuration.cs
@@ -31,7 +31,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Runtime
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Console;
     using Microsoft.Extensions.Options;
-    using Microsoft.OpenApi.Models;
+    using Microsoft.OpenApi;
     using OpenTelemetry;
     using OpenTelemetry.Exporter;
     using OpenTelemetry.Logs;

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Services/AssetDeviceIntegration.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Services/AssetDeviceIntegration.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All rights reserved.
 //  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
 // ------------------------------------------------------------
@@ -836,7 +836,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                         TypeRef = d.DataSetType,
                         DataSource = d.DataSetRootNodeId,
                         EventGroupConfiguration = null,
-                        DefaultEventsDestinations = null,
+                        DefaultDestinations = null,
                         Events = d.OpcNodes!.Select(n => new DiscoveredAssetEvent
                         {
                             Name = n.DisplayName!, // Event name
@@ -1584,7 +1584,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
 
                 var entry = CreateEntryForAssetResource(template, additionalConfiguration, [node]);
                 entry = AddDestination(entry, resource.Asset.DefaultEventsDestinations,
-                    resource.EventGroup.DefaultEventsDestinations, @event.Destinations,
+                    resource.EventGroup.DefaultDestinations, @event.Destinations,
                     errors, resource);
                 entries.Add(entry with
                 {
@@ -2891,13 +2891,13 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
                     return;
                 }
                 var status = GetAssetStatusResource(resource);
-                status.Status.ManagementGroups ??= new List<AssetManagementGroupStatusSchemaElement>();
+                status.Status.ManagementGroups ??= new List<AssetManagementGroupStatus>();
                 Debug.Assert(status.Status.ManagementGroups != null);
-                status.Status.ManagementGroups.Add(new AssetManagementGroupStatusSchemaElement
+                status.Status.ManagementGroups.Add(new AssetManagementGroupStatus
                 {
                     Name = resource.ManagementGroup.Name,
                     Actions = resource.ManagementGroup.Actions.ConvertAll(a =>
-                        new AssetManagementGroupActionStatusSchemaElement
+                        new AssetManagementGroupActionStatus
                         {
                             Name = a.Name,
                             Error = new ConfigError
@@ -2919,14 +2919,14 @@ namespace Azure.IIoT.OpcUa.Publisher.Services
             private void Add(ManagementActionResource resource, string code, string error)
             {
                 var status = GetAssetStatusResource(resource);
-                status.Status.ManagementGroups ??= new List<AssetManagementGroupStatusSchemaElement>();
+                status.Status.ManagementGroups ??= new List<AssetManagementGroupStatus>();
                 Debug.Assert(status.Status.ManagementGroups != null);
-                status.Status.ManagementGroups.Add(new AssetManagementGroupStatusSchemaElement
+                status.Status.ManagementGroups.Add(new AssetManagementGroupStatus
                 {
                     Name = resource.ManagementGroup.Name,
-                    Actions = new List<AssetManagementGroupActionStatusSchemaElement>
+                    Actions = new List<AssetManagementGroupActionStatus>
                     {
-                        new AssetManagementGroupActionStatusSchemaElement
+                        new AssetManagementGroupActionStatus
                         {
                             Name = resource.Action.Name,
                             Error = new ConfigError

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Services/AssetDeviceIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Services/AssetDeviceIntegrationTests.cs
@@ -495,9 +495,9 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Services
             var dataset = new AssetDataset
             {
                 Name = "ds1",
-                DataPoints = new List<AssetDatasetDataPointSchemaElement>
+                DataPoints = new List<AssetDatasetDataPoint>
                 {
-                    new AssetDatasetDataPointSchemaElement { Name = "dp1", DataSource = "ns=2;s=dp1" }
+                    new AssetDatasetDataPoint { Name = "dp1", DataSource = "ns=2;s=dp1" }
                 }
             };
             var @event = new AssetEvent { Name = "ev1", DataSource = "ns=2;s=ev1" };


### PR DESCRIPTION
## Summary

Bumps the lock-stepped `Furly.*` packages **1.2.2 → 1.2.6** to pick up the IoT Hub reconnect fix for [#2399](https://github.com/Azure/Industrial-IoT/issues/2399) (module crashed with repeated `ObjectDisposedException` and never reconnected after the IoT Hub connection was disabled then re‑enabled).

The Furly upgrade also advances several transitive dependencies that had breaking changes; those are adapted in this PR.

## Changes

- **`Directory.Packages.props`**
  - All 14 `Furly.*` packages → **1.2.6**.
  - `Azure.Core` **1.59.0 → 1.60.0** (required by `Furly.Azure` 1.2.6; otherwise NU1605 downgrade).
- **Azure IoT Operations ADR SDK** (`Azure.Iot.Operations.Services`, transitive via `Furly.Azure.IoT.Operations` 1.2.6) renamed several model types — adapted in `AssetDeviceIntegration.cs` (+ its test):
  - `DefaultEventsDestinations` → `DefaultDestinations` on `AssetEventGroup` / `DiscoveredAssetEventGroup` (the top‑level `Asset.DefaultEventsDestinations` is unchanged).
  - `AssetManagementGroupStatusSchemaElement` → `AssetManagementGroupStatus`.
  - `AssetManagementGroupActionStatusSchemaElement` → `AssetManagementGroupActionStatus`.
  - `AssetDatasetDataPointSchemaElement` → `AssetDatasetDataPoint` (test).
- **`Microsoft.OpenApi` 2.x** (transitive via `Swashbuckle.AspNetCore` pulled by `Furly.Extensions.AspNetCore` 1.2.6) flattened its namespace — `using Microsoft.OpenApi.Models;` → `using Microsoft.OpenApi;` in `Runtime/Configuration.cs` (only `OpenApiLicense` was affected).

All type changes are 1:1 renames with identical shapes; no behavioral change intended.

## Validation

- Verified the #2399 recovery fix is present in the resolved `Furly.Azure.IoT.Edge` 1.2.6.
- Full solution builds (Release, analyzers on) — 0 errors.
- `Azure.IIoT.OpcUa.Publisher.Tests`: **876 passed / 0 failed** (incl. 25 `AssetDeviceIntegration` tests).
- `Azure.IIoT.OpcUa.Publisher.Module.Tests` (Controller + Filters): **790 passed / 0 failed** (27 skipped).

> Note: local restore used nuget.org directly because the repo's Azure Artifacts feed pull‑through hadn't indexed 1.2.6 yet; `Nuget.Config` is unchanged in this PR. CI restores from nuget.org and will resolve 1.2.6.
