### PR TITLE
Fix CI nuget_pack NU5026 by building before packing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -444,6 +444,16 @@ jobs:
         run: |
           dotnet restore Industrial-IoT.slnx \
             -s https://api.nuget.org/v3/index.json
+      - name: Build solution
+        # Pack does not build the projects when run against the solution
+        # (the packable project outputs would be missing -> NU5026), so build
+        # the Release outputs explicitly before packing with --no-build.
+        shell: bash
+        run: |
+          dotnet build Industrial-IoT.slnx \
+            -c Release \
+            --no-restore \
+            /p:ContinuousIntegrationBuild=true
       - name: Pack solution
         shell: bash
         run: |
@@ -451,6 +461,7 @@ jobs:
             -c Release \
             -o ./nupkgs \
             --no-restore \
+            --no-build \
             /p:ContinuousIntegrationBuild=true
       - name: Validate produced packages
         shell: bash


### PR DESCRIPTION
## Problem
The **Pack NuGet packages** job (`nuget_pack`) has been failing on every `push`/`schedule` run of `ci.yml` (e.g. [run 29491454766](https://github.com/Azure/Industrial-IoT/actions/runs/29491454766/job/87610919794)) with:

```
error NU5026: The file '.../Azure.IIoT.OpcUa.Publisher.Models/src/bin/Release/net10.0/Azure.IIoT.OpcUa.Publisher.Models.dll'
to be packed was not found on disk.
```
(same for `Azure.IIoT.OpcUa.Publisher.Sdk` and `Azure.IIoT.OpcUa.Publisher.Testing.Servers`.)

The job only runs on `push`/`schedule` (`if: github.event_name != 'pull_request'`), so PR CI stayed green while every push/schedule run failed — this is pre-existing and unrelated to recent feature PRs.

## Root cause
The step ran `dotnet pack Industrial-IoT.slnx --no-restore` on a clean checkout. Solution-level `dotnet pack` does **not** build the projects first, so the packable projects' Release assemblies never exist and pack fails with NU5026. Reproduced locally: pack succeeds only when prior Release build output happens to be present, and fails on a clean tree.

## Fix
Add an explicit Release build before packing and pass `--no-build` to pack:

```yaml
- name: Build solution
  run: dotnet build Industrial-IoT.slnx -c Release --no-restore /p:ContinuousIntegrationBuild=true
- name: Pack solution
  run: dotnet pack Industrial-IoT.slnx -c Release -o ./nupkgs --no-restore --no-build /p:ContinuousIntegrationBuild=true
```

## Validation
Verified locally on a clean Release tree (all Release `bin`/`obj` removed): the build succeeds and `dotnet pack --no-build` produces all three expected packages (`Models`, `Sdk`, `Testing.Servers`) plus their `.snupkg` symbols.

> Note: `nuget_pack` is skipped on `pull_request`, so this PR's CI does not exercise the packing path. The fix was validated locally; it will run on the merge `push` to `main`.
