### PR TITLE
Capture second-publisher module logs on direct-method failure in writer-group CS e2e test

### DIFF
--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
@@ -172,6 +172,26 @@ namespace OpcPublisherAEE2ETests.Standalone
             }
         }
 
+        /// <summary>
+        /// Assert that a direct method call to the second publisher returned 200. On any
+        /// other status - in particular the 500/null signature seen when the config
+        /// service throws - dump the module container logs into the test output so the
+        /// actual server-side exception is visible without another (billable) E2E cycle.
+        /// </summary>
+        private async Task AssertMethodStatusOkAsync(MethodResultModel result,
+            string methodName, CancellationToken ct)
+        {
+            if (result?.Status != (int)HttpStatusCode.OK)
+            {
+                var logs = await TestHelper.GetModuleLogsAsync(
+                    _context, _deployment.ModuleName, ct: ct).ConfigureAwait(false);
+                _context.OutputHelper?.WriteLine(
+                    $"{methodName} failed with status {result?.Status}: {result?.JsonPayload}" +
+                    $"{Environment.NewLine}=== {_deployment.ModuleName} module logs ==={Environment.NewLine}{logs}");
+            }
+            Assert.Equal((int)HttpStatusCode.OK, result?.Status);
+        }
+
         private async Task PublishNodesAsync(string json, CancellationToken ct)
         {
             await UnpublishAllNodesAsync(ct).ConfigureAwait(false);
@@ -186,7 +206,7 @@ namespace OpcPublisherAEE2ETests.Standalone
                     },
                     ct).ConfigureAwait(false);
 
-                Assert.Equal((int)HttpStatusCode.OK, result.Status);
+                await AssertMethodStatusOkAsync(result, "PublishNodes", ct).ConfigureAwait(false);
             }
 
             var result1 = await CallMethodAsync(
@@ -196,7 +216,7 @@ namespace OpcPublisherAEE2ETests.Standalone
                 },
                 ct).ConfigureAwait(false);
 
-            Assert.Equal((int)HttpStatusCode.OK, result1.Status);
+            await AssertMethodStatusOkAsync(result1, "GetConfiguredEndpoints", ct).ConfigureAwait(false);
             var response = _serializer.Deserialize<GetConfiguredEndpointsResponseModel>(result1.JsonPayload);
             Assert.Equal(entries.Length, response.Endpoints.Count);
         }
@@ -222,7 +242,7 @@ namespace OpcPublisherAEE2ETests.Standalone
                 }
                 break;
             }
-            Assert.Equal((int)HttpStatusCode.OK, result?.Status);
+            await AssertMethodStatusOkAsync(result, "UnpublishAllNodes", ct).ConfigureAwait(false);
 
             var result1 = await CallMethodAsync(
                 new MethodParameterModel
@@ -231,7 +251,7 @@ namespace OpcPublisherAEE2ETests.Standalone
                 },
                 ct).ConfigureAwait(false);
 
-            Assert.Equal((int)HttpStatusCode.OK, result1.Status);
+            await AssertMethodStatusOkAsync(result1, "GetConfiguredEndpoints", ct).ConfigureAwait(false);
             var response = _serializer.Deserialize<GetConfiguredEndpointsResponseModel>(result1.JsonPayload);
             Assert.Empty(response.Endpoints);
         }

--- a/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
@@ -200,6 +200,37 @@ namespace OpcPublisherAEE2ETests
         }
 
         /// <summary>
+        /// Retrieve the recent logs of an IoT Edge module from the edge VM. Best
+        /// effort - intended for surfacing the cause of a failed direct method call
+        /// (which the module logs at Error) into the test output, since the module
+        /// container logs are otherwise not collected by the E2E pipeline.
+        /// </summary>
+        /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>
+        /// <param name="moduleName">The IoT Edge module whose logs to fetch</param>
+        /// <param name="tail">Number of trailing log lines to fetch</param>
+        /// <param name="ct"></param>
+        public static async Task<string> GetModuleLogsAsync(IIoTPlatformTestContext context,
+            string moduleName, int tail = 1000, CancellationToken ct = default)
+        {
+            try
+            {
+                using var client = await CreateSshClientAndConnectAsync(context, ct).ConfigureAwait(false);
+                var command = client.RunCommand(
+                    $"sudo iotedge logs {moduleName} --tail {tail} 2>&1");
+                var output = command.Result;
+                if (string.IsNullOrWhiteSpace(output) && !string.IsNullOrWhiteSpace(command.Error))
+                {
+                    output = command.Error;
+                }
+                return output;
+            }
+            catch (Exception ex)
+            {
+                return $"Failed to read logs for module {moduleName}: {ex.Message}";
+            }
+        }
+
+        /// <summary>
         /// Create a new ScpClient based on SshConfig and directly connects to host
         /// </summary>
         /// <param name="context">Shared Context for E2E testing Industrial IoT Platform</param>


### PR DESCRIPTION
## Problem
The new e2e test `TestWriterGroupPublishesUnderChildDeviceIdentity` (PR #2498, issue #2426) deterministically fails with a 500 (null) from one of the direct-method calls in `PublishNodesAsync` on the freshly deployed second publisher module (`publisher_standalone_cs`). The readiness probe added in #2504 confirmed the module is method-ready (GetConfiguredEndpoints returns 200), yet a subsequent call still 500s. The failure does not reproduce locally, and the module container logs are not collected by the E2E pipeline, so the actual server-side exception is invisible.

## Change
- Add `TestHelper.GetModuleLogsAsync` - a best-effort helper that fetches `iotedge logs <module>` over the existing SSH connection to the edge VM.
- In the CS writer-group test, dump the `publisher_standalone_cs` module logs into the test output whenever any of the three direct-method assertions (UnpublishAllNodes, PublishNodes, GetConfiguredEndpoints) returns non-200, via a shared `AssertMethodStatusOkAsync` helper.

This surfaces the root-cause exception on the next E2E run so the deterministic 500 can be fixed, without another blind guess. Diagnostics are scoped to this test only; shared `DynamicAciTestBase` behavior is unchanged.