### PR TITLE
Wait for second publisher to be method-ready in writer-group CS e2e test

### DIFF
--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
@@ -83,6 +83,13 @@ namespace OpcPublisherAEE2ETests.Standalone
         public async Task TestDeploySecondPublisher()
         {
             await _context.RegistryHelper.DeployStandalonePublisherAsync(_deployment, _timeoutToken);
+
+            // Reaching IoT Hub "Connected" state does not guarantee the freshly deployed
+            // module is ready to serve direct methods: its method handlers and configuration
+            // services may still be initializing, during which an invocation transiently
+            // fails (405 while the handler registers, 5xx while the services start). Wait
+            // until a benign read-only method succeeds before any test relies on it.
+            await WaitUntilPublisherReadyAsync(_timeoutToken);
         }
 
         [Fact, PriorityOrder(1)]
@@ -135,6 +142,34 @@ namespace OpcPublisherAEE2ETests.Standalone
                 parameters,
                 _context,
                 ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Wait until the freshly deployed publisher module is ready to serve direct
+        /// methods by polling a benign, read-only method until it returns 200. Transient
+        /// 405 (handler not yet registered) and 5xx (services still starting) responses
+        /// are tolerated; the loop is bounded by the test timeout token.
+        /// </summary>
+        private async Task WaitUntilPublisherReadyAsync(CancellationToken ct)
+        {
+            while (true)
+            {
+                var result = await CallMethodAsync(
+                    new MethodParameterModel
+                    {
+                        Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                    },
+                    ct).ConfigureAwait(false);
+
+                if (result.Status == (int)HttpStatusCode.OK)
+                {
+                    return;
+                }
+
+                _context.OutputHelper?.WriteLine(
+                    $"Publisher {_deployment.ModuleName} not ready yet (status {result.Status}), retrying...");
+                await Task.Delay(TestConstants.DefaultDelayMilliseconds, ct).ConfigureAwait(false);
+            }
         }
 
         private async Task PublishNodesAsync(string json, CancellationToken ct)


### PR DESCRIPTION
## Summary

Fixes the one failing test in the **E2E Standalone → Run A&E tests** job (e.g. [run 28953406506](https://github.com/Azure/Industrial-IoT/actions/runs/28953406506)):

`EWriterGroupConnectionStringTestTheory.TestWriterGroupPublishesUnderChildDeviceIdentity` (added by #2498) failed with:

```
Called method UnpublishAllNodes_V1.
Got internal error 500 (null), trying again to call publisher after delay...   (x3)
Assert.Equal() Failure: Expected 200, Actual 500
```

## Root cause

This is the **only** test that deploys a *second, fresh* publisher module (`publisher_standalone_cs`) and calls a direct method on it **immediately**. Every other standalone/A&E test reuses the default `publisher_standalone`, which has been running (warm) since early in the run.

`DeployStandalonePublisherAsync` waits for the module to reach IoT Hub `ConnectionState == Connected` — but **`Connected` ≠ direct-method-ready**. The first call returns `500 (null)`, not `405`: the method handler is registered, but the invocation throws because the module's configuration services are still initializing. The retry budget is far too small for a cold module — `TestHelper.CallMethodAsync` retries `>=500` only 3×/~6s, and the test's `UnpublishAllNodesAsync` loop retries only on `405` — so a startup-window `500` fails almost immediately.

## Fix

After deploying the second publisher, poll a benign read-only method (`GetConfiguredEndpoints_V1`) until it returns `200`, tolerating transient `405`/`5xx`, before any assertion relies on the module. This mirrors how `WaitForIIoTModulesConnectedAsync` guarantees connectivity, but at the method-serving level. The loop is bounded by the existing 10-minute test timeout token.

The change is scoped to this test (its `TestDeploySecondPublisher` + a new `WaitUntilPublisherReadyAsync` helper); the shared `DynamicAciTestBase.UnpublishAllNodesAsync` is untouched, so real `500`s in later calls are not masked.

## Notes

- Not related to the Furly bump (#2497 unmerged; the E2E `latest` image is built from `main` = Furly 1.2.2). This test only started running after the base64/CR fix (#2501) let the suite past fixture construction.
- If the module were to return `500` *deterministically* (not a readiness window), the probe would instead time out in `TestDeploySecondPublisher` — a clearer signal that isolates a non-readiness cause. In that case the exact exception is now available in the module logs via #2489's Error-level `MethodCallFailed` logging.

## Validation

E2E-only change; can't be exercised locally. Requires a post-merge **E2E Standalone** dispatch to confirm the A&E job goes green.
