### PR TITLE
Bump Furly to 1.2.8 to fix MQTT reconnect memory/handle leak (#2365)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,20 +52,20 @@
   </ItemGroup>
 
   <ItemGroup Label="Furly (keep all in lock-step)">
-    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.6" />
-    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.6" />
-    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.6" />
-    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.6" />
-    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.6" />
-    <PackageVersion Include="Furly.Tunnel" Version="1.2.6" />
+    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.8" />
+    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.8" />
+    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.8" />
+    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.8" />
+    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.8" />
+    <PackageVersion Include="Furly.Tunnel" Version="1.2.8" />
   </ItemGroup>
 
   <ItemGroup Label="OpenTelemetry">


### PR DESCRIPTION
## What

Bumps all Furly packages 1.2.6 → 1.2.8 (kept in lock-step) to pick up [microsoft/project-furly#15](https://github.com/microsoft/project-furly/pull/15).

## Why

Fixes the MQTT-side memory/handle leak reported in #2365. Furly's `MqttClient.HandleSessionClosedAsync` recreated a lost session via `CreateSession()` but never disposed the old `MqttSession`, so every MQTT session-lost/reconnect leaked its underlying MQTTnet client, event-handler subscriptions, `Meter`/instruments, `CancellationTokenSource`, `SemaphoreSlim`/`AutoResetEvent` (each an OS handle) and its acknowledgement worker thread. project-furly#15 disposes the orphaned session.

(The OPC-server-restart side of #2365 was already fixed on `main` by #2500 + meter disposal.)

## Verification

Rebuilt the publisher module against Furly 1.2.8 and re-ran a live broker-flap repro (ConsoleReferenceServer, 5 sessions/135 monitored items, 18 MQTT broker restarts), comparing `dotnet-gcdump` heap reports:

| Type | pre-fix (18 flaps) | 1.2.8 (18 flaps) |
|---|---|---|
| `Func<MqttClientDisconnectedEventArgs,Task>` | 5→95 | 5→5 |
| `Func<MqttClientConnectedEventArgs,Task>` | 2→38 | 2→2 |
| `CancellationTokenSource` | 78→132 | 78→78 |
| `SemaphoreSlim` | 42→96 | 43→43 |
| `ObservableUpDownCounter<Int32>` | 153→189 | 153→153 |
| `MqttSession+PendingAck` | 1→19 | 1→1 |
| `DiagLinkedList<ListenerSubscription>` | 542→650 | 542→542 |

Managed heap flat (26.9 MB); process handle count retired to baseline after cooldown (pre-fix plateaued ~74 above). `dotnet restore` from nuget.org + module build succeed on 1.2.8.

Closes #2365
