### PR TITLE
Update NuGet packages to latest stable versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,16 +17,16 @@
   </ItemGroup>
 
   <ItemGroup Label="Microsoft.Extensions and ASP.NET Core">
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.ResourceMonitoring" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup Label="Azure SDK">
@@ -38,34 +38,34 @@
     <PackageVersion Include="Azure.ResourceManager.ContainerRegistry" Version="1.4.0" />
     <PackageVersion Include="Azure.ResourceManager.IotHub" Version="1.1.1" />
     <PackageVersion Include="Azure.ResourceManager.Storage" Version="1.7.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.0" />
-    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageVersion Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageVersion Include="Microsoft.Azure.Devices" Version="1.41.0" />
     <PackageVersion Include="Microsoft.Azure.Devices.Client" Version="1.42.3" />
   </ItemGroup>
 
   <ItemGroup Label="OPC Foundation">
-    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.378.145" />
-    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.5.378.145" />
-    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.5.378.145" />
-    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.378.145" />
+    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Client" Version="1.5.378.156" />
+    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Client.ComplexTypes" Version="1.5.378.156" />
+    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Core" Version="1.5.378.156" />
+    <PackageVersion Include="OPCFoundation.NetStandard.Opc.Ua.Server" Version="1.5.378.156" />
   </ItemGroup>
 
   <ItemGroup Label="Furly (keep all in lock-step)">
-    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.8" />
-    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.8" />
-    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.8" />
-    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.8" />
-    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.8" />
-    <PackageVersion Include="Furly.Tunnel" Version="1.2.8" />
+    <PackageVersion Include="Furly.Azure.EventHubs" Version="1.2.9" />
+    <PackageVersion Include="Furly.Azure.IoT" Version="1.2.9" />
+    <PackageVersion Include="Furly.Azure.IoT.Edge" Version="1.2.9" />
+    <PackageVersion Include="Furly.Azure.IoT.Operations" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Abstractions" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.AspNetCore" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Autofac" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Dapr" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Json" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.MessagePack" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Mqtt" Version="1.2.9" />
+    <PackageVersion Include="Furly.Extensions.Newtonsoft" Version="1.2.9" />
+    <PackageVersion Include="Furly.Tunnel" Version="1.2.9" />
   </ItemGroup>
 
   <ItemGroup Label="OpenTelemetry">
@@ -73,19 +73,19 @@
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test and build tooling">
-    <PackageVersion Include="Autofac.Extras.Moq" Version="7.0.0" />
+    <PackageVersion Include="Autofac.Extras.Moq" Version="8.0.1" />
     <PackageVersion Include="AutoFixture" Version="4.18.1" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.9.50" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
@@ -106,7 +106,7 @@
     <PackageVersion Include="Microsoft.Json.Schema" Version="2.3.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageVersion Include="Mono.Options" Version="6.12.0.148" />
-    <PackageVersion Include="MQTTnet.Extensions.Rpc" Version="5.1.0.1559" />
+    <PackageVersion Include="MQTTnet.Extensions.Rpc" Version="5.2.0.1603" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="SharpPcap" Version="6.3.1" />
     <PackageVersion Include="SSH.NET" Version="2025.1.0" />


### PR DESCRIPTION
## Summary
Bumps all centrally-managed NuGet packages in `Directory.Packages.props` to their latest **stable** versions available on nuget.org (**38 packages**).

## Updated packages
| Package(s) | From → To |
|---|---|
| Microsoft.Extensions.* / AspNetCore.Mvc.Testing (9) | 10.0.9 → **10.0.10** |
| Microsoft.Extensions.Diagnostics.ResourceMonitoring | 10.7.0 → **10.8.0** |
| Azure.Storage.Blobs / Queues | → **12.29.1** / **12.27.1** |
| OPCFoundation.NetStandard.Opc.Ua.* (4) | 1.5.378.145 → **1.5.378.156** |
| Furly.* (14, in lock-step) | 1.2.8 → **1.2.9** |
| OpenTelemetry.Instrumentation.AspNetCore / Http / Runtime | 1.15.x → **1.16.0** |
| Autofac.Extras.Moq | 7.0.0 → **8.0.1** |
| Microsoft.NET.Test.Sdk | 18.6.0 → **18.8.1** |
| Microsoft.SourceLink.GitHub | 10.0.300 → **10.0.301** |
| Nerdbank.GitVersioning | 3.9.50 → **3.10.91** |
| MQTTnet.Extensions.Rpc | 5.1.0.1559 → **5.2.0.1603** |

## Intentionally left unchanged
- **Pinned** (per the documented policy in `Directory.Packages.props`): `FluentAssertions [7.2.0]` (8.x is a commercial license) and `Moq [4.20.2]` (later versions added SponsorLink).
- Packages whose only newer versions are **prereleases** (e.g. Microsoft.Azure.Devices 2.0.0-rc, Azure.ResourceManager.* betas, AutoFixture 5.0-preview, xunit.runner.visualstudio 4.0.0-pre). `OpenTelemetry.Exporter.Prometheus.AspNetCore` stays at `1.16.0-beta.1` (only prerelease published).

## Notes
- `Autofac.Extras.Moq` 8.0.1 requires `Moq >= 4.18.4`, satisfied by the pinned 4.20.2, and provides a `net10.0` target.

## Validation
- Restore + full solution build: **0 errors**.
- Tests: **Publisher 891/891** and **OpcUa 2158/2158** passing (these exercise Furly serializers and `AutoMock` most heavily, confirming the Furly 1.2.9 and Autofac.Extras.Moq 8.0.1 bumps are clean).
