### PR TITLE
Fix UnpublishAllNodes 500 on freshly deployed publisher with a named --pf file

### DIFF
--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/E_WriterGroupConnectionStringTestTheory.cs
@@ -64,7 +64,8 @@ namespace OpcPublisherAEE2ETests.Standalone
                 moduleName: kModuleName,
                 deploymentName: kDeploymentName,
                 publishedNodesFile: TestConstants.PublishedNodesFolder + "/published_nodes_cs.json",
-                pkiPath: TestConstants.PublishedNodesFolder + "/pki_cs");
+                pkiPath: TestConstants.PublishedNodesFolder + "/pki_cs",
+                createFileIfNotExist: true);
 
             _iotHubClient = TestHelper.DeviceServiceClient(
                 _context.IoTHubConfig.IoTHubConnectionString,

--- a/e2e-tests/OpcPublisher-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/deploy/IoTHubPublisherDeployment.cs
@@ -41,15 +41,24 @@ namespace OpcPublisherAEE2ETests.Deploy
         /// pki folder. Supply a distinct path so a second publisher module does not share
         /// the certificate store of the default one.
         /// </param>
+        /// <param name="createFileIfNotExist">
+        /// When true, pass the --cf argument so the publisher is permitted to create the
+        /// configured --pf file if it does not yet exist. Required when a module is driven
+        /// exclusively through direct methods (which persist to that file) and the file is
+        /// never transferred to the edge VM beforehand; otherwise the first persist fails
+        /// with a FileNotFoundException because the file is opened with FileMode.Open.
+        /// </param>
         public IoTHubPublisherDeployment(IIoTPlatformTestContext context, MessagingMode messagingMode,
             string moduleName = kModuleName, string deploymentName = kDeploymentName,
-            string publishedNodesFile = null, string pkiPath = null) : base(context)
+            string publishedNodesFile = null, string pkiPath = null,
+            bool createFileIfNotExist = false) : base(context)
         {
             MessagingMode = messagingMode;
             DeploymentName = deploymentName;
             ModuleName = moduleName;
             _publishedNodesFile = publishedNodesFile ?? TestConstants.PublishedNodesFullName;
             _pkiPath = pkiPath ?? (TestConstants.PublishedNodesFolder + "/pki");
+            _createFileIfNotExist = createFileIfNotExist;
         }
 
         /// <inheritdoc />
@@ -95,19 +104,28 @@ namespace OpcPublisherAEE2ETests.Deploy
             }
 
             // Configure create options per os specified
+            var cmd = new List<string>
+            {
+                "--pki=" + _pkiPath,
+                "--dm", // Disable metadata support
+                "--aa",
+                "--pf=" + _publishedNodesFile,
+                "--mm=" + MessagingMode.ToString(),
+                "--fm=true",
+                "--RuntimeStateReporting=true"
+            };
+            if (_createFileIfNotExist)
+            {
+                // Permit the module to create the --pf file if it does not exist yet. Without
+                // this a module driven only through direct methods fails the first persist
+                // (e.g. UnpublishAllNodes) with a FileNotFoundException.
+                cmd.Add("--cf=true");
+            }
             var createOptions = JsonConvert.SerializeObject(new
             {
                 Hostname = ModuleName,
                 User = "root",
-                Cmd = new[] {
-                    "--pki=" + _pkiPath,
-                    "--dm", // Disable metadata support
-                    "--aa",
-                    "--pf=" + _publishedNodesFile,
-                    "--mm=" + MessagingMode.ToString(),
-                    "--fm=true",
-                    "--RuntimeStateReporting=true"
-                },
+                Cmd = cmd.ToArray(),
                 HostConfig = new
                 {
                     Binds = new[] {
@@ -170,6 +188,7 @@ namespace OpcPublisherAEE2ETests.Deploy
 
         private readonly string _publishedNodesFile;
         private readonly string _pkiPath;
+        private readonly bool _createFileIfNotExist;
         private const string kModuleName = "publisher_standalone";
         private const string kDeploymentName = "__default-opcpublisher-standalone";
         private const string kTargetCondition = "(tags.__type__ = 'iiotedge' AND IS_DEFINED(tags.unmanaged))";

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Storage/PublishedNodesProvider.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Storage/PublishedNodesProvider.cs
@@ -121,6 +121,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Storage
                     fileStream.SetLength(0);
                     fileStream.Write(Encoding.UTF8.GetBytes(content));
                 }
+                catch (IOException e) when (e is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    // The configured file (or its directory) does not exist and the file
+                    // mode does not permit creating it (a named --pf file was specified
+                    // without CreatePublishFileIfNotExist/--cf). Relaxing share policies
+                    // cannot help here, so fail with an actionable error instead of the
+                    // misleading restricted-share retry below.
+                    _logger.UpdateFileMissing(e, _fileName);
+                    throw;
+                }
                 catch (IOException e)
                 {
                     _logger.UpdateFileRestrictedShare(_fileName);
@@ -211,6 +221,13 @@ namespace Azure.IIoT.OpcUa.Publisher.Storage
         [LoggerMessage(EventId = EventClass + 3, Level = LogLevel.Error,
             Message = "Failed to update published nodes file at \"{Path}\"")]
         public static partial void UpdateFileFailed(this ILogger logger, Exception exception, string path);
+
+        [LoggerMessage(EventId = EventClass + 5, Level = LogLevel.Error,
+            Message = "Failed to update published nodes file at \"{Path}\": the file or its " +
+            "directory does not exist and the publisher is not permitted to create it. Enable " +
+            "CreatePublishFileIfNotExist (the --cf command line option) so the module can create " +
+            "the configured publish file.")]
+        public static partial void UpdateFileMissing(this ILogger logger, Exception exception, string path);
 
         [LoggerMessage(EventId = EventClass + 4, Level = LogLevel.Trace,
             Message = "No raising event while writing ({Changed}).")]

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Services/PublishedNodesJsonServicesTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Services/PublishedNodesJsonServicesTests.cs
@@ -1148,6 +1148,97 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Services
             results.Should().BeEmpty();
         }
 
+        /// <summary>
+        /// Builds a config service backed by a published nodes provider that points at
+        /// <paramref name="publishedNodesFile"/>, mirroring how the module wires it up
+        /// from the --pf/--cf command line options. Used to exercise the case where a
+        /// named publish file does not exist yet (as for a freshly deployed module driven
+        /// only through direct methods).
+        /// </summary>
+        private PublishedNodesJsonServices CreateConfigServiceForFile(
+            string publishedNodesFile, bool? createFileIfNotExist)
+        {
+            var options = new PublisherConfig(new ConfigurationBuilder().Build()).ToOptions();
+            options.Value.PublishedNodesFile = publishedNodesFile;
+            options.Value.CreatePublishFileIfNotExist = createFileIfNotExist;
+            options.Value.UseFileChangePolling = true;
+            options.Value.DefaultTransport = WriterGroupTransport.Mqtt;
+            options.Value.MessagingProfile = MessagingProfile.Get(
+                MessagingMode.PubSub, MessageEncoding.Json);
+
+            var factory = new PhysicalFileProviderFactory(options,
+                _loggerFactory.CreateLogger<PhysicalFileProviderFactory>());
+            var provider = new PublishedNodesProvider(factory, options,
+                _loggerFactory.CreateLogger<PublishedNodesProvider>());
+            var configService = new PublishedNodesJsonServices(
+                _publishedNodesJobConverter,
+                _publisher,
+                _loggerFactory.CreateLogger<PublishedNodesJsonServices>(),
+                provider,
+                _newtonSoftJsonSerializer);
+            configService.GetAwaiter().GetResult();
+            return configService;
+        }
+
+        [Fact]
+        public async Task UnpublishAllNodesCreatesMissingFileWhenPermittedAsync()
+        {
+            // Reproduces the writer-group child-device E2E scenario: a publisher pointed at
+            // a named --pf file that does not exist yet, driven purely through direct
+            // methods. When CreatePublishFileIfNotExist (--cf) is enabled the first persist
+            // (the purge issued by UnpublishAllNodes) must create the file rather than
+            // failing with a FileNotFoundException.
+            var missingFile = Path.Combine(Path.GetTempPath(), $"pn_{Guid.NewGuid():N}.json");
+            File.Exists(missingFile).Should().BeFalse();
+            try
+            {
+                await using var configService = CreateConfigServiceForFile(
+                    missingFile, createFileIfNotExist: true);
+
+                // Act - purge against a fresh, not-yet-existing file must not throw.
+                await configService.UnpublishAllNodesAsync(null);
+
+                // Assert - the file was created and the configuration is empty.
+                File.Exists(missingFile).Should().BeTrue();
+                var results = await configService.GetConfiguredEndpointsAsync(false);
+                results.Should().BeEmpty();
+            }
+            finally
+            {
+                if (File.Exists(missingFile))
+                {
+                    File.Delete(missingFile);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task UnpublishAllNodesFailsWhenFileMissingAndCreateNotPermittedAsync()
+        {
+            // Documents the contract: a named --pf file that does not exist and may not be
+            // created (CreatePublishFileIfNotExist not set) cannot be persisted to. The
+            // operation surfaces the missing-file error instead of silently succeeding.
+            var missingFile = Path.Combine(Path.GetTempPath(), $"pn_{Guid.NewGuid():N}.json");
+            File.Exists(missingFile).Should().BeFalse();
+            try
+            {
+                await using var configService = CreateConfigServiceForFile(
+                    missingFile, createFileIfNotExist: null);
+
+                await Assert.ThrowsAsync<FileNotFoundException>(
+                    () => configService.UnpublishAllNodesAsync(null));
+
+                File.Exists(missingFile).Should().BeFalse();
+            }
+            finally
+            {
+                if (File.Exists(missingFile))
+                {
+                    File.Delete(missingFile);
+                }
+            }
+        }
+
         [Fact]
         public async Task Legacy25PublishedNodesFileErrorAsync()
         {


### PR DESCRIPTION
## Root cause
The captured module logs (added in #2505) revealed the deterministic 500 in `TestWriterGroupPublishesUnderChildDeviceIdentity`:

```
Failed to update published nodes file at "/mount/opc_publisher/published_nodes_cs.json"
System.IO.FileNotFoundException: Could not find file '/mount/opc_publisher/published_nodes_cs.json'.
   at PublishedNodesProvider.WriteContent(...) PublishedNodesProvider.cs:line 116
   at PublishedNodesJsonServices.PersistPublishedNodesAsync() line 896
   at PublishedNodesJsonServices.UnpublishAllNodesAsync(...) line 670
```

A publisher configured with a **named** `--pf` file but **without** `CreatePublishFileIfNotExist` (`--cf`) opens the file with `FileMode.Open`. The second module (`publisher_standalone_cs`) points `--pf` at a brand-new `published_nodes_cs.json` and is driven purely through direct methods, so the file never exists when the first persist (the purge issued by `UnpublishAllNodes`) runs -> `FileNotFoundException` -> the router surfaces `500 (null)` to the caller. The default `publisher_standalone` module avoids this only because other tests transfer `published_nodes.json` to the edge VM first.

## Changes
- **E2E (makes the test green):** `IoTHubPublisherDeployment` gains a `createFileIfNotExist` flag that appends `--cf=true`; the writer-group child-device test enables it so the module can create its named publish file.
- **Product diagnostics:** `PublishedNodesProvider.WriteContent` no longer misclassifies a missing file/directory as a restricted-share violation (which triggered a pointless relaxed-share retry and a misleading warning). `FileNotFoundException`/`DirectoryNotFoundException` now log an actionable `UpdateFileMissing` error pointing at `--cf`.
- **Unit tests:** `PublishedNodesJsonServices` tests for both the create-when-permitted (file created, purge succeeds) and not-permitted (`FileNotFoundException`, file not created) paths. Both pass locally.

Follow-up to #2498, #2504, #2505.