### PR TITLE
Fix E2E IoT Hub connstring parse: strip CR from KeyVault secrets

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -105,6 +105,12 @@ jobs:
             local env_name="$2"
             local val
             val=$(az keyvault secret show --vault-name "$KeyVaultName" --name "$name" --query value -o tsv 2>/dev/null || true)
+            # The az CLI on Windows runners emits values with CRLF line
+            # endings; command substitution strips the trailing LF but leaves
+            # a CR, which corrupts single-line secrets such as the IoT Hub
+            # connection string (its base64 SharedAccessKey then fails to
+            # parse). Strip all CRs so values are used verbatim.
+            val="${val//$'\r'/}"
             if [ -z "$val" ]; then
               echo "::warning::KeyVault secret '$name' is missing or empty"
               return


### PR DESCRIPTION
## Summary

The **E2E Standalone → Run A&E tests (PublisherMode=AE)** job failed ([run 28946762109](https://github.com/Azure/Industrial-IoT/actions/runs/28946762109)) with a mass of:

```
Class fixture type 'IIoTStandaloneTestContext' threw in its constructor
---- System.FormatException : The input is not a valid Base-64 string ...
   at Microsoft.Azure.Devices.IotHubConnectionStringBuilder.Validate()
   ...
   at OpcPublisherAEE2ETests.RegistryHelper..ctor(...) RegistryHelper.cs:line 35
```

## Root cause

Every failing test aborts in the shared class-fixture constructor, where `RegistryManager.CreateFromConnectionString(PCS_IOTHUB_CONNSTRING)` validates the connection string. The failure is a **base64 parse error on the `SharedAccessKey`**, which means the connection string was present but **corrupted** (an unset value would instead throw `InvalidOperationException: "IoT Hub connection string is not provided."`).

The corruption comes from how the reusable workflow fetches Key Vault secrets on the **windows-latest** runner:

```bash
val=$(az keyvault secret show ... --query value -o tsv ...)
```

`az` emits values with **CRLF** line endings; bash command substitution strips the trailing `LF` but leaves the `CR`. So `PCS_IOTHUB_CONNSTRING` ends with a carriage return, and `...;SharedAccessKey=<base64>\r` fails base64 validation.

## Fix

Strip all carriage returns from fetched Key Vault secret values in `e2e-run-tests.yml` so single-line secrets (connection strings, IPs, ids) are used verbatim:

```bash
val="${val//$'\r'/}"
```

This is safe for the multi-line secrets fetched here too (SSH keys are `\n`-delimited).

## Validation

Workflow-only change; it can't be exercised locally (requires the full Azure E2E deployment). Re-running the **E2E Standalone** workflow after merge should get the A&E job past fixture construction. The `basic (standalone)` job in the same run passed, so the deployed resources and the secret itself are fine — only the fetch was corrupting the value.
