### PR TITLE
Add refresh-only condition handling to surface retained conditions once (#2434)

### DIFF
--- a/docs/opc-publisher/definitions.md
+++ b/docs/opc-publisher/definitions.md
@@ -363,6 +363,7 @@ Condition handling options model
 
 |Name|Description|Schema|
 |---|---|---|
+|**refreshRetainedConditionsOnStart**  <br>*optional*|Issue a single ConditionRefresh when the event subscription is<br>established (and again after a reconnect) so retained conditions<br>already present on the server are delivered once as regular events.<br>Unlike snapshotInterval this does not cache conditions or<br>periodically re-send snapshots. Ignored when snapshotInterval is set.|boolean|
 |**snapshotInterval**  <br>*optional*|Time interval for sending pending interval snapshot in seconds.|integer (int32)|
 |**updateInterval**  <br>*optional*|Time interval for sending pending interval updates in seconds.|integer (int32)|
 

--- a/docs/opc-publisher/openapi.json
+++ b/docs/opc-publisher/openapi.json
@@ -6162,6 +6162,10 @@
           "format": "int32",
           "description": "Time interval for sending pending interval snapshot in seconds.",
           "type": "integer"
+        },
+        "refreshRetainedConditionsOnStart": {
+          "description": "Issue a single ConditionRefresh when the event subscription is\n            established (and again after a reconnect) so retained conditions\n            already present on the server are delivered once as regular events.\n            Unlike SnapshotInterval this does not cache conditions or\n            periodically re-send snapshots. Ignored when SnapshotInterval is set.",
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/opc-publisher/readme.md
+++ b/docs/opc-publisher/readme.md
@@ -462,7 +462,8 @@ The configuration consists a JSON array of [entries](./definitions.md#publishedn
       },
       "ConditionHandling": {
         "UpdateInterval": "integer",
-        "SnapshotInterval": "integer"
+        "SnapshotInterval": "integer",
+        "RefreshRetainedConditionsOnStart": "boolean"
       },
       "EventFilter": {
         (*)
@@ -997,10 +998,11 @@ The `ConditionHandling` section consists of the following properties:
 
 - `UpdateInterval` - the interval, in seconds, which a message is sent if anything has been updated during this interval.
 - `SnapshotInterval` - the interval, in seconds, that triggers a message to be sent regardless of if there has been an update or not.
+- `RefreshRetainedConditionsOnStart` - a boolean that, when set to `true`, issues a single `ConditionRefresh` when the event subscription is established (and again after a reconnect) so that conditions with the `Retain` flag already present on the server are delivered once. Unlike `SnapshotInterval`/`UpdateInterval` it does not cache conditions or periodically re-send snapshots, so no duplicate messages are produced. This is useful when you only want to pick up the alarms and conditions that already exist on the server at startup and then continue receiving new event changes normally. This option is ignored when `SnapshotInterval` is set, because snapshotting already performs the initial refresh.
 
-One or both of these must be set for condition handling to be in effect. You can use the condition handling configuration regardless if you are using advanced or simple event filters. If you specify the`ConditionHandling` option property without an `EventFilter` property it is ignored, as condition handling has no effect for data change subscriptions.
+For the snapshotting behavior, one or both of `UpdateInterval` and `SnapshotInterval` must be set for condition handling to be in effect. Alternatively, set `RefreshRetainedConditionsOnStart` to `true` for the one-time refresh behavior. You can use the condition handling configuration regardless if you are using advanced or simple event filters. If you specify the`ConditionHandling` option property without an `EventFilter` property it is ignored, as condition handling has no effect for data change subscriptions.
 
-Conditions are sent as `ua-condition` data set messages. This is a message type not part of the official standard but allows separating condition snapshots from regular `ua-event` data set messages.
+Condition snapshots (produced through `SnapshotInterval`/`UpdateInterval`) are sent as `ua-condition` data set messages. This is a message type not part of the official standard but allows separating condition snapshots from regular `ua-event` data set messages. Retained conditions delivered through `RefreshRetainedConditionsOnStart` are surfaced once as regular `ua-event` messages (the `RefreshStart`/`RefreshEnd` envelope events are suppressed).
 
 ## Publish to a Unified Namespace
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Models/src/ConditionHandlingOptionsModel.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Models/src/ConditionHandlingOptionsModel.cs
@@ -26,5 +26,18 @@ namespace Azure.IIoT.OpcUa.Publisher.Models
         [DataMember(Name = "snapshotInterval", Order = 2,
             EmitDefaultValue = false)]
         public int? SnapshotInterval { get; set; }
+
+        /// <summary>
+        /// Issue a single ConditionRefresh when the event subscription is
+        /// established (and again after a reconnect) so retained conditions
+        /// already present on the server are delivered once as regular events.
+        /// Unlike <see cref="SnapshotInterval"/> this does not cache conditions
+        /// or periodically re-send snapshots. Ignored when
+        /// <see cref="SnapshotInterval"/> is set (snapshotting already performs
+        /// the initial refresh).
+        /// </summary>
+        [DataMember(Name = "refreshRetainedConditionsOnStart", Order = 3,
+            EmitDefaultValue = false)]
+        public bool? RefreshRetainedConditionsOnStart { get; set; }
     }
 }

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Resources/PendingAlarmsRefreshOnStart.json
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Resources/PendingAlarmsRefreshOnStart.json
@@ -1,0 +1,19 @@
+[
+    {
+        "EndpointUrl": "{{EndpointUrl}}",
+        "UseSecurity": false,
+        "DataSetWriterGroup": "{{DataSetWriterGroup}}",
+        "OpcNodes": [
+            {
+                "DisplayName": "PendingAlarms",
+                "Id": "i=2253",
+                "EventFilter": {
+                    "TypeDefinitionId": "i=2041"
+                },
+                "ConditionHandling": {
+                    "RefreshRetainedConditionsOnStart": true
+                }
+            }
+        ]
+    }
+]

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicSamplesIntegrationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/ReferenceServer/BasicSamplesIntegrationTests.cs
@@ -301,6 +301,51 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.ReferenceServer
         }
 
         [Fact]
+        public async Task CanRefreshRetainedConditionsOnStartTestAsync()
+        {
+            // With RefreshRetainedConditionsOnStart set (and no SnapshotInterval),
+            // the publisher issues a single ConditionRefresh once the event
+            // subscription is established, so the retained alarms already present
+            // on the server are delivered once as regular events (not ua-condition
+            // snapshots) without any periodic re-sending.
+            var messages = await ProcessMessagesAsync(
+                nameof(CanRefreshRetainedConditionsOnStartTestAsync),
+                "./Resources/PendingAlarmsRefreshOnStart.json", GetPendingAlarmEvent);
+
+            // Assert - a retained alarm was delivered through the initial refresh.
+            messages.ForEach(m => _output.WriteLine(m.Topic + m.Message.ToJsonString()));
+            var evt = messages[0].Message;
+
+            Assert.Equal(JsonValueKind.Object, evt.ValueKind);
+            Assert.Equal("i=2253", evt.GetProperty("NodeId").GetString());
+            Assert.Equal("PendingAlarms", evt.GetProperty("DisplayName").GetString());
+
+            // The retained condition is delivered as a regular event whose Value
+            // carries the condition fields (Severity is a scalar here).
+            Assert.True(evt.TryGetProperty("Value", out var value));
+            Assert.Equal(JsonValueKind.Object, value.ValueKind);
+            Assert.True(value.TryGetProperty("Severity", out var sev));
+            Assert.True(sev.GetInt32() >= 0);
+        }
+
+        /// <summary>
+        /// Safely match a retained PendingAlarms condition event delivered through
+        /// the normal event path. Guards value kinds so non-alarm events (and the
+        /// suppressed refresh markers, should any slip through) do not throw.
+        /// </summary>
+        /// <param name="jsonElement"></param>
+        private static JsonElement GetPendingAlarmEvent(JsonElement jsonElement)
+        {
+            return jsonElement.ValueKind == JsonValueKind.Object &&
+                jsonElement.TryGetProperty("NodeId", out var nodeId) &&
+                nodeId.ValueKind == JsonValueKind.String &&
+                nodeId.GetString() == "i=2253" &&
+                jsonElement.TryGetProperty("Value", out var value) &&
+                value.ValueKind == JsonValueKind.Object &&
+                value.TryGetProperty("Severity", out _) ? jsonElement : default;
+        }
+
+        [Fact]
         public async Task CanSendDataItemToIoTHubTestWithDeviceMethodAsync()
         {
             const string name = nameof(CanSendDataItemToIoTHubTestWithDeviceMethodAsync);

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Condition.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Condition.cs
@@ -29,47 +29,18 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
         [KnownType(typeof(DataChangeFilter))]
         [KnownType(typeof(EventFilter))]
         [KnownType(typeof(AggregateFilter))]
-        internal class Condition : Event
+        internal class Condition : Event, IConditionRefreshable
         {
             /// <summary>
             /// Whether timer is enabled
             /// </summary>
             public bool TimerEnabled { get; set; }
 
-            /// <summary>
-            /// Whether a subscription wide condition refresh is required for
-            /// this item. A refresh is only required when the item (re-)entered
-            /// a good state since the last refresh was sent. While the item is
-            /// in a bad state the pending flag is reset so that a subsequent
-            /// transition from bad to good triggers a new refresh. This avoids
-            /// cyclically refreshing conditions on every resync when nothing
-            /// about the condition item itself changed.
-            /// </summary>
-            public bool IsConditionRefreshRequired
-            {
-                get
-                {
-                    if (IsBad)
-                    {
-                        // Reset so a future bad to good transition refreshes.
-                        _conditionRefreshSent = false;
-                        return false;
-                    }
-                    return !_conditionRefreshSent;
-                }
-            }
+            /// <inheritdoc/>
+            public bool IsConditionRefreshRequired => ConditionRefreshRequired;
 
-            /// <summary>
-            /// Mark that a subscription wide condition refresh has been
-            /// completed for this item while it was in a good state.
-            /// </summary>
-            public void OnConditionRefreshCompleted()
-            {
-                if (IsGood)
-                {
-                    _conditionRefreshSent = true;
-                }
-            }
+            /// <inheritdoc/>
+            public void OnConditionRefreshCompleted() => MarkConditionRefreshCompleted();
 
             /// <summary>
             /// Create condition item
@@ -104,9 +75,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                 _updateInterval = item._updateInterval;
                 _conditionHandlingState = item._conditionHandlingState;
                 _lastSentPendingConditions = item._lastSentPendingConditions;
-                // Intentionally do not copy _conditionRefreshSent: a cloned item
-                // (for example after a subscription transfer) should re-issue a
-                // condition refresh once it is good again to re-establish state.
+                // The condition-refresh-sent flag lives in the base Event and is
+                // intentionally not copied there: a cloned item (for example after
+                // a subscription transfer) should re-issue a condition refresh once
+                // it is good again to re-establish state.
                 if (item.TimerEnabled)
                 {
                     EnableConditionTimer();
@@ -178,18 +150,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                     return false;
                 }
 
-                var evFilter = Filter as EventFilter;
-                var eventTypeIndex = evFilter?.SelectClauses.IndexOf(
-                    evFilter.SelectClauses
-                        .Find(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType
-                            && x.BrowsePath?.FirstOrDefault() == BrowseNames.EventType));
-
                 var state = _conditionHandlingState;
 
                 // now, is this a regular event or RefreshStartEventType/RefreshEndEventType?
-                if (eventTypeIndex.HasValue && eventTypeIndex.Value != -1)
+                var eventType = GetRefreshEventType(eventFields);
+                if (eventType != null)
                 {
-                    var eventType = eventFields.EventFields[eventTypeIndex.Value].Value as NodeId;
                     if (eventType == ObjectTypeIds.RefreshStartEventType)
                     {
                         // stop the timers during condition refresh
@@ -207,27 +173,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                     }
                     else if (eventType == ObjectTypeIds.RefreshRequiredEventType)
                     {
-                        var noErrorFound = true;
-                        Debug.Assert(Subscription != null);
-
                         // issue a condition refresh to make sure we are in a correct state
-                        _logger.IssuingConditionRefresh(this, Template.DisplayName,
-                            Subscription.DisplayName);
-                        try
-                        {
-                            Subscription.ConditionRefreshAsync(default).GetAwaiter().GetResult(); // TODO
-                        }
-                        catch (Exception e)
-                        {
-                            _logger.ConditionRefreshFailed(this,
-                                Template.DisplayName, Subscription.DisplayName, e.Message);
-                            noErrorFound = false;
-                        }
-                        if (noErrorFound)
-                        {
-                            _logger.ConditionRefreshCompleted(this,
-                                Template.DisplayName, Subscription.DisplayName);
-                        }
+                        IssueConditionRefresh();
                         return true;
                     }
                 }
@@ -532,7 +479,6 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
             private TimerEx? _conditionTimer;
             private readonly object _timerLock = new();
             private bool _disposed;
-            private bool _conditionRefreshSent;
         }
     }
 

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.ConditionRefresh.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.ConditionRefresh.cs
@@ -1,0 +1,149 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
+{
+    using Azure.IIoT.OpcUa.Publisher.Stack.Models;
+    using Microsoft.Extensions.Logging;
+    using Opc.Ua;
+    using Opc.Ua.Client;
+    using System;
+    using System.Diagnostics;
+    using System.Runtime.Serialization;
+
+    internal abstract partial class OpcUaMonitoredItem
+    {
+        /// <summary>
+        /// A monitored event item that participates in the subscription wide
+        /// one-time ConditionRefresh (issued when the item first becomes good
+        /// and again after a reconnect) so retained conditions already present
+        /// on the server are delivered once. Unlike <see cref="Condition"/> it
+        /// does not cache conditions or periodically re-send snapshots.
+        /// </summary>
+        internal interface IConditionRefreshable
+        {
+            /// <summary>
+            /// Whether a subscription wide condition refresh is required for
+            /// this item (it (re-)entered a good state since the last refresh).
+            /// </summary>
+            bool IsConditionRefreshRequired { get; }
+
+            /// <summary>
+            /// Mark that a subscription wide condition refresh has completed for
+            /// this item while it was in a good state.
+            /// </summary>
+            void OnConditionRefreshCompleted();
+        }
+
+        /// <summary>
+        /// Refresh-only condition item. Behaves like a regular event
+        /// subscription (events are forwarded as they arrive) but requests a
+        /// single ConditionRefresh once established so retained conditions are
+        /// surfaced once. The RefreshStart/RefreshEnd envelope markers are
+        /// suppressed; a RefreshRequired notification re-issues the refresh.
+        /// </summary>
+        [DataContract(Namespace = Namespaces.OpcUaXsd)]
+        [KnownType(typeof(DataChangeFilter))]
+        [KnownType(typeof(EventFilter))]
+        [KnownType(typeof(AggregateFilter))]
+        internal sealed class ConditionRefresh : Event, IConditionRefreshable
+        {
+            /// <inheritdoc/>
+            public bool IsConditionRefreshRequired => ConditionRefreshRequired;
+
+            /// <inheritdoc/>
+            public void OnConditionRefreshCompleted() => MarkConditionRefreshCompleted();
+
+            /// <summary>
+            /// Create refresh-only condition item
+            /// </summary>
+            /// <param name="owner"></param>
+            /// <param name="template"></param>
+            /// <param name="logger"></param>
+            /// <param name="timeProvider"></param>
+            public ConditionRefresh(ISubscriber owner, EventMonitoredItemModel template,
+                ILogger<Event> logger, TimeProvider timeProvider) :
+                base(owner, template, logger, timeProvider)
+            {
+            }
+
+            /// <summary>
+            /// Copy constructor
+            /// </summary>
+            /// <param name="item"></param>
+            /// <param name="copyEventHandlers"></param>
+            /// <param name="copyClientHandle"></param>
+            private ConditionRefresh(ConditionRefresh item, bool copyEventHandlers,
+                bool copyClientHandle)
+                : base(item, copyEventHandlers, copyClientHandle)
+            {
+                // The refresh-sent flag lives in the base Event and is
+                // intentionally not copied so a cloned item re-issues a refresh
+                // once it is good again to re-establish state.
+            }
+
+            /// <inheritdoc/>
+            public override MonitoredItem CloneMonitoredItem(
+                bool copyEventHandlers, bool copyClientHandle)
+            {
+                return new ConditionRefresh(this, copyEventHandlers, copyClientHandle);
+            }
+
+            /// <inheritdoc/>
+            public override bool Equals(object? obj)
+            {
+                if (obj is not ConditionRefresh item)
+                {
+                    return false;
+                }
+                return base.Equals(item);
+            }
+
+            /// <inheritdoc/>
+            public override int GetHashCode()
+            {
+                return 2035794739 + base.GetHashCode();
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                var str = $"Condition Refresh Item '{Template.StartNodeId}'";
+                if (RemoteId.HasValue)
+                {
+                    str += $" with server id {RemoteId} " +
+                        $"({(Status?.Created == true ? "" : "not ")}created)";
+                }
+                return str;
+            }
+
+            /// <inheritdoc/>
+            protected override bool ProcessEventNotification(DateTimeOffset timestamp,
+                EventFieldList eventFields, MonitoredItemNotifications notifications)
+            {
+                Debug.Assert(Valid);
+                Debug.Assert(Template != null);
+
+                var eventType = GetRefreshEventType(eventFields);
+                if (eventType == ObjectTypeIds.RefreshStartEventType ||
+                    eventType == ObjectTypeIds.RefreshEndEventType)
+                {
+                    // Suppress the refresh envelope markers - only the retained
+                    // condition events emitted between them are forwarded.
+                    return true;
+                }
+                if (eventType == ObjectTypeIds.RefreshRequiredEventType)
+                {
+                    // Re-issue a condition refresh to re-establish correct state.
+                    IssueConditionRefresh();
+                    return true;
+                }
+
+                // Forward everything else as a regular event notification.
+                return base.ProcessEventNotification(timestamp, eventFields, notifications);
+            }
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Event.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Event.cs
@@ -402,6 +402,86 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
             }
 
             /// <summary>
+            /// Whether a subscription wide condition refresh is required for this
+            /// item. A refresh is only required when the item (re-)entered a good
+            /// state since the last refresh was sent. While the item is in a bad
+            /// state the pending flag is reset so that a subsequent transition
+            /// from bad to good triggers a new refresh. This avoids cyclically
+            /// refreshing on every resync when nothing about the item changed.
+            /// </summary>
+            protected bool ConditionRefreshRequired
+            {
+                get
+                {
+                    if (IsBad)
+                    {
+                        // Reset so a future bad to good transition refreshes.
+                        _conditionRefreshSent = false;
+                        return false;
+                    }
+                    return !_conditionRefreshSent;
+                }
+            }
+
+            /// <summary>
+            /// Mark that a subscription wide condition refresh has been completed
+            /// for this item while it was in a good state.
+            /// </summary>
+            protected void MarkConditionRefreshCompleted()
+            {
+                if (IsGood)
+                {
+                    _conditionRefreshSent = true;
+                }
+            }
+
+            /// <summary>
+            /// Return the event type node id of the notification if the configured
+            /// event filter selects it, otherwise null. Used to detect the
+            /// RefreshStart/RefreshEnd/RefreshRequired markers emitted around a
+            /// ConditionRefresh.
+            /// </summary>
+            /// <param name="eventFields"></param>
+            protected NodeId? GetRefreshEventType(EventFieldList eventFields)
+            {
+                var evFilter = Filter as EventFilter;
+                var eventTypeIndex = evFilter?.SelectClauses.IndexOf(
+                    evFilter.SelectClauses
+                        .Find(x => x.TypeDefinitionId == ObjectTypeIds.BaseEventType
+                            && x.BrowsePath?.FirstOrDefault() == BrowseNames.EventType));
+                if (eventTypeIndex.HasValue && eventTypeIndex.Value != -1 &&
+                    eventTypeIndex.Value < eventFields.EventFields.Count)
+                {
+                    return eventFields.EventFields[eventTypeIndex.Value].Value as NodeId;
+                }
+                return null;
+            }
+
+            /// <summary>
+            /// Issue a subscription wide condition refresh so retained conditions
+            /// are (re-)delivered. Failures are logged but not propagated.
+            /// </summary>
+            protected void IssueConditionRefresh()
+            {
+                Debug.Assert(Subscription != null);
+                _logger.IssuingConditionRefresh(this, Template.DisplayName,
+                    Subscription.DisplayName);
+                try
+                {
+                    Subscription.ConditionRefreshAsync(default).GetAwaiter().GetResult(); // TODO
+                    _logger.ConditionRefreshCompleted(this, Template.DisplayName,
+                        Subscription.DisplayName);
+                }
+                catch (Exception e)
+                {
+                    _logger.ConditionRefreshFailed(this, Template.DisplayName,
+                        Subscription.DisplayName, e.Message);
+                }
+            }
+
+            private bool _conditionRefreshSent;
+
+            /// <summary>
             /// Convert to monitored item notifications
             /// </summary>
             /// <param name="eventFields"></param>

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.cs
@@ -286,6 +286,11 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                             yield return new Condition(owner, emi,
                                 factory.CreateLogger<Condition>(), timeProvider);
                         }
+                        else if (emi.ConditionHandling?.RefreshRetainedConditionsOnStart == true)
+                        {
+                            yield return new ConditionRefresh(owner, emi,
+                                factory.CreateLogger<ConditionRefresh>(), timeProvider);
+                        }
                         else
                         {
                             yield return new Event(owner, emi,

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSubscription.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaSubscription.cs
@@ -1560,7 +1560,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
             // RefreshStartEvent/RefreshEndEvent for every subscribed condition.
             //
             var conditionsToRefresh = set
-                .OfType<OpcUaMonitoredItem.Condition>()
+                .OfType<OpcUaMonitoredItem.IConditionRefreshable>()
                 .Where(c => c.IsConditionRefreshRequired)
                 .ToList();
             if (conditionsToRefresh.Count > 0)

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/OpcUaMonitoredItemTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/OpcUaMonitoredItemTests.cs
@@ -319,6 +319,130 @@ namespace Azure.IIoT.OpcUa.Publisher.Tests.Stack
             Assert.True(condition.IsConditionRefreshRequired);
         }
 
+        [Fact]
+        public async Task RefreshOnlyItemIsCreatedWhenRefreshRetainedConditionsOnStartIsSetAsync()
+        {
+            // SnapshotInterval null but the refresh-on-start flag set -> the
+            // lightweight refresh-only item (no snapshotting) is created.
+            var refreshOnly = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel(),
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    RefreshRetainedConditionsOnStart = true
+                }
+            };
+            var refreshItem = await GetMonitoredItemAsync(refreshOnly);
+            Assert.IsType<OpcUaMonitoredItem.ConditionRefresh>(refreshItem);
+            Assert.IsAssignableFrom<OpcUaMonitoredItem.IConditionRefreshable>(refreshItem);
+
+            // SnapshotInterval set -> the snapshotting Condition item (which also
+            // performs the initial refresh) takes precedence.
+            var snapshot = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel(),
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    SnapshotInterval = 10,
+                    RefreshRetainedConditionsOnStart = true
+                }
+            };
+            var snapshotItem = await GetMonitoredItemAsync(snapshot);
+            Assert.IsType<OpcUaMonitoredItem.Condition>(snapshotItem);
+
+            // Neither set -> a plain event item that does not participate in
+            // condition refresh.
+            var plain = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel()
+            };
+            var plainItem = await GetMonitoredItemAsync(plain);
+            Assert.IsType<OpcUaMonitoredItem.Event>(plainItem);
+            Assert.IsNotAssignableFrom<OpcUaMonitoredItem.IConditionRefreshable>(plainItem);
+        }
+
+        [Fact]
+        public async Task RefreshOnlyItemDoesNotAddConditionSnapshotSelectClausesAsync()
+        {
+            // The refresh-only item forwards events normally, so it must not add
+            // the ConditionType NodeId/Retain select clauses that the snapshotting
+            // Condition item adds for its caching logic.
+            var refreshOnly = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel(),
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    RefreshRetainedConditionsOnStart = true
+                }
+            };
+            var refreshItem = await GetMonitoredItemAsync(refreshOnly);
+            var refreshFilter = (EventFilter)refreshItem.Filter;
+
+            var snapshot = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel(),
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    SnapshotInterval = 10
+                }
+            };
+            var snapshotItem = await GetMonitoredItemAsync(snapshot);
+            var snapshotFilter = (EventFilter)snapshotItem.Filter;
+
+            // The snapshotting item adds two extra ConditionType select clauses
+            // (NodeId + Retain); the refresh-only item does not.
+            Assert.Equal(snapshotFilter.SelectClauses.Count - 2, refreshFilter.SelectClauses.Count);
+            Assert.DoesNotContain(refreshFilter.SelectClauses,
+                x => x.TypeDefinitionId == ObjectTypeIds.ConditionType &&
+                    x.BrowsePath?.FirstOrDefault() == "Retain");
+        }
+
+        [Fact]
+        public async Task RefreshOnlyConditionRefreshIsRequiredOnBadToGoodTransitionAsync()
+        {
+            var template = new EventMonitoredItemModel
+            {
+                StartNodeId = "i=2258",
+                EventFilter = new EventFilterModel(),
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    RefreshRetainedConditionsOnStart = true
+                }
+            };
+            var item = await GetMonitoredItemAsync(template)
+                as OpcUaMonitoredItem.ConditionRefresh;
+            Assert.NotNull(item);
+
+            // Not yet created (bad) -> no refresh required.
+            Assert.True(item.IsBad);
+            Assert.False(item.IsConditionRefreshRequired);
+
+            // Item becomes good -> a refresh is required once, and reading the
+            // property again while good is stable.
+            SetCreateResult(item, StatusCodes.Good);
+            Assert.True(item.IsGood);
+            Assert.True(item.IsConditionRefreshRequired);
+            Assert.True(item.IsConditionRefreshRequired);
+
+            // After the refresh completed no more refresh is required while good.
+            item.OnConditionRefreshCompleted();
+            Assert.False(item.IsConditionRefreshRequired);
+
+            // Item goes bad -> no refresh required, and a bad->good transition
+            // requires a refresh again (reconnect case).
+            SetCreateResult(item, StatusCodes.BadNodeIdUnknown);
+            Assert.True(item.IsBad);
+            Assert.False(item.IsConditionRefreshRequired);
+            SetCreateResult(item, StatusCodes.Good);
+            Assert.True(item.IsGood);
+            Assert.True(item.IsConditionRefreshRequired);
+        }
+
         /// <summary>
         /// Drive the underlying stack monitored item status to a created/good
         /// or bad state by invoking the internal SetCreateResult method.

--- a/src/Azure.IIoT.OpcUa/src/Publisher/Extensions/ConditionHandlingOptionsModelEx.cs
+++ b/src/Azure.IIoT.OpcUa/src/Publisher/Extensions/ConditionHandlingOptionsModelEx.cs
@@ -47,6 +47,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Models
             {
                 return false;
             }
+            if (model.RefreshRetainedConditionsOnStart != that.RefreshRetainedConditionsOnStart)
+            {
+                return false;
+            }
             return true;
         }
     }

--- a/src/Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
+++ b/src/Azure.IIoT.OpcUa/src/Publisher/Extensions/OpcNodeModelEx.cs
@@ -239,6 +239,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Config.Models
             hash.Add(model.ModelChangeHandling?.RebrowseIntervalTimespan);
             hash.Add(model.ConditionHandling?.UpdateInterval);
             hash.Add(model.ConditionHandling?.SnapshotInterval);
+            hash.Add(model.ConditionHandling?.RefreshRetainedConditionsOnStart);
             hash.Add(model.UseCyclicRead);
             hash.Add(model.GetNormalizedCyclicReadMaxAge());
             hash.Add(model.RegisterNode);

--- a/src/Azure.IIoT.OpcUa/tests/Publisher/Extensions/OpcNodeModelExTests.cs
+++ b/src/Azure.IIoT.OpcUa/tests/Publisher/Extensions/OpcNodeModelExTests.cs
@@ -117,5 +117,40 @@ namespace Azure.IIoT.OpcUa.Publisher.Config.Models
             Assert.False(comparer.Equals(opcNode1, opcNode2));
             Assert.False(comparer.GetHashCode(opcNode1) == comparer.GetHashCode(opcNode2));
         }
+
+        [Fact]
+        public void ConditionHandlingRefreshRetainedConditionsOnStartAffectsEquality()
+        {
+            var comparer = OpcNodeModelEx.Comparer;
+
+            static OpcNodeModel NewNode(bool? refreshOnStart) => new()
+            {
+                Id = "id",
+                ConditionHandling = new ConditionHandlingOptionsModel
+                {
+                    RefreshRetainedConditionsOnStart = refreshOnStart
+                }
+            };
+
+            // Same value -> equal with matching hash code.
+            var a = NewNode(true);
+            var b = NewNode(true);
+            Assert.True(comparer.Equals(a, b));
+            Assert.True(comparer.GetHashCode(a) == comparer.GetHashCode(b));
+
+            // Different value -> not equal and hash codes differ.
+            var c = NewNode(false);
+            Assert.False(comparer.Equals(a, c));
+            Assert.False(comparer.GetHashCode(a) == comparer.GetHashCode(c));
+
+            // Null vs set -> not equal.
+            var d = NewNode(null);
+            Assert.False(comparer.Equals(a, d));
+
+            // The IsSameAs extension honors the new field directly.
+            Assert.True(a.ConditionHandling.IsSameAs(b.ConditionHandling));
+            Assert.False(a.ConditionHandling.IsSameAs(c.ConditionHandling));
+            Assert.False(a.ConditionHandling.IsSameAs(d.ConditionHandling));
+        }
     }
 }


### PR DESCRIPTION
## Summary
Fixes #2434 (feature part).

The originally reported bug — `ConditionRefresh` not reaching the server — was already resolved in 2.9.14/2.9.15 via the OPC UA stack update (confirmed by the reporter). This PR implements the follow-up **feature** requested in that issue: pull in the alarms/conditions that already exist (are retained) on the server **once** when the subscription starts, without enabling the periodic snapshotting that re-sends the whole cached condition set (which produced the duplicate messages the user did not want).

## What changed
A new opt-in condition-handling mode: **`RefreshRetainedConditionsOnStart`**.

When set on an event's `ConditionHandling` (and `SnapshotInterval` is not set), OPC Publisher issues a single `ConditionRefresh` once the event subscription is established — and again after a reconnect — so retained conditions are delivered **once** as regular `ua-event` messages. Unlike `SnapshotInterval`/`UpdateInterval` it does **not** cache conditions or periodically re-send snapshots, so no duplicate messages are produced.

```json
"ConditionHandling": {
    "RefreshRetainedConditionsOnStart": true
}
```

## Implementation
- **Model:** add `ConditionHandlingOptionsModel.RefreshRetainedConditionsOnStart` (`bool?`); wired through `ConditionHandlingOptionsModelEx.IsSameAs` and `OpcNodeModelEx` hashing. Storage round-trips via the existing `Clone` (no converter change).
- **Stack:** new `OpcUaMonitoredItem.ConditionRefresh` event item and a shared `IConditionRefreshable` contract implemented by both it and the existing `Condition`. `OpcUaSubscription` now issues the one-time refresh for any `IConditionRefreshable` (was hard-typed to `Condition`). Refresh-marker detection and the refresh call are factored into shared `Event` helpers; `RefreshStart`/`RefreshEnd` envelope markers are suppressed and `RefreshRequired` re-issues the refresh.
- **Factory:** `SnapshotInterval != null` → `Condition` (unchanged; snapshotting already performs the initial refresh); else `RefreshRetainedConditionsOnStart == true` → the new refresh-only item; else plain `Event`.
- **Behavior:** the bad→good transition semantics are reused, so a monitored item that drops and re-enters a good state refreshes again (reconnect case). Backward compatible and additive — existing `SnapshotInterval` behavior is untouched.

## Docs
Updated `docs/opc-publisher/readme.md`, `definitions.md`, and `openapi.json`.

## Tests
- Unit (`OpcUaMonitoredItemTests`): factory selection (refresh-only vs `Condition` vs `Event`), bad→good refresh semantics for the refresh-only item, and that it does not add the snapshot ConditionType select clauses.
- Model (`OpcNodeModelExTests`): the new field participates in equality/hash and `IsSameAs`.
- Integration (`BasicSamplesIntegrationTests` against the alarm test server): retained alarms are delivered once through the initial refresh.

## Validation
- Full solution build: 0 errors.
- OpcUa suite 2159/2159, Publisher suite 894/894 (including the new unit tests), existing condition/alarm integration tests 14/14, and the new refresh-only integration test all pass.
