### PR TITLE
Stop watchdog heartbeats from racing the value they wait for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,10 +160,14 @@ jobs:
         # coverlet.msbuild, which crashes the Publisher project run with
         # "Unable to read beyond the end of the stream" during result
         # serialization.
+        #
+        # `Category!=LongRunning` excludes the multi-minute telemetry
+        # quality soak tests; they are run by soak.yml on a schedule.
         shell: pwsh
         run: |
           dotnet test "${{ matrix.project.path }}" --no-build -c Release `
             --blame-hang-timeout 30m --blame-hang-dump-type none `
+            --filter "Category!=LongRunning" `
             --logger "trx;LogFileName=test-results.trx" `
             --results-directory ./testresults/${{ matrix.project.name }} `
             --collect:"XPlat Code Coverage;Format=cobertura"

--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -51,6 +51,16 @@ on:
         required: false
         type: string
         default: '1.4'
+      soak_minutes:
+        description: 'Observation window for the long running telemetry quality tests, in minutes'
+        required: false
+        type: string
+        default: ''
+      soak_nodes:
+        description: 'Number of counter nodes for the long running telemetry quality tests'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -164,6 +174,10 @@ jobs:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           IOT_EDGE_VERSION: ${{ inputs.edge_version }}
+          # Only consumed by the long running telemetry quality tests; empty
+          # values leave the in-code defaults (30 minutes, 100 nodes) in place.
+          IIOT_E2E_SOAK_MINUTES: ${{ inputs.soak_minutes }}
+          IIOT_E2E_SOAK_NODES: ${{ inputs.soak_nodes }}
         run: |
           set -euo pipefail
           mkdir -p e2e-tests/results

--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -144,12 +144,17 @@ jobs:
   # init: compute the resource group name once so every other job uses the
   # same value. <generated> mirrors the internal pipeline's date+counter
   # pattern: e2etesting<YYYYMMDD><run_number>.
+  #
+  # It also derives the job timeout of the telemetry quality soaks from the
+  # configured observation window. GitHub Actions expressions have no
+  # arithmetic operators, so this cannot be done inline in the job's `with:`.
   # --------------------------------------------------------------------------
   init:
     name: Compute run variables
     runs-on: ubuntu-latest
     outputs:
       resource_group_name: ${{ steps.compute.outputs.rg }}
+      soak_timeout_minutes: ${{ steps.compute.outputs.soak_timeout }}
     steps:
       - id: compute
         shell: bash
@@ -164,6 +169,13 @@ jobs:
           fi
           echo "rg=${rg}" >> "$GITHUB_OUTPUT"
           echo "Resource group: ${rg}"
+
+          # Observation window plus headroom for restoring and building the
+          # test solution, deploying the publisher module, creating the
+          # simulation container, warming up and tearing everything down.
+          soak_minutes="${{ inputs.soak_minutes || '30' }}"
+          echo "soak_timeout=$((soak_minutes + 60))" >> "$GITHUB_OUTPUT"
+          echo "Soak job timeout: $((soak_minutes + 60)) minutes"
 
   # --------------------------------------------------------------------------
   # deploy_standalone: deploys the standalone IIoT infrastructure (KeyVault,
@@ -369,9 +381,7 @@ jobs:
       key_vault_name: ${{ needs.deploy_standalone.outputs.key_vault_name }}
       filter_name: PublisherMode
       filter_value: soakcounters
-      # Observation window plus headroom for module deployment, simulation
-      # container creation, warm up and teardown.
-      timeout_minutes: ${{ fromJSON(inputs.soak_minutes || '30') + 60 }}
+      timeout_minutes: ${{ fromJSON(needs.init.outputs.soak_timeout_minutes) }}
       result_label: soak-counters
       image_registry: ${{ inputs.image_registry || 'ghcr.io' }}
       image_namespace: ${{ inputs.image_namespace || 'azure' }}
@@ -396,7 +406,7 @@ jobs:
       key_vault_name: ${{ needs.deploy_standalone.outputs.key_vault_name }}
       filter_name: PublisherMode
       filter_value: soakheartbeat
-      timeout_minutes: ${{ fromJSON(inputs.soak_minutes || '30') + 60 }}
+      timeout_minutes: ${{ fromJSON(needs.init.outputs.soak_timeout_minutes) }}
       result_label: soak-heartbeat
       image_registry: ${{ inputs.image_registry || 'ghcr.io' }}
       image_namespace: ${{ inputs.image_namespace || 'azure' }}

--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -57,6 +57,16 @@ on:
         required: false
         type: string
         default: ''
+      soak_minutes:
+        description: 'Observation window of the long running telemetry quality tests, in minutes'
+        required: false
+        type: string
+        default: '30'
+      soak_nodes:
+        description: 'Number of 2 second counter nodes for the telemetry quality soak'
+        required: false
+        type: string
+        default: '100'
   workflow_dispatch:
     inputs:
       image_tag:
@@ -89,6 +99,16 @@ on:
         required: false
         type: boolean
         default: true
+      soak_minutes:
+        description: 'Observation window of the long running telemetry quality tests, in minutes'
+        required: false
+        type: string
+        default: '30'
+      soak_nodes:
+        description: 'Number of 2 second counter nodes for the telemetry quality soak'
+        required: false
+        type: string
+        default: '100'
 
 permissions:
   id-token: write   # OIDC federation to Azure
@@ -328,12 +348,71 @@ jobs:
     secrets: inherit
 
   # --------------------------------------------------------------------------
+  # run_tests_soak_counters / run_tests_soak_heartbeat: long running telemetry
+  # quality soaks. They depend only on the deploy jobs, NOT on run_tests_ae, so
+  # they run in parallel with the A&E job -- each deploys its own publisher
+  # module into the shared IoT Edge gateway, creates its own OPC PLC simulation
+  # and reads from its own Event Hub consumer group, so nothing is contended.
+  #
+  # The counter soak reproduces the customer configuration (2 s publishing,
+  # sampling and heartbeat interval, queue size > 1, samples encoding) against
+  # nodes that count up every 2 s. A value arrives on every cycle, so the
+  # heartbeat watchdog must never fire and the stream must be complete,
+  # ordered, free of repeats and evenly spaced.
+  # --------------------------------------------------------------------------
+  run_tests_soak_counters:
+    name: Run telemetry quality soak (counters)
+    needs: [init, deploy_standalone, deploy_test_resources]
+    uses: ./.github/workflows/e2e-run-tests.yml
+    with:
+      resource_group_name: ${{ needs.init.outputs.resource_group_name }}
+      key_vault_name: ${{ needs.deploy_standalone.outputs.key_vault_name }}
+      filter_name: PublisherMode
+      filter_value: soakcounters
+      # Observation window plus headroom for module deployment, simulation
+      # container creation, warm up and teardown.
+      timeout_minutes: ${{ fromJSON(inputs.soak_minutes || '30') + 60 }}
+      result_label: soak-counters
+      image_registry: ${{ inputs.image_registry || 'ghcr.io' }}
+      image_namespace: ${{ inputs.image_namespace || 'azure' }}
+      image_tag: ${{ inputs.image_tag || 'latest' }}
+      edge_version: '1.4'
+      soak_minutes: ${{ inputs.soak_minutes || '30' }}
+      soak_nodes: ${{ inputs.soak_nodes || '100' }}
+    secrets: inherit
+
+  # --------------------------------------------------------------------------
+  # The complement: nodes that change only every 2 minutes with a 10 s
+  # heartbeat, so heartbeats must fire. Asserts that they fire at the right
+  # cadence and that they do not produce stale or unevenly spaced values for a
+  # consumer that honours the heartbeat indicator.
+  # --------------------------------------------------------------------------
+  run_tests_soak_heartbeat:
+    name: Run telemetry quality soak (heartbeat)
+    needs: [init, deploy_standalone, deploy_test_resources]
+    uses: ./.github/workflows/e2e-run-tests.yml
+    with:
+      resource_group_name: ${{ needs.init.outputs.resource_group_name }}
+      key_vault_name: ${{ needs.deploy_standalone.outputs.key_vault_name }}
+      filter_name: PublisherMode
+      filter_value: soakheartbeat
+      timeout_minutes: ${{ fromJSON(inputs.soak_minutes || '30') + 60 }}
+      result_label: soak-heartbeat
+      image_registry: ${{ inputs.image_registry || 'ghcr.io' }}
+      image_namespace: ${{ inputs.image_namespace || 'azure' }}
+      image_tag: ${{ inputs.image_tag || 'latest' }}
+      edge_version: '1.4'
+      soak_minutes: ${{ inputs.soak_minutes || '30' }}
+    secrets: inherit
+
+  # --------------------------------------------------------------------------
   # cleanup: always-on resource group teardown. Skip when the operator opts
   # out via the cleanup=false input (for triage of a failed run).
   # --------------------------------------------------------------------------
   cleanup:
     name: Delete resource group
-    needs: [init, deploy_standalone, deploy_test_resources, run_tests_ae, run_tests_basic]
+    needs: [init, deploy_standalone, deploy_test_resources, run_tests_ae, run_tests_basic,
+            run_tests_soak_counters, run_tests_soak_heartbeat]
     if: always() && (inputs.cleanup == null || inputs.cleanup == true) && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,161 @@
+name: Soak
+
+# ----------------------------------------------------------------------------
+# Long running telemetry quality soak.
+#
+# Reproduces the customer scenario of thousands of variables
+# published with a two second publishing interval, a two second sampling
+# interval, a queue size larger than one and a two second heartbeat, in samples
+# encoding. The counter test server makes the expected stream decidable -- every
+# variable counts up from zero by exactly one every update interval, so the
+# value carries its own sequence number and its own expected source timestamp.
+#
+# The run fails when any of the four symptoms the customer reported reappears:
+#   (a) a counter value is lost
+#   (b) a counter goes backwards
+#   (c) two consecutive source timestamps are not one update interval apart
+#   (d) a value is repeated after a newer one was already delivered
+#
+# These tests carry [Trait("Category", "LongRunning")] and are excluded from the
+# pull request build in ci.yml.
+# ----------------------------------------------------------------------------
+
+on:
+  schedule:
+    # Nightly at 02:00 UTC, well clear of the 10:00 UTC CI build.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      nodes:
+        description: 'Number of counter variables to publish'
+        type: string
+        default: '500'
+      minutes:
+        description: 'Minutes of telemetry to analyse per scenario'
+        type: string
+        default: '30'
+      full_scale:
+        description: 'Also run the 3000 node customer scale scenario'
+        type: boolean
+        default: false
+
+concurrency:
+  group: soak-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  PROJECT: src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
+
+jobs:
+  # --------------------------------------------------------------------------
+  # One job per scenario so that a 30 minute analysis window per scenario still
+  # fits comfortably inside the job timeout and the scenarios run in parallel.
+  # --------------------------------------------------------------------------
+  soak:
+    name: Soak (${{ matrix.scenario.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - name: Samples
+            test: SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync
+          - name: PubSub
+            test: PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync
+          - name: QueuedValues
+            test: QueuedValuesArriveCompleteAndInOrderAsync
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+      - name: Restore
+        # Restore against nuget.org explicitly; the repo Nuget.Config points
+        # only at the internal Azure Artifacts feed.
+        run: dotnet restore "$PROJECT" -s https://api.nuget.org/v3/index.json
+        shell: bash
+      - name: Build
+        run: dotnet build "$PROJECT" -c Release --no-restore
+        shell: bash
+      - name: Soak
+        env:
+          IIOT_TELEMETRY_SOAK_NODES: ${{ inputs.nodes || '500' }}
+          IIOT_TELEMETRY_SOAK_MINUTES: ${{ inputs.minutes || '30' }}
+        shell: bash
+        run: |
+          dotnet test "$PROJECT" --no-build -c Release \
+            --blame-hang-timeout 90m --blame-hang-dump-type none \
+            --filter "FullyQualifiedName~${{ matrix.scenario.test }}" \
+            --logger "trx;LogFileName=soak-results.trx" \
+            --logger "console;verbosity=detailed" \
+            --results-directory ./testresults/${{ matrix.scenario.name }} \
+            | tee ./soak-${{ matrix.scenario.name }}.log
+          exit ${PIPESTATUS[0]}
+      - name: Upload soak results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-${{ matrix.scenario.name }}
+          path: |
+            ./testresults
+            ./soak-*.log
+          if-no-files-found: warn
+          retention-days: 30
+
+  # --------------------------------------------------------------------------
+  # The reported scale of three thousand nodes. Opt in only, because hosting the
+  # test server and the publisher side by side at that scale is heavy for a
+  # GitHub hosted runner.
+  # --------------------------------------------------------------------------
+  full_scale:
+    name: Soak (3000 nodes)
+    if: inputs.full_scale
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+      - name: Restore
+        run: dotnet restore "$PROJECT" -s https://api.nuget.org/v3/index.json
+        shell: bash
+      - name: Build
+        run: dotnet build "$PROJECT" -c Release --no-restore
+        shell: bash
+      - name: Soak
+        env:
+          IIOT_TELEMETRY_SOAK_FULLSCALE: '1'
+          IIOT_TELEMETRY_SOAK_MINUTES: ${{ inputs.minutes || '30' }}
+        shell: bash
+        run: |
+          dotnet test "$PROJECT" --no-build -c Release \
+            --blame-hang-timeout 150m --blame-hang-dump-type none \
+            --filter "FullyQualifiedName~CustomerScenarioAtFullScaleAsync" \
+            --logger "trx;LogFileName=soak-results.trx" \
+            --logger "console;verbosity=detailed" \
+            --results-directory ./testresults/FullScale \
+            | tee ./soak-fullscale.log
+          exit ${PIPESTATUS[0]}
+      - name: Upload soak results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: soak-fullscale
+          path: |
+            ./testresults
+            ./soak-*.log
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/opc-publisher/readme.md
+++ b/docs/opc-publisher/readme.md
@@ -753,6 +753,14 @@ A continuous periodic sending of the last known value (`PeriodicLKV`) or last go
 
 The heartbeat behavior `WatchdogLKVDiagnosticsOnly` is special, it allows you to log heartbeat in the diagnostics output without sending heartbeats as part of the outgoing messages.
 
+##### Watchdog grace period
+
+A watchdog heartbeat is only emitted when *no* value was received for the heartbeat interval. The watchdog countdown is restarted whenever a value is received, so it expires exactly one heartbeat interval after that value. The *next* value however can only arrive one publishing interval later, plus the network round trip and the time it takes to process the publish response. Without an allowance for this, a heartbeat interval that is at or below the publishing interval (for example a heartbeat of 2 seconds on a node published every 2 seconds) makes the watchdog win that race on nearly every cycle, and the previous value is re-sent with its now stale `SourceTimestamp`. A consumer sees this as an old value arriving right after a new one, and as a source timestamp cadence broken by zero length gaps.
+
+Because values can only be delivered on publish boundaries, the absence of data cannot be established any earlier than one publishing interval after the heartbeat interval expired. OPC Publisher therefore waits for the heartbeat interval **plus one publishing interval** before it declares a node silent and emits the watchdog heartbeat. The grace period is never longer than the heartbeat interval itself, so a heartbeat configured much shorter than the publishing interval keeps the requested cadence. Once values genuinely stop, the first heartbeat is emitted after this grace period and all following ones follow the configured heartbeat interval.
+
+> This only applies to the `Watchdog*` behaviors. `PeriodicLKV` and `PeriodicLKG` send on a fixed period by design, regardless of whether values are arriving.
+
 ##### Heartbeat indicator
 
 > This feature is in preview

--- a/docs/opc-publisher/troubleshooting.md
+++ b/docs/opc-publisher/troubleshooting.md
@@ -15,6 +15,7 @@ In this document you find information about
   - [Check data arriving in IoT Hub](#check-data-arriving-in-iot-hub)
     - [IoT Hub Metrics](#iot-hub-metrics)
       - [Use Azure IoT Explorer](#use-azure-iot-explorer)
+  - [Duplicated, stale or unevenly spaced values](#duplicated-stale-or-unevenly-spaced-values)
 - [Restart the module](#restart-the-module)
 - [Analyzing network capture files](#analyzing-network-capture-files)
   - [Netcap](#netcap)
@@ -152,6 +153,29 @@ As a next step the Azure IoT Explorer can be used to validate that messages for 
 To view the telemetry of OPC Publisher in Azure IoT Explorer, go to its Telemetry and start monitoring telemetry from that publisher module of choice. If you do not receive any messages for that device after a long period since starting monitoring, then there is a problem which causes telemetry messages not to be delivered to IoT Hub.
 
 ![Azure IoT Explorer](./media/image34.png)
+
+### Duplicated, stale or unevenly spaced values
+
+If a consumer observes any of the following on nodes that are configured with a `HeartbeatInterval`, the cause is almost always the heartbeat and not lost or reordered data:
+
+- the same value arriving twice in a row,
+- an "old" value arriving shortly after a newer one,
+- a `SourceTimestamp` distance of zero between two consecutive messages instead of the expected sampling interval.
+
+A heartbeat re-sends the last known value **including its original `SourceTimestamp`**, so it is indistinguishable from a real value change unless the [heartbeat indicator](./readme.md#heartbeat-indicator) is enabled. The indicator is only part of the *full featured* messaging profiles, so with `--mm=Samples` or `--mm=PubSub` it is not emitted. Use `--mm=FullSamples` or `--mm=FullNetworkMessages` (or `--fm=True`) and drop or specially handle every message that carries `"Heartbeat": true`.
+
+To confirm how many heartbeats are being produced, check the `# Generated Heartbeat Notifications` line of the [diagnostics output](./observability.md) (`ingressHeartbeats`) and compare it with `# Ingress value changes` (`ingressValueChanges`). If the number of heartbeats is of the same order of magnitude as the number of value changes, then heartbeats are firing while data is flowing. Note that OPC Publisher applies a [watchdog grace period](./readme.md#watchdog-grace-period) so that a heartbeat configured at or below the publishing interval does not race the value it is waiting for.
+
+To rule out that values were actually dropped or that the server queue overflowed, check these counters in the same diagnostics output:
+
+| Counter | Meaning when non-zero |
+| --- | --- |
+| `ingressNotificationsDropped` | Notifications were dropped before encoding because the send queue was saturated. Increase `--om` or reduce the load. |
+| `encoderNotificationsDropped` | Notifications could not be encoded, e.g. because of a configuration mismatch. |
+| `outgressInputBufferDropped` | Encoded messages were dropped because the transport could not keep up. |
+| `serverQueueOverflows` | The OPC UA server dropped queued values. Increase `QueueSize` or the publishing interval. |
+
+If all of these are zero, no value was lost inside OPC Publisher.
 
 ## Restart the module
 

--- a/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
+++ b/e2e-tests/OpcPublisher-E2E-Tests/OpcPublisher-AE-E2E-Tests.csproj
@@ -36,6 +36,17 @@
     <ProjectReference Include="..\..\src\Azure.IIoT.OpcUa.Publisher.Sdk\src\Azure.IIoT.OpcUa.Publisher.Sdk.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <!--
+      The telemetry quality validator is shared verbatim with the in process
+      soak tests in src/Azure.IIoT.OpcUa.Publisher.Module/tests. It is linked
+      rather than pulled in through a project reference so that this project
+      does not take a dependency on the publisher or the OPC UA server stack;
+      the file itself only needs System.Text.Json.
+    -->
+    <Compile Include="..\..\src\Azure.IIoT.OpcUa.Publisher.Testing\shared\*.cs"
+             LinkBase="Telemetry" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="opc-plc-files\sc001.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/e2e-tests/OpcPublisher-E2E-Tests/RegistryHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/RegistryHelper.cs
@@ -169,7 +169,12 @@ namespace OpcPublisherAEE2ETests
         {
             // Create base edge deployment.
             var edgeBase = new IoTHubEdgeBaseDeployment(_context);
-            var baseDeploymentResult = await edgeBase.CreateOrUpdateLayeredDeploymentAsync(ct);
+            // The base deployment is shared by every test job targeting this edge
+            // device. Recreating it would restart edgeAgent and edgeHub and with
+            // them the modules of any job running in parallel, so leave an
+            // existing one alone.
+            var baseDeploymentResult = await edgeBase.CreateOrUpdateLayeredDeploymentAsync(
+                ct, replaceExisting: false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _context.OutputHelper.WriteLine("Created/Updated new edge base deployment.");
 
@@ -217,7 +222,12 @@ namespace OpcPublisherAEE2ETests
 
             // Create base edge deployment (idempotent - shared with the default publisher).
             var edgeBase = new IoTHubEdgeBaseDeployment(_context);
-            var baseDeploymentResult = await edgeBase.CreateOrUpdateLayeredDeploymentAsync(ct);
+            // The base deployment is shared by every test job targeting this edge
+            // device. Recreating it would restart edgeAgent and edgeHub and with
+            // them the modules of any job running in parallel, so leave an
+            // existing one alone.
+            var baseDeploymentResult = await edgeBase.CreateOrUpdateLayeredDeploymentAsync(
+                ct, replaceExisting: false);
             Assert.True(baseDeploymentResult, "Failed to create/update new edge base deployment.");
             _context.OutputHelper.WriteLine("Created/Updated new edge base deployment.");
 
@@ -398,9 +408,18 @@ namespace OpcPublisherAEE2ETests
         /// </summary>
         /// <param name="configuration"></param>
         /// <param name="ct"> Cancellation token </param>
+        /// <param name="replaceExisting">
+        /// When false an already existing configuration with the same
+        /// identifier is returned unchanged instead of being recreated.
+        /// <see cref="Configuration"/> has no value equality, so an existing
+        /// configuration always compares as different and would otherwise be
+        /// removed and re-added on every call - which restarts the modules of
+        /// any test job running against the same edge device in parallel.
+        /// </param>
         public async Task<Configuration> CreateOrUpdateConfigurationAsync(
             Configuration configuration,
-            CancellationToken ct = default
+            CancellationToken ct = default,
+            bool replaceExisting = true
         )
         {
             try
@@ -417,6 +436,13 @@ namespace OpcPublisherAEE2ETests
                     }
                     catch (DeviceAlreadyExistsException)
                     {
+                        if (!replaceExisting)
+                        {
+                            // Another job created it concurrently - use theirs.
+                            _context.OutputHelper.WriteLine(
+                                "IoT Hub device configuration was created concurrently, reusing it");
+                            return await RegistryManager.GetConfigurationAsync(configuration.Id, ct).ConfigureAwait(false);
+                        }
                         // Technically update below should now work but for some reason it does not.
                         // Remove and re-add in case we are forcing updates.
                         _context.OutputHelper.WriteLine("IoT Hub device configuration already existed, remove and recreate it");
@@ -425,7 +451,7 @@ namespace OpcPublisherAEE2ETests
                     }
                 }
 
-                if (Equals(configuration, getConfig))
+                if (!replaceExisting || Equals(configuration, getConfig))
                 {
                     return getConfig;
                 }

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityCountersTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityCountersTestTheory.cs
@@ -1,0 +1,197 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace OpcPublisherAEE2ETests.Standalone
+{
+    using OpcPublisherAEE2ETests.TestExtensions;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// <para>
+    /// Long running end to end validation of the customer configuration on a
+    /// publisher module deployed to IoT Edge: publishing interval, sampling
+    /// interval and heartbeat interval all two seconds, queue size larger than
+    /// one, samples encoding, against OPC PLC nodes that count up by exactly
+    /// one every two seconds.
+    /// </para>
+    /// <para>
+    /// Because a fresh value arrives on every publish cycle the heartbeat
+    /// watchdog must never fire. Before the watchdog grace period was
+    /// introduced it fired on roughly six out of ten cycles and re-sent the
+    /// previous value with its now stale source timestamp, which a consumer
+    /// saw as an old value arriving right after a new one and as a source
+    /// timestamp cadence broken by zero length gaps.
+    /// </para>
+    /// <para>
+    /// The counter value is its own sequence number, so a lost value shows up
+    /// as a gap, a reordered value as a decrease, and the expected source
+    /// timestamp distance is exactly one update interval.
+    /// </para>
+    /// </summary>
+    [TestCaseOrderer(TestCaseOrderer.FullName, TestConstants.TestAssemblyName)]
+    [Trait(TestConstants.TraitConstants.PublisherModeTraitName,
+        TestConstants.TraitConstants.PublisherModeSoakCountersTraitValue)]
+    public sealed class FTelemetryQualityCountersTestTheory : SoakTestBase,
+        IClassFixture<IIoTStandaloneTestContext>
+    {
+        public FTelemetryQualityCountersTestTheory(IIoTStandaloneTestContext context,
+            ITestOutputHelper output)
+            : base(context, output, kModuleName, kDeploymentName,
+                TestConstants.SoakCountersConsumerGroupName)
+        {
+        }
+
+        [Fact, PriorityOrder(0)]
+        public async Task TestDeployPublisher()
+        {
+            await DeployPublisherAsync();
+        }
+
+        [Fact, PriorityOrder(1)]
+        public async Task TestTelemetryStreamIsCompleteOrderedAndFreeOfHeartbeatsAsync()
+        {
+            var nodeCount = TestConstants.Soak.FastNodeCount;
+            var updateInterval = TestConstants.Soak.FastUpdateInterval;
+
+            // Arrange - an OPC PLC whose fast nodes count up every two seconds.
+            // The slow node family is left at its default and simply not
+            // subscribed to; passing --sn=0 would rely on the simulator
+            // accepting a zero node count, and a rejected command line fails
+            // the whole container.
+            await TestHelper.CreateSimulationContainerAsync(Context, new List<string>
+            {
+                "/bin/sh", "-c", string.Join(' ',
+                    "./opcplc", "--autoaccept", "--pn=50000",
+                    $"--fn={nodeCount}",
+                    $"--fr={(int)updateInterval.TotalSeconds}",
+                    "--ft=uint")
+            }, TimeoutToken, nameDiscriminator: kSimulationName,
+                cpuCores: 2.0, memoryInGB: 4.0);
+
+            // Act - publish every fast node with the customer configuration.
+            var nodeIds = Enumerable.Range(1, nodeCount)
+                .Select(TestConstants.Soak.FastNodeId);
+            await PublishNodesAsync(
+                PublishedNodes(nodeIds, TestConstants.Soak.FastHeartbeatInterval),
+                TimeoutToken);
+
+            var report = await ObserveAsync(new TelemetryQualityOptions
+            {
+                UpdateInterval = updateInterval,
+                ExpectedNodeCount = nodeCount,
+                //
+                // OPC PLC derives its source timestamps from a wall clock
+                // simulation timer, so the spacing is approximate. Half the
+                // update interval is still far tighter than the zero length
+                // gap a spurious heartbeat produces.
+                //
+                Tolerance = TimeSpan.FromSeconds(1),
+                HeartbeatInterval = TestConstants.Soak.FastHeartbeatInterval,
+                PublishingInterval = TestConstants.Soak.PublishingInterval
+            }, WarmupFor(nodeCount));
+
+            // Assert
+            Assert.True(report.TotalSamples > 0, "No telemetry arrived at all.");
+            Assert.True(report.NodesMissing == 0,
+                $"{report.NodesMissing} node(s) never reported.{Environment.NewLine}{report}");
+
+            //
+            // Correctness assertions. None of these can be caused by timing
+            // jitter on shared infrastructure, so they are strict.
+            //
+
+            // (a) no value the customer expects is lost
+            Assert.True(report.MissingValues == 0,
+                $"{report.MissingValues} value(s) were lost.{Environment.NewLine}{report}");
+
+            // (b) values never go backwards
+            Assert.True(report.OutOfOrderValues == 0,
+                $"{report.OutOfOrderValues} value(s) arrived out of order." +
+                $"{Environment.NewLine}{report}");
+            Assert.True(report.OutOfOrderIncludingHeartbeats == 0,
+                $"{report.OutOfOrderIncludingHeartbeats} message(s) carried a value older " +
+                $"than one already delivered.{Environment.NewLine}{report}");
+
+            // (d) a repeat, if any, always says that it is a heartbeat
+            Assert.True(report.UnflaggedRepeats == 0,
+                $"{report.UnflaggedRepeats} value(s) were repeated without the heartbeat " +
+                $"indicator.{Environment.NewLine}{report}");
+
+            Assert.True(report.SamplesWithoutSourceTimestamp == 0,
+                $"{report.SamplesWithoutSourceTimestamp} message(s) had no source " +
+                $"timestamp.{Environment.NewLine}{report}");
+
+            //
+            // Timing assertions. A real deployment can stall briefly - the
+            // simulator derives its source timestamps from a wall clock timer
+            // and shares a two vCPU edge VM and an IoT Hub with the other
+            // test jobs - so these carry a small budget instead of demanding
+            // a perfect run. The regression being guarded here produced a
+            // heartbeat on roughly six out of ten cycles, so a budget of one
+            // percent still catches it with a sixty fold margin.
+            //
+            AssertWithinBudget(report.HeartbeatSamples, report.ValueSamples,
+                "heartbeat(s) were emitted although a value arrived on every publish cycle",
+                report);
+            AssertWithinBudget(report.RepeatedValues, report.ValueSamples,
+                "message(s) repeated an already delivered value", report);
+            AssertWithinBudget(report.ValueIntervalViolations, report.ValueSamples,
+                $"value(s) were not {updateInterval} apart from their predecessor", report);
+            AssertWithinBudget(report.MessageIntervalViolations, report.ValueSamples,
+                "message(s) broke the expected source timestamp cadence", report);
+        }
+
+        /// <summary>
+        /// Assert that an observation stayed inside a small fraction of the
+        /// total, so an occasional hiccup on shared infrastructure does not
+        /// fail the run while a systematic defect still does.
+        /// </summary>
+        /// <param name="observed"></param>
+        /// <param name="total"></param>
+        /// <param name="what"></param>
+        /// <param name="report"></param>
+        private static void AssertWithinBudget(long observed, long total, string what,
+            TelemetryQualityReport report)
+        {
+            var budget = Math.Max(kMinimumBudget, total / 100);
+            Assert.True(observed <= budget,
+                $"{observed} {what}, which exceeds the budget of {budget} " +
+                $"(1% of {total} value samples).{Environment.NewLine}{report}");
+        }
+
+        [Fact, PriorityOrder(998)]
+        public async Task TestCleanup()
+        {
+            await UnpublishAllNodesAsync(TimeoutToken);
+            await CleanupAsync();
+        }
+
+        /// <summary>
+        /// Time given to the publisher to create every monitored item and to
+        /// let the first values settle before the stream is analysed.
+        /// </summary>
+        /// <param name="nodeCount"></param>
+        private static TimeSpan WarmupFor(int nodeCount)
+        {
+            return TimeSpan.FromMinutes(1) + TimeSpan.FromMilliseconds(20 * nodeCount);
+        }
+
+        private const string kModuleName = "publisher_soak_fast";
+        private const string kDeploymentName = "__default-opcpublisher-soak-fast";
+        private const string kSimulationName = "soakfast";
+
+        /// <summary>
+        /// Smallest budget granted regardless of stream size, so a short run
+        /// is not failed by a single hiccup.
+        /// </summary>
+        private const int kMinimumBudget = 5;
+    }
+}

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityHeartbeatTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityHeartbeatTestTheory.cs
@@ -1,0 +1,217 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace OpcPublisherAEE2ETests.Standalone
+{
+    using OpcPublisherAEE2ETests.TestExtensions;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// <para>
+    /// The complement of
+    /// <see cref="FTelemetryQualityCountersTestTheory"/>: nodes that change
+    /// only every two minutes while the publisher is configured with a ten
+    /// second heartbeat. Here heartbeats <em>must</em> fire - that is the
+    /// whole point of the feature - and this test proves that the watchdog
+    /// grace period did not break them.
+    /// </para>
+    /// <para>
+    /// It also proves that firing heartbeats do not reproduce the two symptoms
+    /// the customer reported. A heartbeat legitimately resends the last value
+    /// with its original source timestamp, so a consumer that ignores the
+    /// heartbeat indicator sees a repeated value and a zero length source
+    /// timestamp gap. What must hold is that
+    /// </para>
+    /// <list type="bullet">
+    /// <item>every repeat carries the <c>Heartbeat</c> indicator, so a
+    /// consumer can filter them out,</item>
+    /// <item>a heartbeat never carries a value or a timestamp older than one
+    /// already delivered, and</item>
+    /// <item>with heartbeats excluded, the real value stream is still
+    /// complete, ordered and exactly two minutes apart.</item>
+    /// </list>
+    /// </summary>
+    [TestCaseOrderer(TestCaseOrderer.FullName, TestConstants.TestAssemblyName)]
+    [Trait(TestConstants.TraitConstants.PublisherModeTraitName,
+        TestConstants.TraitConstants.PublisherModeSoakHeartbeatTraitValue)]
+    public sealed class FTelemetryQualityHeartbeatTestTheory : SoakTestBase,
+        IClassFixture<IIoTStandaloneTestContext>
+    {
+        public FTelemetryQualityHeartbeatTestTheory(IIoTStandaloneTestContext context,
+            ITestOutputHelper output)
+            : base(context, output, kModuleName, kDeploymentName,
+                TestConstants.SoakHeartbeatConsumerGroupName)
+        {
+            _output = output;
+        }
+
+        [Fact, PriorityOrder(0)]
+        public async Task TestDeployPublisher()
+        {
+            await DeployPublisherAsync();
+        }
+
+        [Fact, PriorityOrder(1)]
+        public async Task TestHeartbeatsFireWithoutProducingStaleOrUnevenlySpacedValuesAsync()
+        {
+            var nodeCount = TestConstants.Soak.SlowNodeCount;
+            var updateInterval = TestConstants.Soak.SlowUpdateInterval;
+            var heartbeatInterval = TestConstants.Soak.SlowHeartbeatInterval;
+
+            // Arrange - an OPC PLC whose slow nodes count up every two minutes.
+            // The fast node family is left at its default and simply not
+            // subscribed to.
+            await TestHelper.CreateSimulationContainerAsync(Context, new List<string>
+            {
+                "/bin/sh", "-c", string.Join(' ',
+                    "./opcplc", "--autoaccept", "--pn=50000",
+                    $"--sn={nodeCount}",
+                    $"--sr={(int)updateInterval.TotalSeconds}",
+                    "--st=uint")
+            }, TimeoutToken, nameDiscriminator: kSimulationName,
+                cpuCores: 1.0, memoryInGB: 1.5);
+
+            // Act
+            var nodeIds = Enumerable.Range(1, nodeCount)
+                .Select(TestConstants.Soak.SlowNodeId);
+            await PublishNodesAsync(PublishedNodes(nodeIds, heartbeatInterval), TimeoutToken);
+
+            var report = await ObserveAsync(new TelemetryQualityOptions
+            {
+                UpdateInterval = updateInterval,
+                ExpectedNodeCount = nodeCount,
+                //
+                // OPC PLC derives its source timestamps from a wall clock
+                // simulation timer, so over a two minute cycle a few seconds
+                // of drift are expected and harmless.
+                //
+                Tolerance = TimeSpan.FromSeconds(5),
+                HeartbeatInterval = heartbeatInterval,
+                PublishingInterval = TestConstants.Soak.PublishingInterval,
+                HeartbeatTolerance = TimeSpan.FromSeconds(5)
+            }, kWarmup);
+
+            // Assert
+            Assert.True(report.TotalSamples > 0, "No telemetry arrived at all.");
+            Assert.True(report.NodesMissing == 0,
+                $"{report.NodesMissing} node(s) never reported.{Environment.NewLine}{report}");
+
+            //
+            // Heartbeats have to fire, on every node. Values arrive every
+            // update interval and the watchdog waits one heartbeat interval
+            // plus one publishing interval before declaring the node silent,
+            // so this many heartbeats fit between two value changes. Half of
+            // the resulting expectation is required, which still fails
+            // decisively if heartbeats stopped firing while tolerating a
+            // window that does not start and end on a value boundary.
+            //
+            var earliestHeartbeat = heartbeatInterval + TestConstants.Soak.PublishingInterval;
+            var perValueChange = (int)((updateInterval - earliestHeartbeat) / heartbeatInterval);
+            var valueChanges = (int)(Duration / updateInterval);
+            var expectedHeartbeats = Math.Max(1, valueChanges * perValueChange);
+            var minimumHeartbeats = Math.Max(1, expectedHeartbeats / 2);
+            _output.WriteLine($"Expecting at least {minimumHeartbeats} heartbeat(s) per node " +
+                $"({valueChanges} value change(s) x {perValueChange} heartbeat(s), halved).");
+            Assert.True(report.MinHeartbeatsPerNode >= minimumHeartbeats,
+                $"Expected at least {minimumHeartbeats} heartbeat(s) on every node but the " +
+                $"quietest node produced {report.MinHeartbeatsPerNode}." +
+                $"{Environment.NewLine}{report}");
+
+            //
+            // Correctness assertions - unaffected by timing jitter.
+            //
+
+            // (d) a repeat is only ever a heartbeat, and it says so.
+            Assert.True(report.UnflaggedRepeats == 0,
+                $"{report.UnflaggedRepeats} value(s) were repeated without the heartbeat " +
+                $"indicator, so a consumer cannot tell them apart from real data." +
+                $"{Environment.NewLine}{report}");
+
+            // (d) nothing older than what was already delivered is ever sent.
+            Assert.True(report.OutOfOrderIncludingHeartbeats == 0,
+                $"{report.OutOfOrderIncludingHeartbeats} message(s) carried a value older " +
+                $"than one already delivered.{Environment.NewLine}{report}");
+            Assert.True(report.HeartbeatsWithChangedTimestamp == 0,
+                $"{report.HeartbeatsWithChangedTimestamp} heartbeat(s) altered the source " +
+                $"timestamp of the value they resend.{Environment.NewLine}{report}");
+
+            // (a)/(b) the real value stream is unaffected by the heartbeats.
+            Assert.True(report.MissingValues == 0,
+                $"{report.MissingValues} value(s) were lost.{Environment.NewLine}{report}");
+            Assert.True(report.OutOfOrderValues == 0,
+                $"{report.OutOfOrderValues} value(s) arrived out of order." +
+                $"{Environment.NewLine}{report}");
+            Assert.True(report.SamplesWithoutSourceTimestamp == 0,
+                $"{report.SamplesWithoutSourceTimestamp} message(s) had no source " +
+                $"timestamp.{Environment.NewLine}{report}");
+
+            //
+            // Timing assertions carry a small budget: the simulator derives
+            // its source timestamps from a wall clock timer and shares the
+            // edge VM and IoT Hub with the other test jobs.
+            //
+
+            // Heartbeats must never arrive before the watchdog grace period.
+            AssertWithinBudget(report.EarlyHeartbeats, report.HeartbeatSamples,
+                "heartbeat(s) arrived before the watchdog grace period elapsed", report);
+
+            // ... and must keep the configured cadence once they do.
+            AssertWithinBudget(report.HeartbeatCadenceViolations, report.HeartbeatSamples,
+                $"gap(s) between consecutive heartbeats did not match the configured " +
+                $"{heartbeatInterval}", report);
+
+            // (c) the real value stream stays exactly one update interval apart.
+            AssertWithinBudget(report.ValueIntervalViolations, report.ValueSamples,
+                $"value(s) were not {updateInterval} apart from their predecessor", report);
+        }
+
+        /// <summary>
+        /// Assert that an observation stayed inside a small fraction of the
+        /// total, so an occasional hiccup on shared infrastructure does not
+        /// fail the run while a systematic defect still does.
+        /// </summary>
+        /// <param name="observed"></param>
+        /// <param name="total"></param>
+        /// <param name="what"></param>
+        /// <param name="report"></param>
+        private static void AssertWithinBudget(long observed, long total, string what,
+            TelemetryQualityReport report)
+        {
+            var budget = Math.Max(kMinimumBudget, total / 100);
+            Assert.True(observed <= budget,
+                $"{observed} {what}, which exceeds the budget of {budget} " +
+                $"(1% of {total}).{Environment.NewLine}{report}");
+        }
+
+        [Fact, PriorityOrder(998)]
+        public async Task TestCleanup()
+        {
+            await UnpublishAllNodesAsync(TimeoutToken);
+            await CleanupAsync();
+        }
+
+        /// <summary>
+        /// One full value cycle of warm up, so the analysed window starts with
+        /// every node having reported at least once and the heartbeat watchdog
+        /// already armed.
+        /// </summary>
+        private static readonly TimeSpan kWarmup = TimeSpan.FromMinutes(3);
+        private const string kModuleName = "publisher_soak_slow";
+        private const string kDeploymentName = "__default-opcpublisher-soak-slow";
+        private const string kSimulationName = "soakslow";
+
+        /// <summary>
+        /// Smallest budget granted regardless of stream size.
+        /// </summary>
+        private const int kMinimumBudget = 5;
+        private readonly ITestOutputHelper _output;
+    }
+}

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/SoakTestBase.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/SoakTestBase.cs
@@ -1,0 +1,343 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace OpcPublisherAEE2ETests.Standalone
+{
+    using OpcPublisherAEE2ETests.Deploy;
+    using OpcPublisherAEE2ETests.TestExtensions;
+    using Azure.IIoT.OpcUa.Publisher.Models;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
+    using Azure.Messaging.EventHubs.Consumer;
+    using Furly.Extensions.Serializers;
+    using Furly.Extensions.Serializers.Newtonsoft;
+    using Microsoft.Azure.Devices;
+    using Newtonsoft.Json.Linq;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// <para>
+    /// Base class for the long running telemetry quality tests. Each derived
+    /// scenario deploys its <em>own</em> OPC Publisher module into the shared
+    /// IoT Edge gateway and creates its <em>own</em> OPC PLC simulation, so
+    /// the scenarios can run in parallel with each other and with the A&amp;E
+    /// tests without contending for the published nodes file, the pki store,
+    /// the simulation server or the event hub consumer group.
+    /// </para>
+    /// <para>
+    /// Reusing the deployed resource group, IoT Hub and edge VM rather than
+    /// standing up a second set is deliberate: the code under test is the
+    /// publisher module, and duplicating the (slow, expensive) infrastructure
+    /// would add cost and cleanup risk without adding coverage.
+    /// </para>
+    /// </summary>
+    public abstract class SoakTestBase : IDisposable
+    {
+        /// <summary>
+        /// Shared test context
+        /// </summary>
+        protected IIoTStandaloneTestContext Context { get; }
+
+        /// <summary>
+        /// Cancellation for the whole scenario
+        /// </summary>
+        protected CancellationToken TimeoutToken { get; }
+
+        /// <summary>
+        /// Deployment of this scenario's publisher module
+        /// </summary>
+        protected IoTHubPublisherDeployment Deployment { get; }
+
+        /// <summary>
+        /// Writer id used to configure and recognize this scenario's data
+        /// </summary>
+        protected string WriterId { get; }
+
+        /// <summary>
+        /// How long telemetry is observed after the warm up
+        /// </summary>
+        protected static TimeSpan Duration => TestConstants.Soak.Duration;
+
+        /// <summary>
+        /// Create the scenario
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="output"></param>
+        /// <param name="moduleName">Module identity of this scenario's publisher</param>
+        /// <param name="deploymentName">Layered deployment name, must be unique</param>
+        /// <param name="consumerGroup">Dedicated event hub consumer group</param>
+        protected SoakTestBase(IIoTStandaloneTestContext context, ITestOutputHelper output,
+            string moduleName, string deploymentName, string consumerGroup)
+        {
+            Context = context ?? throw new ArgumentNullException(nameof(context));
+            Context.SetOutputHelper(output);
+            _output = output;
+
+            //
+            // The default ten minute test timeout cannot bound a soak. Allow
+            // the observation window plus enough headroom for deploying the
+            // module, creating the simulation container and tearing both down.
+            //
+            _timeoutTokenSource = new CancellationTokenSource(Duration + kOverhead);
+            TimeoutToken = _timeoutTokenSource.Token;
+
+            WriterId = Guid.NewGuid().ToString();
+            _serializer = new NewtonsoftJsonSerializer();
+            _consumer = Context.GetEventHubConsumerClient(consumerGroup);
+
+            Deployment = new IoTHubPublisherDeployment(Context,
+                OpcPublisherAEE2ETests.MessagingMode.Samples,
+                moduleName: moduleName,
+                deploymentName: deploymentName,
+                publishedNodesFile: TestConstants.PublishedNodesFolder + "/published_nodes_" + moduleName + ".json",
+                pkiPath: TestConstants.PublishedNodesFolder + "/pki_" + moduleName,
+                createFileIfNotExist: true);
+
+            _iotHubClient = TestHelper.DeviceServiceClient(
+                Context.IoTHubConfig.IoTHubConnectionString,
+                Microsoft.Azure.Devices.TransportType.Amqp_WebSocket_Only);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <inheritdoc/>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _consumer?.CloseAsync(CancellationToken.None).GetAwaiter().GetResult();
+                _consumer?.DisposeAsync().AsTask().GetAwaiter().GetResult();
+                _iotHubClient?.Dispose();
+                _timeoutTokenSource?.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Deploy this scenario's publisher module and wait until it serves
+        /// direct methods.
+        /// </summary>
+        protected async Task DeployPublisherAsync()
+        {
+            await Context.RegistryHelper.DeployStandalonePublisherAsync(
+                Deployment, TimeoutToken).ConfigureAwait(false);
+
+            //
+            // Reaching IoT Hub "Connected" state does not guarantee the freshly
+            // deployed module is ready to serve direct methods: its handlers
+            // and configuration services may still be initializing.
+            //
+            await WaitUntilPublisherReadyAsync(TimeoutToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Build the published nodes configuration for a set of counter nodes.
+        /// </summary>
+        /// <param name="nodeIds">Node ids to publish</param>
+        /// <param name="heartbeatInterval">Heartbeat interval</param>
+        protected string PublishedNodes(IEnumerable<string> nodeIds, TimeSpan heartbeatInterval)
+        {
+            var nodes = new JArray();
+            foreach (var nodeId in nodeIds)
+            {
+                nodes.Add(new JObject(
+                    new JProperty("Id", nodeId),
+                    new JProperty("OpcPublishingInterval",
+                        (int)TestConstants.Soak.PublishingInterval.TotalMilliseconds),
+                    new JProperty("OpcSamplingInterval",
+                        (int)TestConstants.Soak.PublishingInterval.TotalMilliseconds),
+                    new JProperty("HeartbeatInterval", (int)heartbeatInterval.TotalSeconds),
+                    new JProperty("QueueSize", TestConstants.Soak.QueueSize)));
+            }
+            return Context.PublishedNodesJson(TestConstants.OpcSimulation.Port, WriterId, nodes);
+        }
+
+        /// <summary>
+        /// Observe the telemetry of this scenario's publisher module and feed
+        /// it into a validator.
+        /// </summary>
+        /// <param name="options">Validator configuration</param>
+        /// <param name="warmup">
+        /// Time given to the publisher to create all monitored items and to
+        /// settle before the stream is analysed.
+        /// </param>
+        protected async Task<TelemetryQualityReport> ObserveAsync(
+            TelemetryQualityOptions options, TimeSpan warmup)
+        {
+            var validator = new TelemetryQualityValidator(options);
+            var stopWatch = Stopwatch.StartNew();
+            var total = await _consumer.ConsumeAsync(Deployment.ModuleName, warmup + Duration,
+                message =>
+                {
+                    if (stopWatch.Elapsed < warmup)
+                    {
+                        return;
+                    }
+                    validator.AddSamplesMessage(message);
+                },
+                onFirstMessage: json => _output.WriteLine("First message:" +
+                    Environment.NewLine + json),
+                TimeoutToken).ConfigureAwait(false);
+
+            var report = validator.CreateReport();
+            _output.WriteLine(string.Create(CultureInfo.InvariantCulture,
+                $"--- {Deployment.ModuleName}: {total} message(s), {warmup} warm up, " +
+                $"{Duration} analysed ---"));
+            _output.WriteLine(report.ToString());
+            return report;
+        }
+
+        /// <summary>
+        /// Remove this scenario's simulation container and layered deployment.
+        /// </summary>
+        protected async Task CleanupAsync()
+        {
+            await TestHelper.DeleteSimulationContainerAsync(Context, TimeoutToken)
+                .ConfigureAwait(false);
+            await Deployment.DeleteLayeredDeploymentAsync(TimeoutToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Publish the given configuration through direct methods.
+        /// </summary>
+        /// <param name="json"></param>
+        /// <param name="ct"></param>
+        protected async Task PublishNodesAsync(string json, CancellationToken ct)
+        {
+            await UnpublishAllNodesAsync(ct).ConfigureAwait(false);
+            var entries = _serializer.Deserialize<PublishedNodesEntryModel[]>(json);
+            foreach (var entry in entries)
+            {
+                var result = await CallMethodAsync(
+                    new MethodParameterModel
+                    {
+                        Name = TestConstants.DirectMethodNames.PublishNodes,
+                        JsonPayload = _serializer.SerializeToString(entry)
+                    }, ct).ConfigureAwait(false);
+
+                await AssertMethodStatusOkAsync(result, "PublishNodes", ct).ConfigureAwait(false);
+            }
+
+            var configured = await CallMethodAsync(
+                new MethodParameterModel
+                {
+                    Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                }, ct).ConfigureAwait(false);
+
+            await AssertMethodStatusOkAsync(configured, "GetConfiguredEndpoints", ct)
+                .ConfigureAwait(false);
+            var response = _serializer.Deserialize<GetConfiguredEndpointsResponseModel>(
+                configured.JsonPayload);
+            Assert.Equal(entries.Length, response.Endpoints.Count);
+        }
+
+        /// <summary>
+        /// Remove all configuration from this scenario's publisher.
+        /// </summary>
+        /// <param name="ct"></param>
+        protected async Task UnpublishAllNodesAsync(CancellationToken ct = default)
+        {
+            MethodResultModel result = null;
+            for (var i = 0; i < 5; i++)
+            {
+                result = await CallMethodAsync(
+                    new MethodParameterModel
+                    {
+                        Name = TestConstants.DirectMethodNames.UnpublishAllNodes,
+                        JsonPayload = "null"
+                    }, ct).ConfigureAwait(false);
+
+                if (result.Status == 405)
+                {
+                    // Retry if method not yet mounted
+                    Context.OutputHelper?.WriteLine(result.JsonPayload);
+                    await Task.Delay(TestConstants.DefaultDelayMilliseconds, ct)
+                        .ConfigureAwait(false);
+                    continue;
+                }
+                break;
+            }
+            await AssertMethodStatusOkAsync(result, "UnpublishAllNodes", ct).ConfigureAwait(false);
+        }
+
+        private async Task<MethodResultModel> CallMethodAsync(MethodParameterModel parameters,
+            CancellationToken ct)
+        {
+            return await TestHelper.CallMethodAsync(_iotHubClient,
+                Context.DeviceConfig.DeviceId, Deployment.ModuleName, parameters,
+                Context, ct).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Poll a benign read-only direct method until the module answers.
+        /// </summary>
+        /// <param name="ct"></param>
+        private async Task WaitUntilPublisherReadyAsync(CancellationToken ct)
+        {
+            while (true)
+            {
+                var result = await CallMethodAsync(
+                    new MethodParameterModel
+                    {
+                        Name = TestConstants.DirectMethodNames.GetConfiguredEndpoints
+                    }, ct).ConfigureAwait(false);
+
+                if (result.Status == (int)HttpStatusCode.OK)
+                {
+                    return;
+                }
+
+                Context.OutputHelper?.WriteLine(
+                    $"Publisher {Deployment.ModuleName} not ready yet " +
+                    $"(status {result.Status}), retrying...");
+                await Task.Delay(TestConstants.DefaultDelayMilliseconds, ct).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Assert a direct method succeeded, dumping the module logs on failure
+        /// so the server side exception is visible without another billable
+        /// end to end cycle.
+        /// </summary>
+        /// <param name="result"></param>
+        /// <param name="methodName"></param>
+        /// <param name="ct"></param>
+        private async Task AssertMethodStatusOkAsync(MethodResultModel result,
+            string methodName, CancellationToken ct)
+        {
+            if (result?.Status != (int)HttpStatusCode.OK)
+            {
+                var logs = await TestHelper.GetModuleLogsAsync(
+                    Context, Deployment.ModuleName, ct: ct).ConfigureAwait(false);
+                Context.OutputHelper?.WriteLine(
+                    $"{methodName} failed with status {result?.Status}: {result?.JsonPayload}" +
+                    $"{Environment.NewLine}=== {Deployment.ModuleName} module logs ==={Environment.NewLine}{logs}");
+            }
+            Assert.Equal((int)HttpStatusCode.OK, result?.Status);
+        }
+
+        /// <summary>
+        /// Headroom on top of the observation window for deploying the module,
+        /// creating the simulation container and tearing both down again.
+        /// </summary>
+        private static readonly TimeSpan kOverhead = TimeSpan.FromMinutes(45);
+        private readonly ITestOutputHelper _output;
+        private readonly ISerializer _serializer;
+        private readonly ServiceClient _iotHubClient;
+        private readonly EventHubConsumerClient _consumer;
+        private readonly CancellationTokenSource _timeoutTokenSource;
+    }
+}

--- a/e2e-tests/OpcPublisher-E2E-Tests/TestConstants.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestConstants.cs
@@ -5,6 +5,9 @@
 
 namespace OpcPublisherAEE2ETests
 {
+    using System;
+    using System.Globalization;
+
     /// <summary>
     /// Contains constants using for End 2 End testing
     /// </summary>
@@ -60,6 +63,135 @@ namespace OpcPublisherAEE2ETests
         /// IoT Hub Event Hubs endpoint consumer group for tests
         /// </summary>
         public const string TestConsumerGroupName = "TestConsumer";
+
+        /// <summary>
+        /// <para>
+        /// Dedicated IoT Hub Event Hubs consumer groups for the long running
+        /// telemetry quality tests.
+        /// </para>
+        /// <para>
+        /// They run in parallel with the A&amp;E job and with each other, and
+        /// each of them keeps a reader open on every partition for the whole
+        /// observation window. The built-in endpoint permits five concurrent
+        /// readers per partition and per consumer group, so giving each soak
+        /// its own group keeps them clear of that budget and of each other.
+        /// </para>
+        /// </summary>
+        public const string SoakCountersConsumerGroupName = "SoakCounters";
+
+        /// <inheritdoc cref="SoakCountersConsumerGroupName"/>
+        public const string SoakHeartbeatConsumerGroupName = "SoakHeartbeat";
+
+        /// <summary>
+        /// Contains constants for the long running telemetry quality tests.
+        /// </summary>
+        internal static class Soak
+        {
+            /// <summary>
+            /// How long telemetry is observed, in minutes, after the warm up.
+            /// </summary>
+            public const string DurationMinutesVariable = "IIOT_E2E_SOAK_MINUTES";
+
+            /// <summary>
+            /// Number of counter nodes to publish.
+            /// </summary>
+            public const string NodeCountVariable = "IIOT_E2E_SOAK_NODES";
+
+            /// <summary>
+            /// Default observation window.
+            /// </summary>
+            public const int DefaultDurationMinutes = 30;
+
+            /// <summary>
+            /// Default number of fast counter nodes. Bounded by the IoT Hub
+            /// S1 daily message quota, which is shared with the A&amp;E job,
+            /// and by the two vCPU IoT Edge VM. Scale beyond this is covered
+            /// by the in-process soak, not by the end to end test.
+            /// </summary>
+            public const int DefaultFastNodeCount = 100;
+
+            /// <summary>
+            /// Number of slow counter nodes used by the heartbeat scenario.
+            /// </summary>
+            public const int SlowNodeCount = 20;
+
+            /// <summary>
+            /// Interval at which the fast counters increment.
+            /// </summary>
+            public static readonly TimeSpan FastUpdateInterval = TimeSpan.FromSeconds(2);
+
+            /// <summary>
+            /// Interval at which the slow counters increment.
+            /// </summary>
+            public static readonly TimeSpan SlowUpdateInterval = TimeSpan.FromMinutes(2);
+
+            /// <summary>
+            /// Publishing and sampling interval used by both scenarios.
+            /// </summary>
+            public static readonly TimeSpan PublishingInterval = TimeSpan.FromSeconds(2);
+
+            /// <summary>
+            /// Heartbeat interval for the counter scenario. Equal to the
+            /// publishing interval, which is exactly the configuration that
+            /// used to make the watchdog race the value it waits for.
+            /// </summary>
+            public static readonly TimeSpan FastHeartbeatInterval = TimeSpan.FromSeconds(2);
+
+            /// <summary>
+            /// Heartbeat interval for the slow scenario. Chosen so that
+            /// roughly eleven heartbeats fall between two value changes
+            /// without multiplying the IoT Hub message volume.
+            /// </summary>
+            public static readonly TimeSpan SlowHeartbeatInterval = TimeSpan.FromSeconds(10);
+
+            /// <summary>
+            /// Queue size configured on every monitored item.
+            /// </summary>
+            public const uint QueueSize = 10;
+
+            /// <summary>
+            /// Node id of the n-th fast counter exposed by OPC PLC. The value
+            /// increments by exactly one every <c>--fr</c> seconds.
+            /// </summary>
+            /// <param name="index">One based node index</param>
+            public static string FastNodeId(int index)
+            {
+                return string.Create(CultureInfo.InvariantCulture,
+                    $"nsu=http://microsoft.com/Opc/OpcPlc/;s=FastUInt{index}");
+            }
+
+            /// <summary>
+            /// Node id of the n-th slow counter exposed by OPC PLC.
+            /// </summary>
+            /// <param name="index">One based node index</param>
+            public static string SlowNodeId(int index)
+            {
+                return string.Create(CultureInfo.InvariantCulture,
+                    $"nsu=http://microsoft.com/Opc/OpcPlc/;s=SlowUInt{index}");
+            }
+
+            /// <summary>
+            /// Observation window, overridable through
+            /// <see cref="DurationMinutesVariable"/>.
+            /// </summary>
+            public static TimeSpan Duration
+                => TimeSpan.FromMinutes(GetPositiveInt(DurationMinutesVariable,
+                    DefaultDurationMinutes));
+
+            /// <summary>
+            /// Number of fast counter nodes, overridable through
+            /// <see cref="NodeCountVariable"/>.
+            /// </summary>
+            public static int FastNodeCount
+                => GetPositiveInt(NodeCountVariable, DefaultFastNodeCount);
+
+            private static int GetPositiveInt(string variable, int fallback)
+            {
+                return int.TryParse(Environment.GetEnvironmentVariable(variable),
+                    CultureInfo.InvariantCulture, out var value) && value > 0
+                        ? value : fallback;
+            }
+        }
 
         /// <summary>
         /// Contains constants for OPC PLC
@@ -225,6 +357,23 @@ namespace OpcPublisherAEE2ETests
             /// The trait value for PublisherMode = standalone
             /// </summary>
             public const string PublisherModeStandaloneTraitValue = "standaloneX";
+
+            /// <summary>
+            /// <para>
+            /// The trait value for the long running counter telemetry quality
+            /// test. It gets its own value so that the soak runs in its own
+            /// <c>dotnet test</c> process, and therefore in parallel with the
+            /// A&amp;E job, rather than being serialized behind it by the
+            /// <c>parallelizeTestCollections: false</c> runner setting.
+            /// </para>
+            /// </summary>
+            public const string PublisherModeSoakCountersTraitValue = "soakcounters";
+
+            /// <summary>
+            /// The trait value for the long running heartbeat telemetry
+            /// quality test.
+            /// </summary>
+            public const string PublisherModeSoakHeartbeatTraitValue = "soakheartbeat";
         }
 
         /// <summary>

--- a/e2e-tests/OpcPublisher-E2E-Tests/TestExtensions/SoakTelemetryReader.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestExtensions/SoakTelemetryReader.cs
@@ -1,0 +1,179 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace OpcPublisherAEE2ETests.TestExtensions
+{
+    using Azure.Messaging.EventHubs.Consumer;
+    using Microsoft.Azure.Devices;
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// <para>
+    /// Streams telemetry from the IoT Hub built-in Event Hubs endpoint into a
+    /// sink for a bounded duration.
+    /// </para>
+    /// <para>
+    /// The long running telemetry quality tests observe a stream for tens of
+    /// minutes, so unlike <see cref="TestHelper.ReadMessagesFromWriterIdAsync(EventHubConsumerClient, string, int, IIoTPlatformTestContext, CancellationToken)"/>
+    /// this reader must not buffer messages, must not write one line of test
+    /// output per message, and must understand the legacy samples encoding
+    /// (a bare monitored item message) in addition to PubSub network messages.
+    /// It parses with <see cref="System.Text.Json"/> because that is what the
+    /// shared telemetry quality validator consumes.
+    /// </para>
+    /// </summary>
+    internal static class SoakTelemetryReader
+    {
+        /// <summary>
+        /// Consume telemetry produced by a single publisher module.
+        /// </summary>
+        /// <param name="consumer">Event hub consumer to read from</param>
+        /// <param name="moduleId">
+        /// Identity of the publisher module whose telemetry is wanted. Every
+        /// soak scenario deploys its own module, and IoT Hub stamps the
+        /// sending module onto each message, so this isolates the scenarios
+        /// from each other and from the A&amp;E tests without having to look
+        /// inside the payload.
+        /// </param>
+        /// <param name="duration">How long to observe</param>
+        /// <param name="sink">
+        /// Invoked once per data set message. The element is only valid for
+        /// the duration of the call.
+        /// </param>
+        /// <param name="onFirstMessage">
+        /// Optional callback receiving the raw json of the first accepted
+        /// message, so a failing run has one concrete example to look at
+        /// without logging the whole stream.
+        /// </param>
+        /// <param name="ct"></param>
+        /// <returns>Number of messages handed to the sink</returns>
+        public static async Task<long> ConsumeAsync(this EventHubConsumerClient consumer,
+            string moduleId, TimeSpan duration, Action<JsonElement> sink,
+            Action<string> onFirstMessage = null, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(consumer);
+            ArgumentNullException.ThrowIfNull(sink);
+
+            var count = 0L;
+            var first = true;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(duration);
+            try
+            {
+                await foreach (var partitionEvent in consumer
+                    .ReadEventsAsync(false, cancellationToken: cts.Token)
+                    .WithCancellation(cts.Token))
+                {
+                    if (partitionEvent.Data == null)
+                    {
+                        continue;
+                    }
+                    if (!partitionEvent.Data.SystemProperties.TryGetValue(
+                            kConnectionModuleId, out var moduleIdObj) ||
+                        moduleIdObj is not string sender ||
+                        !string.Equals(sender, moduleId, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    byte[] body;
+                    if (partitionEvent.Data.Properties.TryGetValue("$$ContentType", out var contentType) &&
+                        contentType is string ct2 && ct2 == "application/json+gzip")
+                    {
+                        body = Decompress(Convert.FromBase64String(
+                            partitionEvent.Data.EventBody.ToString()));
+                    }
+                    else
+                    {
+                        body = partitionEvent.Data.EventBody.ToArray();
+                    }
+                    if (body.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    if (first)
+                    {
+                        first = false;
+                        onFirstMessage?.Invoke(Encoding.UTF8.GetString(body));
+                    }
+
+                    using var document = JsonDocument.Parse(body);
+                    var element = document.RootElement;
+                    if (element.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var item in element.EnumerateArray())
+                        {
+                            sink(item);
+                            count++;
+                        }
+                    }
+                    else if (element.ValueKind == JsonValueKind.Object)
+                    {
+                        sink(element);
+                        count++;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            return count;
+        }
+
+        /// <summary>
+        /// Wait until the given module produces its first telemetry message,
+        /// or the timeout elapses. Used to end the warm up phase as soon as
+        /// the publisher is actually delivering rather than after a fixed
+        /// guess.
+        /// </summary>
+        /// <param name="consumer"></param>
+        /// <param name="moduleId"></param>
+        /// <param name="timeout"></param>
+        /// <param name="ct"></param>
+        /// <returns>How long it took, or null when nothing arrived</returns>
+        public static async Task<TimeSpan?> WaitForFirstMessageAsync(
+            this EventHubConsumerClient consumer, string moduleId, TimeSpan timeout,
+            CancellationToken ct = default)
+        {
+            var stopWatch = Stopwatch.StartNew();
+            var seen = false;
+            using var stop = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            await consumer.ConsumeAsync(moduleId, timeout, _ =>
+            {
+                seen = true;
+                //
+                // Cancelling the token that ConsumeAsync links against breaks
+                // it out of the read loop on the next iteration; it swallows
+                // the resulting cancellation itself.
+                //
+                stop.Cancel();
+            }, onFirstMessage: null, stop.Token).ConfigureAwait(false);
+            return seen ? stopWatch.Elapsed : null;
+        }
+
+        private static byte[] Decompress(byte[] compressed)
+        {
+            using var input = new MemoryStream(compressed);
+            using var gs = new GZipStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            gs.CopyTo(output);
+            return output.ToArray();
+        }
+
+        /// <summary>
+        /// System property IoT Hub stamps onto every device to cloud message
+        /// with the identity of the sending module. Not exposed as a constant
+        /// by <c>Microsoft.Azure.Devices.MessageSystemPropertyNames</c>, which
+        /// only carries the device id.
+        /// </summary>
+        private const string kConnectionModuleId = "iothub-connection-module-id";
+    }
+}

--- a/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
@@ -58,7 +58,15 @@ namespace OpcPublisherAEE2ETests
         {
             var registryManager = context.RegistryHelper.RegistryManager;
             var twin = await registryManager.GetTwinAsync(context.DeviceConfig.DeviceId, ct).ConfigureAwait(false);
-            await registryManager.UpdateTwinAsync(twin.DeviceId, patch, twin.ETag, ct).ConfigureAwait(false);
+            //
+            // Patch unconditionally rather than against the etag read above.
+            // The only patch applied here marks the device as an unmanaged
+            // iiotedge gateway, which every test applies with identical
+            // content, and several test jobs run against the same device in
+            // parallel. Using the read etag would make all but one of them
+            // fail with a precondition failure for no benefit.
+            //
+            await registryManager.UpdateTwinAsync(twin.DeviceId, patch, "*", ct).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,8 +414,18 @@ namespace OpcPublisherAEE2ETests
         /// account key (which we no longer mint anywhere).
         /// </param>
         /// <param name="numInstances">Number of instances</param>
+        /// <param name="nameDiscriminator">
+        /// Optional discriminator that is appended to the container group name and DNS
+        /// label. The default name is derived from a resource group tag and is therefore
+        /// identical for every test run against the same resource group, so two jobs
+        /// running in parallel would collide on it. Supply a distinct value per scenario.
+        /// </param>
+        /// <param name="cpuCores">Requested vCPU cores. Defaults to 0.5.</param>
+        /// <param name="memoryInGB">Requested memory in GB. Defaults to 0.5.</param>
         public static async Task CreateSimulationContainerAsync(IIoTPlatformTestContext context,
-            List<string> commandLine, CancellationToken cancellationToken, string fileToUpload = null, int numInstances = 1)
+            List<string> commandLine, CancellationToken cancellationToken, string fileToUpload = null,
+            int numInstances = 1, string nameDiscriminator = null,
+            double cpuCores = 0.5, double memoryInGB = 0.5)
         {
             var resourceGroup = await GetResourceGroupAsync(context, cancellationToken).ConfigureAwait(false);
 
@@ -423,16 +441,20 @@ namespace OpcPublisherAEE2ETests
                     .ConfigureAwait(false));
             }
 
+            var suffix = string.IsNullOrEmpty(nameDiscriminator)
+                ? "dynamic" : "dynamic-" + nameDiscriminator;
             context.PlcAciDynamicUrls = await Task.WhenAll(
                 Enumerable.Range(0, numInstances)
                     .Select(i =>
                         CreatePlcContainerGroupAsync(resourceGroup,
-                            $"e2etesting-simulation-aci-{i}-{context.TestingSuffix}-dynamic",
+                            $"e2etesting-simulation-aci-{i}-{context.TestingSuffix}-{suffix}",
                             context,
                             commandLine[0],
                             commandLine.GetRange(1, commandLine.Count - 1).ToArray(),
                             configFileName,
                             configFileB64,
+                            cpuCores,
+                            memoryInGB,
                             cancellationToken))).ConfigureAwait(false);
         }
 
@@ -453,13 +475,16 @@ namespace OpcPublisherAEE2ETests
         /// argument. When null, the command runs as-is and no env var is added.
         /// </param>
         /// <param name="configFileB64">Base64-encoded contents of the config file, or null.</param>
+        /// <param name="cpuCores">Requested vCPU cores.</param>
+        /// <param name="memoryInGB">Requested memory in GB.</param>
         /// <param name="cancellationToken"></param>
         private static async Task<string> CreatePlcContainerGroupAsync(ResourceGroupResource resGroup,
             string containerGroupName, IIoTPlatformTestContext context, string executable,
-            string[] commandLine, string configFileName, string configFileB64, CancellationToken cancellationToken)
+            string[] commandLine, string configFileName, string configFileB64,
+            double cpuCores, double memoryInGB, CancellationToken cancellationToken)
         {
             var container = new ContainerInstanceContainer(containerGroupName, context.PLCImage,
-                new ContainerResourceRequirements(new ContainerResourceRequestsContent(0.5, 0.5)));
+                new ContainerResourceRequirements(new ContainerResourceRequestsContent(memoryInGB, cpuCores)));
             container.Command.Add(executable);
             if (configFileB64 != null)
             {

--- a/e2e-tests/OpcPublisher-E2E-Tests/deploy/DeploymentConfiguration.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/deploy/DeploymentConfiguration.cs
@@ -20,12 +20,14 @@ namespace OpcPublisherAEE2ETests.Deploy
         }
 
         /// <inheritdoc />
-        public async Task<bool> CreateOrUpdateLayeredDeploymentAsync(CancellationToken token)
+        public async Task<bool> CreateOrUpdateLayeredDeploymentAsync(CancellationToken token,
+            bool replaceExisting = true)
         {
             var deploymentConfiguration = GetDeploymentConfiguration();
 
             var configuration = await _context.RegistryHelper
-                .CreateOrUpdateConfigurationAsync(deploymentConfiguration, token).ConfigureAwait(false);
+                .CreateOrUpdateConfigurationAsync(deploymentConfiguration, token, replaceExisting)
+                .ConfigureAwait(false);
 
             _context.OutputHelper.WriteLine($"Created deployment {configuration.Id}.");
             return configuration != null;

--- a/e2e-tests/OpcPublisher-E2E-Tests/deploy/IIoTHubEdgeDeployment.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/deploy/IIoTHubEdgeDeployment.cs
@@ -15,8 +15,15 @@ namespace OpcPublisherAEE2ETests.Deploy
         /// Create a new layered deployment or update an existing one.
         /// </summary>
         /// <param name="token">The token to cancel the async task</param>
+        /// <param name="replaceExisting">
+        /// When false an already existing deployment with the same identifier
+        /// is left untouched. Use this for deployments that are shared by
+        /// several test jobs - recreating them would restart the modules of
+        /// the jobs running in parallel.
+        /// </param>
         /// <returns>true if create or update was successful otherwise false</returns>
-        Task<bool> CreateOrUpdateLayeredDeploymentAsync(CancellationToken token);
+        Task<bool> CreateOrUpdateLayeredDeploymentAsync(CancellationToken token,
+            bool replaceExisting = true);
 
         /// <summary>
         /// Get deployment configuration.

--- a/e2e-tests/readme.md
+++ b/e2e-tests/readme.md
@@ -45,6 +45,58 @@ class.
 
 Use and extend the `TestHelper` class.
 
+## Long running telemetry quality tests
+
+Two soak tests validate the quality of the telemetry stream produced by an OPC Publisher
+module that is actually deployed to IoT Edge, complementing the in-process soak in
+`src/Azure.IIoT.OpcUa.Publisher.Module/tests` (which is run by `.github/workflows/soak.yml`).
+They use OPC PLC counter nodes, which increment by exactly one per cycle, so the value is
+its own sequence number: a lost value is a gap, a reordered value is a decrease, and the
+expected source timestamp distance is exactly one update interval.
+
+| Test | Trait | Scenario | Asserts |
+| --- | --- | --- | --- |
+| `FTelemetryQualityCountersTestTheory` | `PublisherMode=soakcounters` | 100 nodes counting up every **2 s**, published with 2 s publishing/sampling interval, queue size 10 and a **2 s heartbeat** | Nothing is lost, reordered, repeated or unevenly spaced, and **no heartbeat fires** — a value arrives on every publish cycle, so the watchdog must stay silent |
+| `FTelemetryQualityHeartbeatTestTheory` | `PublisherMode=soakheartbeat` | 20 nodes counting up every **2 min**, with a **10 s heartbeat** | Heartbeats **do** fire on every node at the configured cadence and never before the watchdog grace period; every repeat carries the `Heartbeat` indicator; heartbeats never alter the source timestamp; and with heartbeats excluded the value stream is complete, ordered and exactly 2 minutes apart |
+
+### Infrastructure
+
+Both tests **reuse the deployed resource group, IoT Hub and IoT Edge VM**. Standing up a
+second environment would roughly double the Azure spend and the resource-leak surface
+without adding coverage — the code under test is the publisher module, not the hub.
+Everything that could cause interference is isolated per scenario instead:
+
+* its own publisher **module identity** (`publisher_soak_fast` / `publisher_soak_slow`)
+  and layered deployment, with its own `--pf` published nodes file and `--pki` folder,
+* its own **OPC PLC simulation container** (distinct name, DNS label and sizing — pass
+  `nameDiscriminator` to `TestHelper.CreateSimulationContainerAsync`),
+* its own `DataSetWriterGroup` / `DataSetWriterId`, and
+* its own Event Hub **consumer group** (`SoakCounters` / `SoakHeartbeat`), because the
+  IoT Hub built-in endpoint allows only five concurrent readers per partition and group.
+
+Telemetry is attributed by the `iothub-connection-module-id` system property, so each
+scenario only ever sees its own publisher's messages.
+
+Because each trait value is run by its own `dotnet test` process, the two soaks run **in
+parallel with each other and with the A&E job** — the xUnit runner is configured with
+`parallelizeTestCollections: false`, so putting them in the same process would serialize
+them instead.
+
+### Configuration
+
+| Environment variable | Default | Meaning |
+| --- | --- | --- |
+| `IIOT_E2E_SOAK_MINUTES` | `30` | How long telemetry is observed after the warm up |
+| `IIOT_E2E_SOAK_NODES` | `100` | Number of 2-second counter nodes |
+
+Both are surfaced as the `soak_minutes` and `soak_nodes` inputs of
+`.github/workflows/e2e-standalone.yml`.
+
+> The node count is bounded by the **IoT Hub S1 daily message quota**, which is shared
+> with the A&E job, and by the two vCPU IoT Edge VM. At the default of 100 nodes the soak
+> produces roughly one network message per second. Raising it much above 250 needs an IoT
+> Hub SKU bump. Scale itself is covered by the in-process soak, which runs 3000 nodes.
+
 ## Authentication
 
 The tests use federated identity (workload identity federation) end to end:

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
@@ -34,6 +34,16 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <!--
+      The telemetry quality validator is shared verbatim with the IoT Edge
+      end to end soak tests in e2e-tests/. It is linked rather than pulled in
+      through a project reference so that neither test project gains a
+      dependency on the other; the file itself only needs System.Text.Json.
+    -->
+    <Compile Include="..\..\Azure.IIoT.OpcUa.Publisher.Testing\shared\*.cs"
+             LinkBase="Telemetry" />
+  </ItemGroup>
+  <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherIntegrationTestBase.cs
@@ -307,6 +307,72 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
         };
 
         /// <summary>
+        /// <para>
+        /// Stream telemetry into a sink for a bounded duration without
+        /// buffering it. <see cref="WaitForMessagesAndMetadataAsync"/>
+        /// accumulates every message into a list, which is fine for the
+        /// short functional tests but exhausts memory in the long running
+        /// telemetry quality tests where millions of messages are produced.
+        /// </para>
+        /// <para>
+        /// The sink is invoked once per data set message; network messages
+        /// that carry an array of messages are flattened. The
+        /// <see cref="JsonElement"/> handed to the sink is only valid for
+        /// the duration of the call, so the sink has to extract everything
+        /// it needs before returning.
+        /// </para>
+        /// </summary>
+        /// <param name="duration"></param>
+        /// <param name="sink"></param>
+        /// <param name="ct"></param>
+        /// <returns>Number of messages that were handed to the sink</returns>
+        protected async Task<long> ConsumeMessagesAsync(TimeSpan duration,
+            Action<JsonElement> sink, CancellationToken ct = default)
+        {
+            ArgumentNullException.ThrowIfNull(sink);
+
+            var stopWatch = Stopwatch.StartNew();
+            var count = 0L;
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(duration);
+            try
+            {
+                await foreach (var evt in _publisher.ReadTelemetryAsync(cts.Token))
+                {
+                    if (evt.Properties.TryGetValue(Constants.MessagePropertySchemaKey, out var schematype) &&
+                        schematype != MessageSchemaTypes.NetworkMessageJson &&
+                        schematype != MessageSchemaTypes.MonitoredItemMessageJson &&
+                        schematype != MessageSchemaTypes.NetworkMessageUadp)
+                    {
+                        continue;
+                    }
+                    if (evt.Data.IsEmpty)
+                    {
+                        continue;
+                    }
+                    using var document = JsonDocument.Parse(evt.Data.ToArray());
+                    var element = document.RootElement;
+                    if (element.ValueKind == JsonValueKind.Array)
+                    {
+                        foreach (var item in element.EnumerateArray())
+                        {
+                            sink(item);
+                            count++;
+                        }
+                    }
+                    else if (element.ValueKind == JsonValueKind.Object)
+                    {
+                        sink(element);
+                        count++;
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+            _logger.MessagesReceived((int)Math.Min(count, int.MaxValue), stopWatch.Elapsed);
+            return count;
+        }
+
+        /// <summary>
         /// Start publisher
         /// </summary>
         /// <param name="test"></param>
@@ -387,6 +453,17 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
         /// Get publisher api
         /// </summary>
         protected IPublisherApi PublisherApi => _publisher?.ClientContainer?.Resolve<IPublisherApi>();
+
+        /// <summary>
+        /// Resolve a service from the running publisher module. Used to read
+        /// the publisher's own diagnostics, e.g. the dropped notification and
+        /// server queue overflow counters, from inside a test.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        protected T ResolveFromPublisher<T>()
+        {
+            return _publisher.Resolve<T>();
+        }
 
         /// <summary>
         /// Stop publisher

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
@@ -1,0 +1,373 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
+{
+    using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
+    using Azure.IIoT.OpcUa.Publisher.Models;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Fixtures;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
+    using Furly.Extensions.Logging;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// <para>
+    /// Long running telemetry quality tests. They reproduce the customer
+    /// scenario of thousands of variables published with a two second
+    /// publishing interval, a two second sampling interval, a queue size
+    /// larger than one and a two second heartbeat, and assert that the
+    /// resulting telemetry stream is
+    /// </para>
+    /// <list type="number">
+    /// <item>complete - no counter value is lost,</item>
+    /// <item>ordered - a counter never goes backwards,</item>
+    /// <item>evenly spaced - consecutive source timestamps are exactly one
+    /// update interval apart, and</item>
+    /// <item>free of stale values - a value is never repeated after a newer
+    /// one was already delivered.</item>
+    /// </list>
+    /// <para>
+    /// The counter server makes this decidable: every variable counts up
+    /// from zero by exactly one, so the value carries its own sequence and
+    /// its own expected timestamp.
+    /// </para>
+    /// </summary>
+    [Trait(TestCategories.Name, TestCategories.LongRunning)]
+    public sealed class TelemetryQualityTests : PublisherIntegrationTestBase
+    {
+        public TelemetryQualityTests(ITestOutputHelper output)
+            : base(output, kTestTimeout, nameof(TelemetryQualityTests))
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// The customer scenario in samples encoding: publishing interval,
+        /// sampling interval and heartbeat interval all two seconds, queue
+        /// size larger than one, against a server whose variables count up
+        /// every two seconds.
+        /// </summary>
+        [Fact]
+        public async Task SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync()
+        {
+            var report = await RunScenarioAsync(
+                nameof(SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync),
+                MessagingMode.FullSamples, NodeCount, kInterval, kInterval, kInterval,
+                kQueueSize, (int)kInterval.TotalSeconds, RunDuration).ConfigureAwait(false);
+
+            AssertClean(report);
+        }
+
+        /// <summary>
+        /// The same scenario in PubSub encoding, as a control that the
+        /// behaviour is not specific to the legacy samples encoder.
+        /// </summary>
+        [Fact]
+        public async Task PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync()
+        {
+            var report = await RunScenarioAsync(
+                nameof(PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync),
+                MessagingMode.PubSub, NodeCount, kInterval, kInterval, kInterval,
+                kQueueSize, (int)kInterval.TotalSeconds, RunDuration).ConfigureAwait(false);
+
+            AssertClean(report);
+        }
+
+        /// <summary>
+        /// Same scenario but with the server producing values four times
+        /// faster than the publishing interval, so every publish carries
+        /// several queued values per monitored item. This is what a queue
+        /// size larger than one is actually for and it exercises the
+        /// ordering of queued values through the encoder.
+        /// </summary>
+        [Fact]
+        public async Task QueuedValuesArriveCompleteAndInOrderAsync()
+        {
+            var updateInterval = TimeSpan.FromMilliseconds(500);
+            var report = await RunScenarioAsync(
+                nameof(QueuedValuesArriveCompleteAndInOrderAsync),
+                MessagingMode.FullSamples, NodeCount, updateInterval,
+                publishingInterval: kInterval, samplingInterval: updateInterval,
+                queueSize: kQueueSize, heartbeatSeconds: (int)kInterval.TotalSeconds,
+                duration: RunDuration).ConfigureAwait(false);
+
+            AssertClean(report);
+        }
+
+        /// <summary>
+        /// The customer scenario at the reported scale of three thousand
+        /// nodes. Opt in because it needs a machine that can host the server
+        /// and the publisher side by side.
+        /// </summary>
+        [SkippableFact]
+        public async Task CustomerScenarioAtFullScaleAsync()
+        {
+            Skip.IfNot(FullScaleEnabled,
+                $"Set {kFullScaleVariable}=1 to run the full scale scenario.");
+
+            var report = await RunScenarioAsync(
+                nameof(CustomerScenarioAtFullScaleAsync),
+                MessagingMode.FullSamples, kFullScaleNodeCount, kInterval, kInterval,
+                kInterval, kQueueSize, (int)kInterval.TotalSeconds,
+                RunDuration).ConfigureAwait(false);
+
+            AssertClean(report);
+        }
+
+        /// <summary>
+        /// Run one scenario and return the resulting quality report.
+        /// </summary>
+        /// <param name="test"></param>
+        /// <param name="mode"></param>
+        /// <param name="nodeCount"></param>
+        /// <param name="updateInterval">Rate at which the server counts up</param>
+        /// <param name="publishingInterval"></param>
+        /// <param name="samplingInterval"></param>
+        /// <param name="queueSize"></param>
+        /// <param name="heartbeatSeconds"></param>
+        /// <param name="duration">How long telemetry is analysed</param>
+        private async Task<TelemetryQualityReport> RunScenarioAsync(string test,
+            MessagingMode mode, int nodeCount, TimeSpan updateInterval,
+            TimeSpan publishingInterval, TimeSpan samplingInterval, uint queueSize,
+            int heartbeatSeconds, TimeSpan duration)
+        {
+            using var loggerFactory = Log.ConsoleFactory(LogLevel.Warning);
+            using var server = CounterServer.Create(nodeCount, updateInterval, loggerFactory);
+            EndpointUrl = server.EndpointUrl;
+
+            var configuration = WriteConfiguration(nodeCount, publishingInterval,
+                samplingInterval, queueSize, heartbeatSeconds);
+            try
+            {
+                StartPublisher(test, configuration,
+                [
+                    $"--mm={mode}",
+                    "--me=Json",
+                    //
+                    // Pin the batching defaults so the scenario does not
+                    // silently change when the shipped defaults change.
+                    //
+                    "--bs=50",
+                    "--bi=10000"
+                ]);
+
+                var validator = new TelemetryQualityValidator(new TelemetryQualityOptions
+                {
+                    UpdateInterval = updateInterval,
+                    ExpectedNodeCount = nodeCount,
+                    HeartbeatInterval = TimeSpan.FromSeconds(heartbeatSeconds),
+                    PublishingInterval = publishingInterval
+                });
+                var samples = mode is MessagingMode.Samples or MessagingMode.FullSamples;
+
+                //
+                // Skip the warm up. Creating thousands of monitored items
+                // takes time and until all of them exist the stream is
+                // legitimately partial.
+                //
+                var warmup = WarmupFor(nodeCount);
+                var stopWatch = Stopwatch.StartNew();
+                var total = await ConsumeMessagesAsync(warmup + duration, message =>
+                {
+                    if (stopWatch.Elapsed < warmup)
+                    {
+                        return;
+                    }
+                    if (samples)
+                    {
+                        validator.AddSamplesMessage(message);
+                    }
+                    else
+                    {
+                        validator.AddPubSubMessage(message);
+                    }
+                }, Ct).ConfigureAwait(false);
+
+                var report = validator.CreateReport();
+                _output.WriteLine($"--- {test} ({mode}, {nodeCount} nodes, " +
+                    $"{updateInterval.TotalMilliseconds} ms update, {duration} analysed, " +
+                    $"{total} messages) ---");
+                _output.WriteLine(report.ToString());
+                _output.WriteLine(DumpDiagnostics());
+                _output.WriteLine($"Server produced values 0..{server.NodeManager.CurrentValue}");
+                return report;
+            }
+            finally
+            {
+                await StopPublisherAsync().ConfigureAwait(false);
+                if (File.Exists(configuration))
+                {
+                    File.Delete(configuration);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Assert that none of the four reported symptoms occurred.
+        /// </summary>
+        /// <param name="report"></param>
+        private static void AssertClean(TelemetryQualityReport report)
+        {
+            Assert.True(report.TotalSamples > 0, "No telemetry was received at all.");
+            Assert.True(report.NodesMissing == 0,
+                $"{report.NodesMissing} node(s) never reported a value.\n{report}");
+
+            // (a) values the customer expects but never sees
+            Assert.True(report.MissingValues == 0,
+                $"{report.MissingValues} value(s) were lost.\n{report}");
+
+            // (b) values arriving out of order
+            Assert.True(report.OutOfOrderValues == 0,
+                $"{report.OutOfOrderValues} value(s) arrived out of order.\n{report}");
+            Assert.True(report.OutOfOrderIncludingHeartbeats == 0,
+                $"{report.OutOfOrderIncludingHeartbeats} message(s) carried a value older " +
+                $"than one already delivered.\n{report}");
+
+            // (c) source timestamps not one interval apart
+            Assert.True(report.SamplesWithoutSourceTimestamp == 0,
+                $"{report.SamplesWithoutSourceTimestamp} message(s) had no source " +
+                $"timestamp.\n{report}");
+            Assert.True(report.ValueIntervalViolations == 0,
+                $"{report.ValueIntervalViolations} value(s) were not one update interval " +
+                $"apart from their predecessor.\n{report}");
+            Assert.True(report.MessageIntervalViolations == 0,
+                $"{report.MessageIntervalViolations} message(s) broke the expected source " +
+                $"timestamp cadence.\n{report}");
+
+            // (d) an old value shortly after a new one
+            Assert.True(report.RepeatedValues == 0,
+                $"{report.RepeatedValues} message(s) repeated an already delivered value " +
+                $"({report.RepeatedValuesFromHeartbeat} of them heartbeats).\n{report}");
+        }
+
+        /// <summary>
+        /// Render the publisher's own view of the run so a failure can be
+        /// attributed to a dropped notification or a server side queue
+        /// overflow rather than to the encoder.
+        /// </summary>
+        private string DumpDiagnostics()
+        {
+            var collector = ResolveFromPublisher<IDiagnosticCollector>();
+            if (collector == null)
+            {
+                return "No diagnostics available.";
+            }
+            var builder = new StringBuilder();
+            foreach (var (writerGroup, diagnostic) in collector.EnumerateDiagnostics())
+            {
+                builder
+                    .AppendLine(CultureInfo.InvariantCulture, $"Writer group '{writerGroup}':")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  ingress data changes      : {diagnostic.IngressDataChanges}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  ingress value changes     : {diagnostic.IngressValueChanges}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  ingress heartbeats        : {diagnostic.IngressHeartbeats}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  ingress dropped           : {diagnostic.IngressNotificationsDropped}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  encoder dropped           : {diagnostic.EncoderNotificationsDropped}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  outgress buffer dropped   : {diagnostic.OutgressInputBufferDropped}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  server queue overflows    : {diagnostic.ServerQueueOverflows}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  messages sent             : {diagnostic.OutgressIoTMessageCount}")
+                    .AppendLine(CultureInfo.InvariantCulture, $"  monitored nodes ok/bad    : {diagnostic.MonitoredOpcNodesSucceededCount}/{diagnostic.MonitoredOpcNodesFailedCount}");
+            }
+            return builder.Length == 0 ? "No writer group diagnostics." : builder.ToString();
+        }
+
+        /// <summary>
+        /// Write a published nodes configuration reproducing the customer
+        /// configuration for the given number of counter nodes.
+        /// </summary>
+        /// <param name="nodeCount"></param>
+        /// <param name="publishingInterval"></param>
+        /// <param name="samplingInterval"></param>
+        /// <param name="queueSize"></param>
+        /// <param name="heartbeatSeconds"></param>
+        private static string WriteConfiguration(int nodeCount, TimeSpan publishingInterval,
+            TimeSpan samplingInterval, uint queueSize, int heartbeatSeconds)
+        {
+            var path = Path.Combine(Path.GetTempPath(),
+                Path.GetRandomFileName() + ".pn.json");
+            using (var stream = File.Create(path))
+            {
+                using var writer = new Utf8JsonWriter(stream);
+                writer.WriteStartArray();
+                writer.WriteStartObject();
+                writer.WriteString("EndpointUrl", "{{EndpointUrl}}");
+                writer.WriteBoolean("UseSecurity", false);
+                writer.WriteString("DataSetWriterGroup", "{{DataSetWriterGroup}}");
+                writer.WriteStartArray("OpcNodes");
+                for (var index = 0; index < nodeCount; index++)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("Id", CounterServer.GetNodeId(index));
+                    writer.WriteNumber("OpcPublishingInterval",
+                        (int)publishingInterval.TotalMilliseconds);
+                    writer.WriteNumber("OpcSamplingInterval",
+                        (int)samplingInterval.TotalMilliseconds);
+                    writer.WriteNumber("HeartbeatInterval", heartbeatSeconds);
+                    writer.WriteNumber("QueueSize", queueSize);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+                writer.WriteEndObject();
+                writer.WriteEndArray();
+                writer.Flush();
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Time given to the publisher to create every monitored item before
+        /// telemetry is analysed.
+        /// </summary>
+        /// <param name="nodeCount"></param>
+        private static TimeSpan WarmupFor(int nodeCount)
+        {
+            return TimeSpan.FromSeconds(30) +
+                TimeSpan.FromMilliseconds(10 * nodeCount);
+        }
+
+        /// <summary>
+        /// Number of counter nodes to publish
+        /// </summary>
+        private static int NodeCount
+            => GetPositiveInt("IIOT_TELEMETRY_SOAK_NODES", kDefaultNodeCount);
+
+        /// <summary>
+        /// How long telemetry is analysed after the warm up
+        /// </summary>
+        private static TimeSpan RunDuration
+            => TimeSpan.FromMinutes(GetPositiveInt("IIOT_TELEMETRY_SOAK_MINUTES",
+                kDefaultDurationMinutes));
+
+        /// <summary>
+        /// Whether the full scale scenario was opted into
+        /// </summary>
+        private static bool FullScaleEnabled
+            => Environment.GetEnvironmentVariable(kFullScaleVariable) == "1";
+
+        private static int GetPositiveInt(string variable, int fallback)
+        {
+            return int.TryParse(Environment.GetEnvironmentVariable(variable),
+                CultureInfo.InvariantCulture, out var value) && value > 0
+                    ? value : fallback;
+        }
+
+        private const string kFullScaleVariable = "IIOT_TELEMETRY_SOAK_FULLSCALE";
+        private const int kDefaultNodeCount = 500;
+        private const int kDefaultDurationMinutes = 2;
+        private const int kFullScaleNodeCount = 3000;
+        private const uint kQueueSize = 10;
+        private static readonly TimeSpan kInterval = TimeSpan.FromSeconds(2);
+        private static readonly TimeSpan kTestTimeout = TimeSpan.FromHours(4);
+        private readonly ITestOutputHelper _output;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Telemetry/TelemetryQualityValidatorTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Telemetry/TelemetryQualityValidatorTests.cs
@@ -1,0 +1,269 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
+{
+    using System;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the telemetry quality validator. The validator has to
+    /// separate what a heartbeat legitimately does (resend the last value
+    /// with its original source timestamp) from what would be a defect
+    /// (losing a value, reordering, or repeating a value without saying so),
+    /// and it has to survive at least once delivery through IoT Hub.
+    /// </summary>
+    public class TelemetryQualityValidatorTests
+    {
+        private static readonly DateTime kEpoch =
+            new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly TimeSpan kTwoSeconds = TimeSpan.FromSeconds(2);
+
+        [Fact]
+        public void CleanCounterStreamProducesNoFindings()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1);
+            for (var i = 0; i < 10; i++)
+            {
+                validator.Add(Value(i));
+            }
+
+            var report = validator.CreateReport();
+            Assert.True(report.IsClean, report.ToString());
+            Assert.Equal(10, report.ValueSamples);
+            Assert.Equal(0, report.HeartbeatSamples);
+        }
+
+        [Fact]
+        public void MissingValueIsCountedAsGap()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1);
+            validator.Add(Value(0));
+            validator.Add(Value(3));
+
+            var report = validator.CreateReport();
+            Assert.Equal(2, report.MissingValues);
+        }
+
+        [Fact]
+        public void ValueGoingBackwardsIsCountedOutOfOrder()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1);
+            validator.Add(Value(5));
+            validator.Add(Value(4));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.OutOfOrderValues);
+            Assert.Equal(1, report.OutOfOrderIncludingHeartbeats);
+        }
+
+        [Fact]
+        public void RepeatWithoutTheHeartbeatIndicatorIsCountedUnflagged()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1);
+            validator.Add(Value(1));
+            validator.Add(Value(1));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.RepeatedValues);
+            Assert.Equal(0, report.RepeatedValuesFromHeartbeat);
+            Assert.Equal(1, report.UnflaggedRepeats);
+        }
+
+        [Fact]
+        public void HeartbeatRepeatIsAttributedToTheHeartbeatAndNotToTheValueStream()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10));
+            validator.Add(Value(1));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(14)));
+            validator.Add(Value(2, messageTimestamp: kEpoch.AddSeconds(24)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.RepeatedValues);
+            Assert.Equal(1, report.RepeatedValuesFromHeartbeat);
+            Assert.Equal(0, report.UnflaggedRepeats);
+
+            // The heartbeat neither opened a gap nor broke the value cadence.
+            Assert.Equal(0, report.MissingValues);
+            Assert.Equal(0, report.OutOfOrderValues);
+            Assert.Equal(0, report.ValueIntervalViolations);
+            Assert.Equal(1, report.HeartbeatSamples);
+        }
+
+        [Fact]
+        public void HeartbeatMustResendTheOriginalSourceTimestamp()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10));
+            validator.Add(Value(1));
+
+            // A heartbeat that shifts the source timestamp forward.
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(12), kEpoch.AddSeconds(14)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.HeartbeatsWithChangedTimestamp);
+        }
+
+        [Fact]
+        public void HeartbeatBeforeTheWatchdogGracePeriodIsFlaggedEarly()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            // Value produced at t=2s, so the earliest legitimate heartbeat is
+            // at 10s + 2s publishing interval = t=14s.
+            validator.Add(Value(1, messageTimestamp: kEpoch.AddSeconds(2)));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(10)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.EarlyHeartbeats);
+        }
+
+        [Fact]
+        public void HeartbeatAtTheWatchdogGracePeriodIsNotFlaggedEarly()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            validator.Add(Value(1, messageTimestamp: kEpoch.AddSeconds(2)));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(14)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(0, report.EarlyHeartbeats);
+        }
+
+        [Fact]
+        public void HeartbeatCadenceIsMeasuredFromTheMessageTimestamp()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            validator.Add(Value(1, messageTimestamp: kEpoch.AddSeconds(2)));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(14)));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(24)));  // ok
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(44)));  // 20s
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.HeartbeatCadenceViolations);
+            Assert.Equal(3, report.HeartbeatSamples);
+            Assert.Equal(3, report.MinHeartbeatsPerNode);
+            Assert.Equal(3, report.MaxHeartbeatsPerNode);
+        }
+
+        [Fact]
+        public void HeartbeatCountsArePerNode()
+        {
+            var validator = Create(kTwoSeconds, nodes: 2,
+                heartbeatInterval: TimeSpan.FromSeconds(10));
+            validator.Add(Value(1, node: "a"));
+            validator.Add(Value(1, node: "b"));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(14), node: "a"));
+
+            var report = validator.CreateReport();
+            Assert.Equal(2, report.NodesSeen);
+            Assert.Equal(0, report.NodesMissing);
+            Assert.Equal(0, report.MinHeartbeatsPerNode);
+            Assert.Equal(1, report.MaxHeartbeatsPerNode);
+        }
+
+        [Fact]
+        public void RedeliveredMessageIsSuppressedInsteadOfBeingReportedAsAStaleValue()
+        {
+            var validator = Create(kTwoSeconds, nodes: 1);
+            validator.Add(Value(1, sequenceNumber: 100));
+            validator.Add(Value(2, sequenceNumber: 101));
+
+            // IoT Hub delivers at least once - the same message again.
+            validator.Add(Value(2, sequenceNumber: 101));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.DuplicateDeliveries);
+            Assert.Equal(0, report.RepeatedValues);
+            Assert.Equal(0, report.UnflaggedRepeats);
+            Assert.Equal(2, report.ValueSamples);
+        }
+
+        [Fact]
+        public void DuplicateSuppressionCanBeDisabled()
+        {
+            var validator = new TelemetryQualityValidator(new TelemetryQualityOptions
+            {
+                UpdateInterval = kTwoSeconds,
+                ExpectedNodeCount = 1,
+                SuppressDuplicates = false
+            });
+            validator.Add(Value(1, sequenceNumber: 100));
+            validator.Add(Value(1, sequenceNumber: 100));
+
+            var report = validator.CreateReport();
+            Assert.Equal(0, report.DuplicateDeliveries);
+            Assert.Equal(1, report.RepeatedValues);
+        }
+
+        [Fact]
+        public void DuplicateWindowIsBounded()
+        {
+            var validator = new TelemetryQualityValidator(new TelemetryQualityOptions
+            {
+                UpdateInterval = kTwoSeconds,
+                ExpectedNodeCount = 1,
+                DuplicateWindow = 2
+            });
+            validator.Add(Value(1, sequenceNumber: 1));
+            validator.Add(Value(2, sequenceNumber: 2));
+            validator.Add(Value(3, sequenceNumber: 3));
+
+            // Sequence number 1 has fallen out of the window, so it is no
+            // longer recognized as a duplicate.
+            validator.Add(Value(4, sequenceNumber: 1));
+
+            var report = validator.CreateReport();
+            Assert.Equal(0, report.DuplicateDeliveries);
+        }
+
+        [Fact]
+        public void NodesThatNeverReportedAreCounted()
+        {
+            var validator = Create(kTwoSeconds, nodes: 5);
+            validator.Add(Value(1, node: "a"));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.NodesSeen);
+            Assert.Equal(4, report.NodesMissing);
+        }
+
+        private static TelemetryQualityValidator Create(TimeSpan updateInterval, int nodes,
+            TimeSpan? heartbeatInterval = null, TimeSpan? heartbeatTolerance = null)
+        {
+            return new TelemetryQualityValidator(new TelemetryQualityOptions
+            {
+                UpdateInterval = updateInterval,
+                ExpectedNodeCount = nodes,
+                HeartbeatInterval = heartbeatInterval,
+                PublishingInterval = kTwoSeconds,
+                HeartbeatTolerance = heartbeatTolerance
+            });
+        }
+
+        private static TelemetrySample Value(long value, string node = "a",
+            DateTime? messageTimestamp = null, uint? sequenceNumber = null)
+        {
+            return new TelemetrySample(node, value,
+                kEpoch.AddTicks(kTwoSeconds.Ticks * value), false,
+                messageTimestamp, sequenceNumber);
+        }
+
+        private static TelemetrySample Heartbeat(long value, DateTime sourceTimestamp,
+            DateTime messageTimestamp, string node = "a")
+        {
+            return new TelemetrySample(node, value, sourceTimestamp, true,
+                messageTimestamp);
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/TestCategories.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/TestCategories.cs
@@ -1,0 +1,28 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests
+{
+    /// <summary>
+    /// xUnit trait names and values used to select or exclude tests.
+    /// </summary>
+    public static class TestCategories
+    {
+        /// <summary>
+        /// Name of the category trait.
+        /// </summary>
+        public const string Name = "Category";
+
+        /// <summary>
+        /// <para>
+        /// Tests that run for minutes to hours. They are excluded from the
+        /// pull request build with <c>--filter "Category!=LongRunning"</c>
+        /// and run by the scheduled soak workflow with
+        /// <c>--filter "Category=LongRunning"</c>.
+        /// </para>
+        /// </summary>
+        public const string LongRunning = "LongRunning";
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityOptions.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityOptions.cs
@@ -1,0 +1,80 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
+{
+    using System;
+
+    /// <summary>
+    /// Configuration of a <see cref="TelemetryQualityValidator"/>.
+    /// </summary>
+    public sealed record class TelemetryQualityOptions
+    {
+        /// <summary>
+        /// Interval at which the server increments every counter. The
+        /// expected source timestamp distance between the counter values
+        /// <c>n</c> and <c>m</c> is <c>(m - n) * UpdateInterval</c>.
+        /// </summary>
+        public TimeSpan UpdateInterval { get; init; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Number of nodes that are expected to report. Used to detect nodes
+        /// that never produced a single value.
+        /// </summary>
+        public int ExpectedNodeCount { get; init; }
+
+        /// <summary>
+        /// Tolerance applied when comparing source timestamp distances.
+        /// Defaults to a tenth of <see cref="UpdateInterval"/>. Servers that
+        /// derive timestamps from a wall clock timer need a larger value than
+        /// servers that use a strictly monotonic schedule.
+        /// </summary>
+        public TimeSpan? Tolerance { get; init; }
+
+        /// <summary>
+        /// Configured heartbeat interval. When set, heartbeat cadence is
+        /// analysed using the message timestamp.
+        /// </summary>
+        public TimeSpan? HeartbeatInterval { get; init; }
+
+        /// <summary>
+        /// Publishing interval of the subscription. Together with
+        /// <see cref="HeartbeatInterval"/> this yields the earliest instant
+        /// at which a watchdog heartbeat may legitimately be emitted after a
+        /// value was received.
+        /// </summary>
+        public TimeSpan? PublishingInterval { get; init; }
+
+        /// <summary>
+        /// Tolerance applied when comparing heartbeat cadence. Defaults to
+        /// half of <see cref="HeartbeatInterval"/>.
+        /// </summary>
+        public TimeSpan? HeartbeatTolerance { get; init; }
+
+        /// <summary>
+        /// <para>
+        /// Drop samples whose writer sequence number was already seen.
+        /// </para>
+        /// <para>
+        /// Delivery through IoT Hub is at least once, so a redelivered
+        /// message is indistinguishable from a value that the publisher
+        /// repeated. Without suppression a transport redelivery would be
+        /// reported as a stale value and fail the run for the wrong reason.
+        /// </para>
+        /// </summary>
+        public bool SuppressDuplicates { get; init; } = true;
+
+        /// <summary>
+        /// How many sequence numbers are remembered for duplicate detection.
+        /// Bounded so a multi hour run cannot exhaust memory.
+        /// </summary>
+        public int DuplicateWindow { get; init; } = 100000;
+
+        /// <summary>
+        /// How many example observations are recorded for diagnosis.
+        /// </summary>
+        public int MaxExamples { get; init; } = 25;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityReport.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityReport.cs
@@ -1,0 +1,196 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Text;
+
+    /// <summary>
+    /// One value observed in the telemetry stream for a single counter node.
+    /// </summary>
+    /// <param name="NodeId">Identity of the node the value belongs to</param>
+    /// <param name="Value">The counter value, which doubles as its sequence</param>
+    /// <param name="SourceTimestamp">Source timestamp as reported by the server</param>
+    /// <param name="IsHeartbeat">Whether the message was flagged a heartbeat</param>
+    /// <param name="MessageTimestamp">
+    /// Time at which the notification was produced by the publisher. A
+    /// heartbeat repeats the source timestamp of the value it resends, so
+    /// only this timestamp can be used to measure heartbeat cadence.
+    /// </param>
+    /// <param name="SequenceNumber">
+    /// Writer sequence number, used to recognize a redelivered message.
+    /// </param>
+    public readonly record struct TelemetrySample(string NodeId, long Value,
+        DateTime? SourceTimestamp, bool IsHeartbeat,
+        DateTime? MessageTimestamp = null, uint? SequenceNumber = null);
+
+    /// <summary>
+    /// <para>
+    /// Aggregated verdict over a telemetry stream produced by a server whose
+    /// variables count up by exactly one every update interval. Because every
+    /// counter value is also its own sequence number, each of the four
+    /// symptoms that motivated these tests maps onto a counter that is either
+    /// zero or not:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>(a) missing values -> <see cref="MissingValues"/></item>
+    /// <item>(b) out of order -> <see cref="OutOfOrderValues"/></item>
+    /// <item>(c) source timestamp distance -> <see cref="ValueIntervalViolations"/>
+    /// for real value changes and <see cref="MessageIntervalViolations"/> for
+    /// what a consumer that ignores the heartbeat flag observes</item>
+    /// <item>(d) old value shortly after a new one -> <see cref="UnflaggedRepeats"/>
+    /// and <see cref="OutOfOrderIncludingHeartbeats"/></item>
+    /// </list>
+    /// </summary>
+    public sealed record class TelemetryQualityReport
+    {
+        /// <summary> Total number of samples that were analysed </summary>
+        public long TotalSamples { get; init; }
+        /// <summary> Samples that were not flagged as heartbeat </summary>
+        public long ValueSamples { get; init; }
+        /// <summary> Samples that were flagged as heartbeat </summary>
+        public long HeartbeatSamples { get; init; }
+        /// <summary> Distinct nodes that produced at least one sample </summary>
+        public int NodesSeen { get; init; }
+        /// <summary> Nodes that never produced a sample </summary>
+        public int NodesMissing { get; init; }
+
+        /// <summary>
+        /// (a) Counter values that were never delivered, counted as the gap
+        /// between two consecutive delivered values.
+        /// </summary>
+        public long MissingValues { get; init; }
+
+        /// <summary>
+        /// (b) Real value changes that arrived after a higher value had
+        /// already been delivered for the same node.
+        /// </summary>
+        public long OutOfOrderValues { get; init; }
+
+        /// <summary>
+        /// (b)/(d) Same as <see cref="OutOfOrderValues"/> but counting
+        /// heartbeats as well, which is what a consumer sees when it does
+        /// not inspect the heartbeat flag.
+        /// </summary>
+        public long OutOfOrderIncludingHeartbeats { get; init; }
+
+        /// <summary>
+        /// (d) Samples that repeated the value that was delivered
+        /// immediately before for the same node.
+        /// </summary>
+        public long RepeatedValues { get; init; }
+
+        /// <summary>
+        /// (d) Subset of <see cref="RepeatedValues"/> that carried the
+        /// heartbeat flag.
+        /// </summary>
+        public long RepeatedValuesFromHeartbeat { get; init; }
+
+        /// <summary>
+        /// (d) Repeats that did <em>not</em> carry the heartbeat flag. A
+        /// consumer that honours the flag can filter heartbeats out, so this
+        /// is the number of stale values it cannot defend itself against and
+        /// must always be zero.
+        /// </summary>
+        public long UnflaggedRepeats => RepeatedValues - RepeatedValuesFromHeartbeat;
+
+        /// <summary>
+        /// (c) Distance between the source timestamps of two consecutive
+        /// real value changes that was not the expected multiple of the
+        /// update interval.
+        /// </summary>
+        public long ValueIntervalViolations { get; init; }
+
+        /// <summary>
+        /// (c) Distance between the source timestamps of two consecutive
+        /// samples, heartbeats included, that was outside tolerance. This is
+        /// expected to be non zero whenever heartbeats are supposed to fire,
+        /// because a heartbeat deliberately repeats a source timestamp.
+        /// </summary>
+        public long MessageIntervalViolations { get; init; }
+
+        /// <summary> Samples that carried no source timestamp at all </summary>
+        public long SamplesWithoutSourceTimestamp { get; init; }
+
+        /// <summary>
+        /// Heartbeats whose source timestamp differed from the source
+        /// timestamp of the value they resend. Must be zero for the
+        /// <c>WatchdogLKV</c> behavior, which resends the last known value
+        /// unchanged.
+        /// </summary>
+        public long HeartbeatsWithChangedTimestamp { get; init; }
+
+        /// <summary>
+        /// Heartbeats that arrived earlier after the preceding value than the
+        /// watchdog grace period allows. A watchdog may only report a node
+        /// silent once the heartbeat interval plus one publishing interval
+        /// passed without data.
+        /// </summary>
+        public long EarlyHeartbeats { get; init; }
+
+        /// <summary>
+        /// Gaps between two consecutive heartbeats of the same node that did
+        /// not match the configured heartbeat interval.
+        /// </summary>
+        public long HeartbeatCadenceViolations { get; init; }
+
+        /// <summary> Lowest number of heartbeats observed on any node </summary>
+        public long MinHeartbeatsPerNode { get; init; }
+
+        /// <summary> Highest number of heartbeats observed on any node </summary>
+        public long MaxHeartbeatsPerNode { get; init; }
+
+        /// <summary>
+        /// Samples that were ignored because their writer sequence number had
+        /// already been seen, i.e. the message was redelivered by the
+        /// transport. Diagnostic only.
+        /// </summary>
+        public long DuplicateDeliveries { get; init; }
+
+        /// <summary> First few observations, for diagnosis </summary>
+        public IReadOnlyList<string> Examples { get; init; } = [];
+
+        /// <summary>
+        /// Whether the stream was complete, ordered and evenly spaced. Only
+        /// meaningful for a scenario in which no heartbeat is expected.
+        /// </summary>
+        public bool IsClean =>
+            MissingValues == 0 &&
+            OutOfOrderValues == 0 &&
+            OutOfOrderIncludingHeartbeats == 0 &&
+            RepeatedValues == 0 &&
+            ValueIntervalViolations == 0 &&
+            MessageIntervalViolations == 0 &&
+            SamplesWithoutSourceTimestamp == 0 &&
+            NodesMissing == 0;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            var builder = new StringBuilder()
+                .AppendLine(CultureInfo.InvariantCulture, $"Samples             : {TotalSamples} ({ValueSamples} values, {HeartbeatSamples} heartbeats)")
+                .AppendLine(CultureInfo.InvariantCulture, $"Nodes               : {NodesSeen} seen, {NodesMissing} never reported")
+                .AppendLine(CultureInfo.InvariantCulture, $"(a) missing values  : {MissingValues}")
+                .AppendLine(CultureInfo.InvariantCulture, $"(b) out of order    : {OutOfOrderValues} (incl. heartbeats: {OutOfOrderIncludingHeartbeats})")
+                .AppendLine(CultureInfo.InvariantCulture, $"(c) value interval  : {ValueIntervalViolations} violations")
+                .AppendLine(CultureInfo.InvariantCulture, $"(c) message interval: {MessageIntervalViolations} violations")
+                .AppendLine(CultureInfo.InvariantCulture, $"(d) repeated values : {RepeatedValues} ({RepeatedValuesFromHeartbeat} heartbeat, {UnflaggedRepeats} unflagged)")
+                .AppendLine(CultureInfo.InvariantCulture, $"    no timestamp    : {SamplesWithoutSourceTimestamp}")
+                .AppendLine(CultureInfo.InvariantCulture, $"    heartbeats/node : {MinHeartbeatsPerNode} min, {MaxHeartbeatsPerNode} max")
+                .AppendLine(CultureInfo.InvariantCulture, $"    hb timestamp    : {HeartbeatsWithChangedTimestamp} changed")
+                .AppendLine(CultureInfo.InvariantCulture, $"    hb too early    : {EarlyHeartbeats}")
+                .AppendLine(CultureInfo.InvariantCulture, $"    hb cadence      : {HeartbeatCadenceViolations} violations")
+                .AppendLine(CultureInfo.InvariantCulture, $"    redelivered     : {DuplicateDeliveries}");
+            foreach (var example in Examples)
+            {
+                builder.AppendLine(CultureInfo.InvariantCulture, $"  ! {example}");
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
@@ -1,0 +1,530 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text.Json;
+
+    /// <summary>
+    /// <para>
+    /// Analyses the telemetry produced for a server whose variables count up
+    /// from zero by exactly one every update interval, so the value carries
+    /// its own ordering and the expected source timestamp distance between
+    /// two values <c>n</c> and <c>m</c> is exactly
+    /// <c>(m - n) * updateInterval</c>.
+    /// </para>
+    /// <para>
+    /// The validator is fed one sample at a time and only keeps per node
+    /// state plus a bounded duplicate detection window, so it can run for
+    /// hours without accumulating memory.
+    /// </para>
+    /// <para>
+    /// It is shared by the in process soak tests and the IoT Edge end to end
+    /// soak tests, which is why it has no dependency beyond
+    /// <see cref="System.Text.Json"/>.
+    /// </para>
+    /// </summary>
+    public sealed class TelemetryQualityValidator
+    {
+        /// <summary>
+        /// Create validator
+        /// </summary>
+        /// <param name="options"></param>
+        public TelemetryQualityValidator(TelemetryQualityOptions options)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            _options = options;
+            _tolerance = options.Tolerance
+                ?? TimeSpan.FromTicks(options.UpdateInterval.Ticks / 10);
+            _heartbeatTolerance = options.HeartbeatTolerance
+                ?? TimeSpan.FromTicks((options.HeartbeatInterval ?? TimeSpan.Zero).Ticks / 2);
+            //
+            // Earliest instant at which a watchdog heartbeat may legitimately
+            // be emitted after a value was received. Values can only be
+            // delivered on publish boundaries, so the absence of data cannot
+            // be established earlier than one publishing interval after the
+            // heartbeat interval expired. The grace is capped at the
+            // heartbeat interval itself, mirroring the publisher.
+            //
+            if (options.HeartbeatInterval.HasValue)
+            {
+                var heartbeatInterval = options.HeartbeatInterval.Value;
+                var publishingInterval = options.PublishingInterval ?? TimeSpan.Zero;
+                var grace = publishingInterval > heartbeatInterval
+                    ? heartbeatInterval : publishingInterval;
+                _earliestHeartbeat = heartbeatInterval + grace;
+            }
+        }
+
+        /// <summary>
+        /// Add a sample to the analysis.
+        /// </summary>
+        /// <param name="sample"></param>
+        public void Add(TelemetrySample sample)
+        {
+            if (IsDuplicate(sample))
+            {
+                _duplicateDeliveries++;
+                return;
+            }
+
+            _totalSamples++;
+            if (sample.IsHeartbeat)
+            {
+                _heartbeatSamples++;
+            }
+            else
+            {
+                _valueSamples++;
+            }
+
+            if (!_nodes.TryGetValue(sample.NodeId, out var state))
+            {
+                _nodes.Add(sample.NodeId, state = new NodeState());
+            }
+
+            if (sample.SourceTimestamp == null)
+            {
+                _samplesWithoutSourceTimestamp++;
+            }
+
+            //
+            // Distance between the source timestamps of two consecutive
+            // samples, which is what a consumer that does not look at the
+            // heartbeat flag observes. A repeated value has a distance of
+            // zero and therefore shows up here.
+            //
+            if (state.LastSampleTimestamp != null && sample.SourceTimestamp != null)
+            {
+                var delta = sample.SourceTimestamp.Value - state.LastSampleTimestamp.Value;
+                if (!IsExpectedDistance(delta, 1))
+                {
+                    _messageIntervalViolations++;
+                    AddExample(
+                        $"{sample.NodeId}: message source timestamp distance {delta} " +
+                        $"(value {state.LastSampleValue} -> {sample.Value}, " +
+                        $"heartbeat={sample.IsHeartbeat})");
+                }
+            }
+
+            if (state.HasSample)
+            {
+                if (sample.Value < state.LastSampleValue)
+                {
+                    _outOfOrderIncludingHeartbeats++;
+                    if (!sample.IsHeartbeat)
+                    {
+                        _outOfOrderValues++;
+                    }
+                    AddExample(
+                        $"{sample.NodeId}: value went backwards {state.LastSampleValue} -> " +
+                        $"{sample.Value} (heartbeat={sample.IsHeartbeat})");
+                }
+                else if (sample.Value == state.LastSampleValue)
+                {
+                    _repeatedValues++;
+                    if (sample.IsHeartbeat)
+                    {
+                        _repeatedValuesFromHeartbeat++;
+                    }
+                    else
+                    {
+                        AddExample(
+                            $"{sample.NodeId}: value {sample.Value} repeated without the " +
+                            "heartbeat indicator");
+                    }
+                }
+            }
+
+            state.HasSample = true;
+            state.LastSampleValue = sample.Value;
+            state.LastSampleTimestamp = sample.SourceTimestamp;
+
+            if (sample.IsHeartbeat)
+            {
+                AnalyzeHeartbeat(sample, state);
+                return;
+            }
+
+            //
+            // Gaps and timestamp distances over real value changes. Heartbeats
+            // repeat a value that was already accounted for and must not be
+            // treated as a new value.
+            //
+            if (state.HasValue && sample.Value > state.LastValue)
+            {
+                var gap = sample.Value - state.LastValue - 1;
+                if (gap > 0)
+                {
+                    _missingValues += gap;
+                    AddExample(
+                        $"{sample.NodeId}: {gap} value(s) missing between " +
+                        $"{state.LastValue} and {sample.Value}");
+                }
+                if (state.LastValueTimestamp != null && sample.SourceTimestamp != null)
+                {
+                    var delta = sample.SourceTimestamp.Value - state.LastValueTimestamp.Value;
+                    if (!IsExpectedDistance(delta, sample.Value - state.LastValue))
+                    {
+                        _valueIntervalViolations++;
+                        AddExample(
+                            $"{sample.NodeId}: value source timestamp distance {delta} " +
+                            $"for {sample.Value - state.LastValue} increment(s) " +
+                            $"({state.LastValue} -> {sample.Value})");
+                    }
+                }
+            }
+
+            if (!state.HasValue || sample.Value > state.LastValue)
+            {
+                state.HasValue = true;
+                state.LastValue = sample.Value;
+                state.LastValueTimestamp = sample.SourceTimestamp;
+                state.LastValueMessageTimestamp = sample.MessageTimestamp;
+            }
+            state.LastHeartbeatMessageTimestamp = null;
+        }
+
+        /// <summary>
+        /// Extract and add every sample carried by a samples mode
+        /// (monitored item) message.
+        /// </summary>
+        /// <param name="message"></param>
+        public void AddSamplesMessage(JsonElement message)
+        {
+            if (message.ValueKind != JsonValueKind.Object ||
+                !message.TryGetProperty("NodeId", out var nodeId) ||
+                nodeId.ValueKind != JsonValueKind.String)
+            {
+                return;
+            }
+            if (!message.TryGetProperty("Value", out var value))
+            {
+                return;
+            }
+            if (!TryReadDataValue(value, out var counter, out var sourceTimestamp))
+            {
+                return;
+            }
+            Add(new TelemetrySample(nodeId.GetString()!, counter, sourceTimestamp,
+                IsHeartbeat(message), ReadTimestamp(message), ReadSequenceNumber(message)));
+        }
+
+        /// <summary>
+        /// Extract and add every sample carried by a PubSub network message
+        /// or a single data set message.
+        /// </summary>
+        /// <param name="message"></param>
+        public void AddPubSubMessage(JsonElement message)
+        {
+            if (message.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            if (message.TryGetProperty("Messages", out var messages) &&
+                messages.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var dataSetMessage in messages.EnumerateArray())
+                {
+                    AddDataSetMessage(dataSetMessage);
+                }
+                return;
+            }
+            AddDataSetMessage(message);
+        }
+
+        /// <summary>
+        /// Build the report
+        /// </summary>
+        public TelemetryQualityReport CreateReport()
+        {
+            var minHeartbeats = 0L;
+            var maxHeartbeats = 0L;
+            if (_nodes.Count > 0)
+            {
+                minHeartbeats = _nodes.Values.Min(n => n.Heartbeats);
+                maxHeartbeats = _nodes.Values.Max(n => n.Heartbeats);
+            }
+            return new TelemetryQualityReport
+            {
+                TotalSamples = _totalSamples,
+                ValueSamples = _valueSamples,
+                HeartbeatSamples = _heartbeatSamples,
+                NodesSeen = _nodes.Count,
+                NodesMissing = Math.Max(0, _options.ExpectedNodeCount - _nodes.Count),
+                MissingValues = _missingValues,
+                OutOfOrderValues = _outOfOrderValues,
+                OutOfOrderIncludingHeartbeats = _outOfOrderIncludingHeartbeats,
+                RepeatedValues = _repeatedValues,
+                RepeatedValuesFromHeartbeat = _repeatedValuesFromHeartbeat,
+                ValueIntervalViolations = _valueIntervalViolations,
+                MessageIntervalViolations = _messageIntervalViolations,
+                SamplesWithoutSourceTimestamp = _samplesWithoutSourceTimestamp,
+                HeartbeatsWithChangedTimestamp = _heartbeatsWithChangedTimestamp,
+                EarlyHeartbeats = _earlyHeartbeats,
+                HeartbeatCadenceViolations = _heartbeatCadenceViolations,
+                MinHeartbeatsPerNode = minHeartbeats,
+                MaxHeartbeatsPerNode = maxHeartbeats,
+                DuplicateDeliveries = _duplicateDeliveries,
+                Examples = _examples.ToList()
+            };
+        }
+
+        /// <summary>
+        /// Analyse a heartbeat: it must repeat the source timestamp of the
+        /// value it resends, it must not arrive before the watchdog grace
+        /// period elapsed, and consecutive heartbeats must be one heartbeat
+        /// interval apart.
+        /// </summary>
+        /// <param name="sample"></param>
+        /// <param name="state"></param>
+        private void AnalyzeHeartbeat(TelemetrySample sample, NodeState state)
+        {
+            state.Heartbeats++;
+
+            if (state.HasValue && state.LastValueTimestamp != null &&
+                sample.SourceTimestamp != null &&
+                sample.SourceTimestamp != state.LastValueTimestamp)
+            {
+                _heartbeatsWithChangedTimestamp++;
+                AddExample(
+                    $"{sample.NodeId}: heartbeat source timestamp {sample.SourceTimestamp} " +
+                    $"differs from the value it resends ({state.LastValueTimestamp})");
+            }
+
+            if (sample.MessageTimestamp == null)
+            {
+                return;
+            }
+
+            if (_earliestHeartbeat != null && state.LastValueMessageTimestamp != null)
+            {
+                var sinceValue = sample.MessageTimestamp.Value -
+                    state.LastValueMessageTimestamp.Value;
+                if (sinceValue + _heartbeatTolerance < _earliestHeartbeat.Value)
+                {
+                    _earlyHeartbeats++;
+                    AddExample(
+                        $"{sample.NodeId}: heartbeat {sinceValue} after the last value, " +
+                        $"earlier than the {_earliestHeartbeat.Value} watchdog grace period");
+                }
+            }
+
+            if (_options.HeartbeatInterval != null &&
+                state.LastHeartbeatMessageTimestamp != null)
+            {
+                var sinceHeartbeat = sample.MessageTimestamp.Value -
+                    state.LastHeartbeatMessageTimestamp.Value;
+                if ((sinceHeartbeat - _options.HeartbeatInterval.Value).Duration() >
+                    _heartbeatTolerance)
+                {
+                    _heartbeatCadenceViolations++;
+                    AddExample(
+                        $"{sample.NodeId}: {sinceHeartbeat} between heartbeats, expected " +
+                        $"{_options.HeartbeatInterval.Value}");
+                }
+            }
+
+            state.LastHeartbeatMessageTimestamp = sample.MessageTimestamp;
+        }
+
+        /// <summary>
+        /// Whether the sample was already seen. Delivery is at least once, so
+        /// a redelivered message must not be reported as a repeated value.
+        /// </summary>
+        /// <param name="sample"></param>
+        private bool IsDuplicate(TelemetrySample sample)
+        {
+            if (!_options.SuppressDuplicates || sample.SequenceNumber == null)
+            {
+                return false;
+            }
+            if (!_seenSequenceNumbers.Add(sample.SequenceNumber.Value))
+            {
+                return true;
+            }
+            _seenSequenceNumberOrder.Enqueue(sample.SequenceNumber.Value);
+            while (_seenSequenceNumberOrder.Count > _options.DuplicateWindow)
+            {
+                _seenSequenceNumbers.Remove(_seenSequenceNumberOrder.Dequeue());
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Add a single PubSub data set message
+        /// </summary>
+        /// <param name="dataSetMessage"></param>
+        private void AddDataSetMessage(JsonElement dataSetMessage)
+        {
+            if (dataSetMessage.ValueKind != JsonValueKind.Object ||
+                !dataSetMessage.TryGetProperty("Payload", out var payload) ||
+                payload.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            var heartbeat = IsHeartbeat(dataSetMessage);
+            var timestamp = ReadTimestamp(dataSetMessage);
+            //
+            // A data set message carries one sequence number for all of its
+            // fields, so it can only be used to deduplicate when the data set
+            // holds a single field.
+            //
+            var fieldCount = payload.EnumerateObject().Count();
+            var sequenceNumber = fieldCount == 1 ? ReadSequenceNumber(dataSetMessage) : null;
+            foreach (var field in payload.EnumerateObject())
+            {
+                if (TryReadDataValue(field.Value, out var counter, out var sourceTimestamp))
+                {
+                    Add(new TelemetrySample(field.Name, counter, sourceTimestamp, heartbeat,
+                        timestamp, sequenceNumber));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Read a counter value and its source timestamp from an encoded
+        /// data value. Depending on the configured field content mask the
+        /// value is either a bare number or an object wrapping it.
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="value"></param>
+        /// <param name="sourceTimestamp"></param>
+        private static bool TryReadDataValue(JsonElement element, out long value,
+            out DateTime? sourceTimestamp)
+        {
+            value = 0;
+            sourceTimestamp = null;
+            if (element.ValueKind == JsonValueKind.Number)
+            {
+                return element.TryGetInt64(out value);
+            }
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                return false;
+            }
+            if (element.TryGetProperty("SourceTimestamp", out var timestamp) &&
+                timestamp.ValueKind == JsonValueKind.String &&
+                timestamp.TryGetDateTime(out var parsed))
+            {
+                sourceTimestamp = parsed.ToUniversalTime();
+            }
+            if (!element.TryGetProperty("Value", out var inner))
+            {
+                return false;
+            }
+            //
+            // Reversible encoding wraps the value once more into a
+            // { "Type": .., "Body": .. } variant envelope.
+            //
+            if (inner.ValueKind == JsonValueKind.Object &&
+                inner.TryGetProperty("Body", out var body))
+            {
+                inner = body;
+            }
+            return inner.ValueKind == JsonValueKind.Number && inner.TryGetInt64(out value);
+        }
+
+        /// <summary>
+        /// Whether the message carries the heartbeat indicator
+        /// </summary>
+        /// <param name="message"></param>
+        private static bool IsHeartbeat(JsonElement message)
+        {
+            return message.TryGetProperty("Heartbeat", out var heartbeat) &&
+                heartbeat.ValueKind == JsonValueKind.True;
+        }
+
+        /// <summary>
+        /// Read the time at which the notification was produced
+        /// </summary>
+        /// <param name="message"></param>
+        private static DateTime? ReadTimestamp(JsonElement message)
+        {
+            return message.TryGetProperty("Timestamp", out var timestamp) &&
+                timestamp.ValueKind == JsonValueKind.String &&
+                timestamp.TryGetDateTime(out var parsed) ? parsed.ToUniversalTime() : null;
+        }
+
+        /// <summary>
+        /// Read the writer sequence number
+        /// </summary>
+        /// <param name="message"></param>
+        private static uint? ReadSequenceNumber(JsonElement message)
+        {
+            return message.TryGetProperty("SequenceNumber", out var sequenceNumber) &&
+                sequenceNumber.ValueKind == JsonValueKind.Number &&
+                sequenceNumber.TryGetUInt32(out var parsed) ? parsed : null;
+        }
+
+        /// <summary>
+        /// Whether the observed distance matches the expected number of
+        /// update intervals within tolerance.
+        /// </summary>
+        /// <param name="observed"></param>
+        /// <param name="increments"></param>
+        private bool IsExpectedDistance(TimeSpan observed, long increments)
+        {
+            var expected = TimeSpan.FromTicks(_options.UpdateInterval.Ticks * increments);
+            return (observed - expected).Duration() <= _tolerance;
+        }
+
+        /// <summary>
+        /// Record an example observation, bounded so a broken stream cannot
+        /// exhaust memory.
+        /// </summary>
+        /// <param name="example"></param>
+        private void AddExample(string example)
+        {
+            if (_examples.Count < _options.MaxExamples)
+            {
+                _examples.Add(example);
+            }
+        }
+
+        /// <summary>
+        /// Per node analysis state
+        /// </summary>
+        private sealed class NodeState
+        {
+            public bool HasSample { get; set; }
+            public long LastSampleValue { get; set; }
+            public DateTime? LastSampleTimestamp { get; set; }
+            public bool HasValue { get; set; }
+            public long LastValue { get; set; }
+            public DateTime? LastValueTimestamp { get; set; }
+            public DateTime? LastValueMessageTimestamp { get; set; }
+            public DateTime? LastHeartbeatMessageTimestamp { get; set; }
+            public long Heartbeats { get; set; }
+        }
+
+        private readonly TelemetryQualityOptions _options;
+        private readonly Dictionary<string, NodeState> _nodes = [];
+        private readonly List<string> _examples = [];
+        private readonly HashSet<uint> _seenSequenceNumbers = [];
+        private readonly Queue<uint> _seenSequenceNumberOrder = new();
+        private readonly TimeSpan _tolerance;
+        private readonly TimeSpan _heartbeatTolerance;
+        private readonly TimeSpan? _earliestHeartbeat;
+        private long _totalSamples;
+        private long _valueSamples;
+        private long _heartbeatSamples;
+        private long _missingValues;
+        private long _outOfOrderValues;
+        private long _outOfOrderIncludingHeartbeats;
+        private long _repeatedValues;
+        private long _repeatedValuesFromHeartbeat;
+        private long _valueIntervalViolations;
+        private long _messageIntervalViolations;
+        private long _samplesWithoutSourceTimestamp;
+        private long _heartbeatsWithChangedTimestamp;
+        private long _earlyHeartbeats;
+        private long _heartbeatCadenceViolations;
+        private long _duplicateDeliveries;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterNodeManager.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterNodeManager.cs
@@ -1,0 +1,236 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Counter
+{
+    using Opc.Ua;
+    using Opc.Ua.Server;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// <para>
+    /// A node manager exposing a configurable number of variables that all
+    /// count up from zero in lockstep. One increment is produced every
+    /// update interval, so the value of a variable is at the same time its
+    /// sequence number: a consumer can detect a lost value as a gap and a
+    /// reordered value as a decrease, without any additional bookkeeping.
+    /// </para>
+    /// <para>
+    /// Variables declare a minimum sampling interval of zero which makes the
+    /// stack monitor them change based instead of through a sampling group.
+    /// Every increment is therefore queued on every monitored item, and with
+    /// a sufficiently large queue the expected telemetry stream is complete
+    /// and gap free no matter which sampling interval a client requests.
+    /// </para>
+    /// </summary>
+    public sealed class CounterNodeManager : CustomNodeManager2
+    {
+        /// <summary>
+        /// Highest counter value that has been produced so far. Every
+        /// variable has been set to every value between zero and this
+        /// value inclusive.
+        /// </summary>
+        public long CurrentValue => Interlocked.Read(ref _counter);
+
+        /// <summary>
+        /// Time at which the counter value zero was produced. Source
+        /// timestamps are derived from this instant when scheduled
+        /// timestamps are enabled.
+        /// </summary>
+        public DateTime Epoch { get; private set; }
+
+        /// <summary>
+        /// Options in use
+        /// </summary>
+        public CounterServerOptions Options { get; }
+
+        /// <summary>
+        /// Create node manager
+        /// </summary>
+        /// <param name="server"></param>
+        /// <param name="configuration"></param>
+        /// <param name="options"></param>
+        public CounterNodeManager(IServerInternal server,
+            ApplicationConfiguration configuration, CounterServerOptions options)
+            : base(server, configuration, Namespaces.Counter)
+        {
+            Options = options ?? new CounterServerOptions();
+            SystemContext.NodeIdFactory = this;
+        }
+
+        /// <summary>
+        /// Browse name of the counter variable with the given index.
+        /// </summary>
+        /// <param name="index"></param>
+        public static string GetBrowseName(int index)
+        {
+            return string.Create(CultureInfo.InvariantCulture, $"Counter_{index}");
+        }
+
+        /// <summary>
+        /// Node id of the counter variable with the given index in the
+        /// namespace uri form understood by the published nodes
+        /// configuration.
+        /// </summary>
+        /// <param name="index"></param>
+        public static string GetNodeId(int index)
+        {
+            return string.Create(CultureInfo.InvariantCulture,
+                $"nsu={Namespaces.Counter};s={GetBrowseName(index)}");
+        }
+
+        /// <inheritdoc/>
+        public override NodeId New(ISystemContext context, NodeState node)
+        {
+            return node.NodeId;
+        }
+
+        /// <inheritdoc/>
+        public override void CreateAddressSpace(
+            IDictionary<NodeId, IList<IReference>> externalReferences)
+        {
+            lock (Lock)
+            {
+                if (!externalReferences.TryGetValue(ObjectIds.ObjectsFolder,
+                    out var references))
+                {
+                    externalReferences[ObjectIds.ObjectsFolder] = references = [];
+                }
+
+                Epoch = DateTime.UtcNow;
+
+                var root = new FolderState(null)
+                {
+                    SymbolicName = kRootName,
+                    ReferenceTypeId = ReferenceTypeIds.Organizes,
+                    TypeDefinitionId = ObjectTypeIds.FolderType,
+                    NodeId = new NodeId(kRootName, NamespaceIndex),
+                    BrowseName = new QualifiedName(kRootName, NamespaceIndex),
+                    DisplayName = new LocalizedText("en", kRootName),
+                    WriteMask = AttributeWriteMask.None,
+                    UserWriteMask = AttributeWriteMask.None,
+                    EventNotifier = EventNotifiers.None
+                };
+                root.AddReference(ReferenceTypeIds.Organizes, true, ObjectIds.ObjectsFolder);
+                references.Add(new NodeStateReference(ReferenceTypeIds.Organizes,
+                    false, root.NodeId));
+
+                _variables = new BaseDataVariableState[Options.NodeCount];
+                for (var index = 0; index < Options.NodeCount; index++)
+                {
+                    var name = GetBrowseName(index);
+                    var variable = new BaseDataVariableState(root)
+                    {
+                        SymbolicName = name,
+                        ReferenceTypeId = ReferenceTypeIds.Organizes,
+                        TypeDefinitionId = VariableTypeIds.BaseDataVariableType,
+                        NodeId = new NodeId(name, NamespaceIndex),
+                        BrowseName = new QualifiedName(name, NamespaceIndex),
+                        DisplayName = new LocalizedText("en", name),
+                        WriteMask = AttributeWriteMask.None,
+                        UserWriteMask = AttributeWriteMask.None,
+                        DataType = DataTypeIds.UInt64,
+                        ValueRank = ValueRanks.Scalar,
+                        AccessLevel = AccessLevels.CurrentRead,
+                        UserAccessLevel = AccessLevels.CurrentRead,
+                        Historizing = false,
+                        Value = (ulong)0,
+                        StatusCode = StatusCodes.Good,
+                        Timestamp = Epoch,
+                        //
+                        // Zero means the stack reports every change instead of
+                        // polling the node through a sampling group. Without
+                        // this, values are sampled at the client's requested
+                        // interval and increments are legitimately lost, which
+                        // would make gap detection meaningless.
+                        //
+                        MinimumSamplingInterval = 0
+                    };
+                    root.AddChild(variable);
+                    _variables[index] = variable;
+                }
+
+                AddPredefinedNode(SystemContext, root);
+            }
+
+            _updates = Task.Factory.StartNew(() => RunAsync(_cts.Token),
+                _cts.Token, TaskCreationOptions.LongRunning,
+                TaskScheduler.Default).Unwrap();
+        }
+
+        /// <inheritdoc/>
+        public override void DeleteAddressSpace()
+        {
+            lock (Lock)
+            {
+                _variables = null;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                try
+                {
+                    _cts.Cancel();
+                    _updates?.GetAwaiter().GetResult();
+                }
+                catch (OperationCanceledException) { }
+                catch (AggregateException) { }
+                finally
+                {
+                    _updates = null;
+                    _cts.Dispose();
+                }
+            }
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Produce one increment on every counter variable.
+        /// </summary>
+        private async Task RunAsync(CancellationToken ct)
+        {
+            using var timer = new PeriodicTimer(Options.UpdateInterval);
+            try
+            {
+                while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+                {
+                    var value = Interlocked.Increment(ref _counter);
+                    var timestamp = Options.UseScheduledTimestamps
+                        ? Epoch.AddTicks(value * Options.UpdateInterval.Ticks)
+                        : DateTime.UtcNow;
+                    lock (Lock)
+                    {
+                        var variables = _variables;
+                        if (variables == null)
+                        {
+                            continue;
+                        }
+                        foreach (var variable in variables)
+                        {
+                            variable.Value = (ulong)value;
+                            variable.Timestamp = timestamp;
+                            variable.ClearChangeMasks(SystemContext, false);
+                        }
+                    }
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        private const string kRootName = "Counters";
+        private readonly CancellationTokenSource _cts = new();
+        private BaseDataVariableState[] _variables;
+        private Task _updates;
+        private long _counter;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServer.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServer.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Counter
+{
+    using Opc.Ua;
+    using Opc.Ua.Server;
+
+    /// <summary>
+    /// Node manager factory for the deterministic counter server.
+    /// </summary>
+    public sealed class CounterServer : INodeManagerFactory
+    {
+        /// <inheritdoc/>
+        public StringCollection NamespacesUris => [Namespaces.Counter];
+
+        /// <summary>
+        /// The node manager that was created, if any. Tests use it to
+        /// correlate the observed telemetry with what the server actually
+        /// produced.
+        /// </summary>
+        public CounterNodeManager NodeManager { get; private set; }
+
+        /// <summary>
+        /// Create factory
+        /// </summary>
+        /// <param name="options"></param>
+        public CounterServer(CounterServerOptions options = null)
+        {
+            _options = options ?? new CounterServerOptions();
+        }
+
+        /// <inheritdoc/>
+        public INodeManager Create(IServerInternal server,
+            ApplicationConfiguration configuration)
+        {
+            var nodeManager = new CounterNodeManager(server, configuration, _options);
+            NodeManager = nodeManager;
+            return nodeManager;
+        }
+
+        private readonly CounterServerOptions _options;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServerOptions.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServerOptions.cs
@@ -1,0 +1,43 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Counter
+{
+    using System;
+
+    /// <summary>
+    /// Options controlling the deterministic counter server. The server
+    /// exposes <see cref="NodeCount"/> variables that all count up from
+    /// zero in lockstep, one increment every <see cref="UpdateInterval"/>.
+    /// </summary>
+    public sealed record class CounterServerOptions
+    {
+        /// <summary>
+        /// Number of counter variables to expose.
+        /// </summary>
+        public int NodeCount { get; init; } = 100;
+
+        /// <summary>
+        /// Interval at which every counter is incremented by exactly one.
+        /// </summary>
+        public TimeSpan UpdateInterval { get; init; } = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// <para>
+        /// When set the source timestamp of every value is taken from a
+        /// strictly monotonic schedule (<c>epoch + counter * interval</c>)
+        /// rather than from the wall clock at the time the value is
+        /// produced.
+        /// </para>
+        /// <para>
+        /// This makes the expected distance between two consecutive source
+        /// timestamps exactly <see cref="UpdateInterval"/>, so any deviation
+        /// observed by a consumer is unambiguously introduced downstream of
+        /// the server and not by timer jitter inside it.
+        /// </para>
+        /// </summary>
+        public bool UseScheduledTimestamps { get; init; } = true;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/Namespaces.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/Namespaces.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Counter
+{
+    /// <summary>
+    /// Defines constants for namespaces used by the counter server.
+    /// </summary>
+    public static class Namespaces
+    {
+        /// <summary>
+        /// The namespace for the nodes provided by the counter server.
+        /// </summary>
+        public const string Counter = "http://microsoft.com/Industrial-IoT/Counter";
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/CounterServer.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Fixtures/CounterServer.cs
@@ -1,0 +1,107 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Testing.Fixtures
+{
+    using global::Counter;
+    using Microsoft.Extensions.Logging;
+    using Opc.Ua.Server;
+    using Opc.Ua.Test;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Hosts the deterministic <see cref="global::Counter.CounterServer"/>
+    /// whose variables all count up from zero in lockstep. Used by the long
+    /// running telemetry quality tests to detect lost, reordered and stale
+    /// values.
+    /// </summary>
+    public class CounterServer : BaseServerFixture
+    {
+        /// <summary>
+        /// The node manager backing the counter variables. Exposes the
+        /// highest value the server has produced so far.
+        /// </summary>
+        public CounterNodeManager NodeManager => _factory.NodeManager;
+
+        /// <summary>
+        /// Options the server was created with
+        /// </summary>
+        public CounterServerOptions Options { get; }
+
+        /// <summary>
+        /// Node id of the counter variable with the given index
+        /// </summary>
+        /// <param name="index"></param>
+        public static string GetNodeId(int index)
+        {
+            return CounterNodeManager.GetNodeId(index);
+        }
+
+        /// <summary>
+        /// Default fixture instance used by xUnit IClassFixture.
+        /// </summary>
+        public CounterServer()
+            : this(new CounterServerOptions())
+        {
+        }
+
+        /// <summary>
+        /// Create fixture with explicit options
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="loggerFactory"></param>
+        public CounterServer(CounterServerOptions options,
+            ILoggerFactory? loggerFactory = null)
+            : this(new global::Counter.CounterServer(options), options, loggerFactory)
+        {
+        }
+
+        /// <summary>
+        /// Create fixture. The factory instance has to exist before the base
+        /// constructor runs because the base constructor is what asks it to
+        /// create the node manager.
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <param name="options"></param>
+        /// <param name="loggerFactory"></param>
+        private CounterServer(global::Counter.CounterServer factory,
+            CounterServerOptions options, ILoggerFactory? loggerFactory)
+            : base((_, _) => Nodes(factory), loggerFactory)
+        {
+            _factory = factory;
+            Options = options;
+        }
+
+        /// <summary>
+        /// Counter server nodes
+        /// </summary>
+        /// <param name="factory"></param>
+        private static IEnumerable<INodeManagerFactory> Nodes(
+            global::Counter.CounterServer factory)
+        {
+            yield return factory;
+        }
+
+        /// <summary>
+        /// Create a counter server with the given number of variables that
+        /// increments every <paramref name="updateInterval"/>.
+        /// </summary>
+        /// <param name="nodeCount"></param>
+        /// <param name="updateInterval"></param>
+        /// <param name="loggerFactory"></param>
+        public static CounterServer Create(int nodeCount, TimeSpan updateInterval,
+            ILoggerFactory? loggerFactory = null)
+        {
+            return new CounterServer(new CounterServerOptions
+            {
+                NodeCount = nodeCount,
+                UpdateInterval = updateInterval
+            }, loggerFactory);
+        }
+
+        private readonly global::Counter.CounterServer _factory;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Heartbeat.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/src/Stack/Services/OpcUaMonitoredItem.Heartbeat.cs
@@ -331,6 +331,39 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                     // A new value was published while we waited - drop heartbeat
                     return;
                 }
+
+                //
+                // Watchdog semantics: a heartbeat is only due when no value
+                // was received for the heartbeat interval. The countdown is
+                // restarted whenever a value is processed, so it elapses
+                // exactly one heartbeat interval after that, while the next
+                // value can only arrive one publishing interval later plus
+                // the round trip and processing time. With a heartbeat
+                // interval at or below the publishing interval the watchdog
+                // therefore wins that race on nearly every cycle and re-sends
+                // the previous value with its now stale source timestamp,
+                // which a consumer sees as an old value arriving right after
+                // a new one.
+                //
+                // Whether the interval really passed without data can only be
+                // established one publishing interval after it expired,
+                // because that is the granularity at which the server is able
+                // to deliver. Postpone the decision until then instead of
+                // sending, and re-arm for exactly the remaining time so that
+                // the heartbeat is still emitted promptly once the values
+                // genuinely stop.
+                //
+                if (!IsPeriodic && LastReceivedTime.HasValue)
+                {
+                    var idle = TimeProvider.GetUtcNow() - LastReceivedTime.Value;
+                    if (!IsWatchdogDue(idle, _heartbeatInterval, PublishingInterval,
+                        out var remaining))
+                    {
+                        RearmHeartbeatTimer(remaining);
+                        return;
+                    }
+                }
+
                 var lastNotification = LastReceivedValue as MonitoredItemNotification;
                 if ((_heartbeatBehavior & HeartbeatBehavior.WatchdogLKG)
                         == HeartbeatBehavior.WatchdogLKG &&
@@ -447,6 +480,117 @@ namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
                 }
             }
 
+            /// <summary>
+            /// Postpone the next elapse of the watchdog without restarting a
+            /// full countdown. Used when the watchdog elapsed while a value
+            /// was still legitimately in flight.
+            /// </summary>
+            /// <param name="dueTime"></param>
+            private void RearmHeartbeatTimer(TimeSpan dueTime)
+            {
+                if (dueTime < kMinimumRearmDelay)
+                {
+                    dueTime = kMinimumRearmDelay;
+                }
+                lock (_timerLock)
+                {
+                    if (_disposed || !TimerEnabled)
+                    {
+                        return;
+                    }
+                    _heartbeatTimer?.Rearm(dueTime);
+                }
+            }
+
+            /// <summary>
+            /// <para>
+            /// Decide whether a watchdog heartbeat is really due. A heartbeat
+            /// must only be sent when no value was received for the heartbeat
+            /// interval. The watchdog countdown is restarted when a value is
+            /// processed, so it elapses exactly one heartbeat interval later,
+            /// while the next value can only arrive one publishing interval
+            /// after the previous one plus the round trip and processing time.
+            /// With a heartbeat interval at or below the publishing interval
+            /// the watchdog would therefore win that race on nearly every
+            /// cycle and re-send the previous value with its now stale source
+            /// timestamp.
+            /// </para>
+            /// <para>
+            /// Values can only be delivered on publish boundaries, so the
+            /// absence of data cannot be established any earlier than one
+            /// publishing interval after the heartbeat interval expired. The
+            /// grace period is never longer than the heartbeat interval
+            /// itself so that a heartbeat configured much shorter than the
+            /// publishing interval keeps its cadence.
+            /// </para>
+            /// </summary>
+            /// <param name="idle">Time since the last value was received</param>
+            /// <param name="heartbeatInterval">Configured heartbeat interval</param>
+            /// <param name="publishingInterval">
+            /// Publishing interval of the owning subscription, or
+            /// <see cref="TimeSpan.Zero"/> when it is not known.
+            /// </param>
+            /// <param name="remaining">
+            /// Time to wait before deciding again when not due yet.
+            /// </param>
+            /// <returns>Whether the heartbeat should be sent now</returns>
+            internal static bool IsWatchdogDue(TimeSpan idle, TimeSpan heartbeatInterval,
+                TimeSpan publishingInterval, out TimeSpan remaining)
+            {
+                var grace = publishingInterval > heartbeatInterval
+                    ? heartbeatInterval : publishingInterval;
+                if (grace < kMinimumGracePeriod)
+                {
+                    grace = kMinimumGracePeriod;
+                }
+                var due = heartbeatInterval + grace;
+                if (idle >= due)
+                {
+                    remaining = TimeSpan.Zero;
+                    return true;
+                }
+                remaining = due - idle;
+                if (remaining < kMinimumRearmDelay)
+                {
+                    remaining = kMinimumRearmDelay;
+                }
+                return false;
+            }
+
+            /// <summary>
+            /// Whether the behavior sends on a fixed period regardless of
+            /// value arrival rather than acting as a watchdog.
+            /// </summary>
+            private bool IsPeriodic
+                => (_heartbeatBehavior & HeartbeatBehavior.PeriodicLKV)
+                    == HeartbeatBehavior.PeriodicLKV;
+
+            /// <summary>
+            /// Publishing interval of the owning subscription, or
+            /// <see cref="TimeSpan.Zero"/> when it cannot be determined.
+            /// </summary>
+            private TimeSpan PublishingInterval
+            {
+                get
+                {
+                    if (Subscription is not Subscription subscription)
+                    {
+                        return TimeSpan.Zero;
+                    }
+                    var interval = subscription.CurrentPublishingInterval;
+                    if (interval <= 0)
+                    {
+                        interval = subscription.PublishingInterval;
+                    }
+                    return interval > 0 ?
+                        TimeSpan.FromMilliseconds(interval) : TimeSpan.Zero;
+                }
+            }
+
+            private static readonly TimeSpan kMinimumGracePeriod
+                = TimeSpan.FromMilliseconds(100);
+            private static readonly TimeSpan kMinimumRearmDelay
+                = TimeSpan.FromMilliseconds(1);
             private TimerEx? _heartbeatTimer;
             private HeartbeatBehavior _heartbeatBehavior;
             private TimeSpan _heartbeatInterval;

--- a/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/Services/OpcUaMonitoredItemHeartbeatTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher/tests/Stack/Services/OpcUaMonitoredItemHeartbeatTests.cs
@@ -1,0 +1,135 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Stack.Services
+{
+    using System;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the heartbeat watchdog decision. A watchdog heartbeat may
+    /// only be emitted when no value was received for the heartbeat interval.
+    /// The countdown is restarted whenever a value is processed, so it
+    /// elapses exactly one heartbeat interval later while the next value can
+    /// only arrive one publishing interval after the previous one plus the
+    /// round trip and processing time. Without an allowance for this the
+    /// watchdog won that race on nearly every cycle whenever the heartbeat
+    /// interval was at or below the publishing interval, and re-sent the
+    /// previous value with its stale source timestamp - a consumer saw an
+    /// old value arriving right after a new one and a source timestamp
+    /// cadence broken by zero length gaps.
+    /// </summary>
+    public class OpcUaMonitoredItemHeartbeatTests
+    {
+        private static readonly TimeSpan kTwoSeconds = TimeSpan.FromSeconds(2);
+
+        [Fact]
+        public void ValueArrivingExactlyOnScheduleDoesNotTriggerHeartbeat()
+        {
+            //
+            // The reported scenario: heartbeat interval equals the publishing
+            // interval, so the countdown elapses exactly when the next value
+            // is still in flight.
+            //
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: kTwoSeconds, heartbeatInterval: kTwoSeconds,
+                publishingInterval: kTwoSeconds, out var remaining);
+
+            Assert.False(due);
+            Assert.Equal(kTwoSeconds, remaining);
+        }
+
+        [Fact]
+        public void ValueArrivingSlightlyLateDoesNotTriggerHeartbeat()
+        {
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: kTwoSeconds + TimeSpan.FromMilliseconds(250),
+                heartbeatInterval: kTwoSeconds, publishingInterval: kTwoSeconds,
+                out var remaining);
+
+            Assert.False(due);
+            Assert.Equal(TimeSpan.FromMilliseconds(1750), remaining);
+        }
+
+        [Fact]
+        public void HeartbeatIsDueOnceAFullPublishCycleWasMissed()
+        {
+            // Values genuinely stopped: heartbeat interval plus one
+            // publishing interval have passed without data.
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromSeconds(4), heartbeatInterval: kTwoSeconds,
+                publishingInterval: kTwoSeconds, out var remaining);
+
+            Assert.True(due);
+            Assert.Equal(TimeSpan.Zero, remaining);
+        }
+
+        [Fact]
+        public void HeartbeatStaysDueWhileValuesRemainAbsent()
+        {
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromMinutes(5), heartbeatInterval: kTwoSeconds,
+                publishingInterval: kTwoSeconds, out _);
+
+            Assert.True(due);
+        }
+
+        [Fact]
+        public void GraceIsCappedAtTheHeartbeatIntervalWhenPublishingIsSlower()
+        {
+            //
+            // A heartbeat much shorter than the publishing interval is a
+            // deliberate configuration - the item is expected to heartbeat
+            // between value changes. The grace must not grow with the
+            // publishing interval or the requested cadence would be lost.
+            //
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromSeconds(4), heartbeatInterval: kTwoSeconds,
+                publishingInterval: TimeSpan.FromSeconds(60), out _);
+
+            Assert.True(due);
+        }
+
+        [Fact]
+        public void FastPublishingOnlyAddsItsOwnIntervalOfGrace()
+        {
+            // Publishing every 100 ms, heartbeat every 2 s: the heartbeat is
+            // due at 2.1 s, not at 4 s.
+            Assert.False(OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromMilliseconds(2050), heartbeatInterval: kTwoSeconds,
+                publishingInterval: TimeSpan.FromMilliseconds(100), out _));
+            Assert.True(OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromMilliseconds(2100), heartbeatInterval: kTwoSeconds,
+                publishingInterval: TimeSpan.FromMilliseconds(100), out _));
+        }
+
+        [Fact]
+        public void UnknownPublishingIntervalStillAllowsForProcessingJitter()
+        {
+            // Without a known publishing interval a minimum allowance for
+            // delivery and processing jitter is still applied.
+            Assert.False(OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: kTwoSeconds, heartbeatInterval: kTwoSeconds,
+                publishingInterval: TimeSpan.Zero, out var remaining));
+            Assert.Equal(TimeSpan.FromMilliseconds(100), remaining);
+
+            Assert.True(OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromMilliseconds(2100), heartbeatInterval: kTwoSeconds,
+                publishingInterval: TimeSpan.Zero, out _));
+        }
+
+        [Fact]
+        public void RemainingTimeIsNeverZeroSoTheTimerCanAlwaysBeRearmed()
+        {
+            var due = OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(
+                idle: TimeSpan.FromSeconds(4) - TimeSpan.FromTicks(1),
+                heartbeatInterval: kTwoSeconds, publishingInterval: kTwoSeconds,
+                out var remaining);
+
+            Assert.False(due);
+            Assert.True(remaining > TimeSpan.Zero);
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa/src/Extensions/TimerEx.cs
+++ b/src/Azure.IIoT.OpcUa/src/Extensions/TimerEx.cs
@@ -169,6 +169,28 @@ namespace Azure.IIoT.OpcUa
         }
 
         /// <summary>
+        /// Re-arm the timer so that it elapses after <paramref name="dueTime"/>
+        /// once, while keeping <see cref="Interval"/> as the period of all
+        /// subsequent elapses. Assigning <see cref="Interval"/> restarts the
+        /// countdown with a full interval, which is not what a caller wants
+        /// when it only needs to postpone the next elapse by the remainder of
+        /// a period.
+        /// </summary>
+        /// <param name="dueTime">
+        /// Time until the next elapse. Must be greater than zero.
+        /// </param>
+        /// <exception cref="ArgumentException"></exception>
+        public void Rearm(TimeSpan dueTime)
+        {
+            if (dueTime <= TimeSpan.Zero)
+            {
+                throw new ArgumentException("Bad due time", nameof(dueTime));
+            }
+            _timer?.Change(dueTime,
+                _autoReset ? _interval : Timeout.InfiniteTimeSpan);
+        }
+
+        /// <summary>
         /// Closes the current timer object.
         /// </summary>
         public void Close()

--- a/src/Azure.IIoT.OpcUa/tests/Extensions/TimerExTests.cs
+++ b/src/Azure.IIoT.OpcUa/tests/Extensions/TimerExTests.cs
@@ -1,0 +1,98 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Extensions
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for <see cref="TimerEx.Rearm(TimeSpan)"/>, which postpones the
+    /// next elapse without restarting a full countdown. The heartbeat
+    /// watchdog needs this to wait out the remainder of a period after it
+    /// elapsed while a value was still in flight; assigning
+    /// <see cref="TimerEx.Interval"/> instead would restart the countdown
+    /// with a full interval and double the heartbeat latency once values
+    /// genuinely stop.
+    /// </summary>
+    public class TimerExTests
+    {
+        [Fact]
+        public async Task RearmMakesTheTimerElapseBeforeTheConfiguredIntervalAsync()
+        {
+            using var elapsed = new SemaphoreSlim(0);
+            using var timer = new TimerEx(TimeSpan.FromMinutes(5))
+            {
+                AutoReset = true
+            };
+            timer.Elapsed += (_, _) => elapsed.Release();
+            timer.Enabled = true;
+
+            timer.Rearm(TimeSpan.FromMilliseconds(50));
+
+            Assert.True(await elapsed.WaitAsync(TimeSpan.FromSeconds(30)),
+                "Timer did not elapse after being re-armed.");
+        }
+
+        [Fact]
+        public void RearmDoesNotChangeTheConfiguredInterval()
+        {
+            using var timer = new TimerEx(TimeSpan.FromMinutes(5))
+            {
+                Enabled = true
+            };
+
+            timer.Rearm(TimeSpan.FromMilliseconds(50));
+
+            Assert.Equal(TimeSpan.FromMinutes(5), timer.Interval);
+        }
+
+        [Fact]
+        public async Task PeriodIsKeptAfterARearmedElapseAsync()
+        {
+            using var elapsed = new SemaphoreSlim(0);
+            using var timer = new TimerEx(TimeSpan.FromMilliseconds(50))
+            {
+                AutoReset = true
+            };
+            timer.Elapsed += (_, _) => elapsed.Release();
+            timer.Enabled = true;
+
+            timer.Rearm(TimeSpan.FromMilliseconds(10));
+
+            // First elapse comes from the re-arm, the following ones from the
+            // unchanged period.
+            for (var i = 0; i < 3; i++)
+            {
+                Assert.True(await elapsed.WaitAsync(TimeSpan.FromSeconds(30)),
+                    $"Timer stopped elapsing after {i} elapse(s).");
+            }
+        }
+
+        [Fact]
+        public void RearmWithNonPositiveDueTimeThrows()
+        {
+            using var timer = new TimerEx(TimeSpan.FromMinutes(5))
+            {
+                Enabled = true
+            };
+
+            Assert.Throws<ArgumentException>(() => timer.Rearm(TimeSpan.Zero));
+            Assert.Throws<ArgumentException>(
+                () => timer.Rearm(TimeSpan.FromMilliseconds(-1)));
+        }
+
+        [Fact]
+        public void RearmOnADisabledTimerIsANoop()
+        {
+            using var timer = new TimerEx(TimeSpan.FromMinutes(5));
+
+            // Does not throw even though no underlying timer exists yet.
+            timer.Rearm(TimeSpan.FromMilliseconds(50));
+        }
+    }
+}

--- a/tools/e2etesting/DeployStandalone.ps1
+++ b/tools/e2etesting/DeployStandalone.ps1
@@ -104,14 +104,18 @@ if (!$iotHub) {
     $iotHub = New-AzIotHub -ResourceGroupName $ResourceGroupName -Name $iotHubName -SkuName S1 -Units 1 -Location $resourceGroup.Location
 }
 
-# Ensure Event Hub additional consumer group for tests
+# Ensure Event Hub additional consumer groups for tests. The Soak* groups belong
+# to the long running telemetry quality tests, which run in parallel with the A&E
+# job and with each other; the built-in endpoint permits five concurrent readers
+# per partition and per consumer group.
 
-$cgName = "TestConsumer"
-$iotHubCg = Get-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $iotHubName | Where-Object Name -eq $cgName
+foreach ($cgName in @("TestConsumer", "SoakCounters", "SoakHeartbeat")) {
+    $iotHubCg = Get-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $iotHubName | Where-Object Name -eq $cgName
 
-if (!$iotHubCg) {
-    Write-Host "Creating IoT Hub Event Hub Consumer Group $($cgName)..."
-    $iotHubCg = Add-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $iotHubName -EventHubConsumerGroupName $cgName
+    if (!$iotHubCg) {
+        Write-Host "Creating IoT Hub Event Hub Consumer Group $($cgName)..."
+        $iotHubCg = Add-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $iotHubName -EventHubConsumerGroupName $cgName
+    }
 }
 
 ## Ensure KeyVault

--- a/tools/e2etesting/DeployTestResources.ps1
+++ b/tools/e2etesting/DeployTestResources.ps1
@@ -91,13 +91,20 @@ Write-Host "Setting KeyVault Secret 'iothub-eventhub-connectionstring' to '***'.
 $secret = ConvertTo-SecureString $ehConnectionString -AsPlainText -Force
 Set-AzKeyVaultSecret -VaultName $keyVault.VaultName -Name "iothub-eventhub-connectionstring" -SecretValue $secret | Out-Null
 
-# Ensure Event Hub additional consumer group for tests
+# Ensure Event Hub additional consumer groups for tests.
+#
+# TestConsumer is shared by the functional tests. The Soak* groups belong to the
+# long running telemetry quality tests, which run in parallel with the A&E job and
+# with each other and hold a reader open on every partition for the whole
+# observation window; the built-in endpoint permits five concurrent readers per
+# partition and per consumer group.
 
-$cgName = "TestConsumer"
-$iotHubCg = Get-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $IoTHubName | Where-Object Name -eq $cgName
-if (!$iotHubCg) {
-    Write-Host "Creating IoT Hub $($IoTHubName) Event Hub Consumer Group $($cgName)..."
-    $iotHubCg = Add-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $IoTHubName -EventHubConsumerGroupName $cgName
+foreach ($cgName in @("TestConsumer", "SoakCounters", "SoakHeartbeat")) {
+    $iotHubCg = Get-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $IoTHubName | Where-Object Name -eq $cgName
+    if (!$iotHubCg) {
+        Write-Host "Creating IoT Hub $($IoTHubName) Event Hub Consumer Group $($cgName)..."
+        $iotHubCg = Add-AzIotHubEventHubConsumerGroup -ResourceGroupName $ResourceGroupName -Name $IoTHubName -EventHubConsumerGroupName $cgName
+    }
 }
 
 # NOTE: Storage account + Azure Files share `acishare` were previously created here to

--- a/tools/e2etesting/bicep/main.bicep
+++ b/tools/e2etesting/bicep/main.bicep
@@ -104,6 +104,26 @@ resource testConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoints/Consumer
   }
 }
 
+// The long running telemetry quality tests run in parallel with the A&E job and
+// with each other, and each keeps a reader open on every partition for the whole
+// observation window. The built-in endpoint permits five concurrent readers per
+// partition and per consumer group, so each soak gets its own group.
+resource soakCountersConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups@2023-06-30' = {
+  parent: iotHub
+  name: 'events/SoakCounters'
+  properties: {
+    name: 'SoakCounters'
+  }
+}
+
+resource soakHeartbeatConsumerGroup 'Microsoft.Devices/IotHubs/eventHubEndpoints/ConsumerGroups@2023-06-30' = {
+  parent: iotHub
+  name: 'events/SoakHeartbeat'
+  properties: {
+    name: 'SoakHeartbeat'
+  }
+}
+
 resource testAcr 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
   name: 'e2etestacr${testSuffix}'
   location: location


### PR DESCRIPTION
## Problem

A customer publishing 3000 variables — each with a 2 s publishing interval, a 2 s sampling interval, a queue size larger than one and a **2 s heartbeat**, in samples encoding — against a server whose variables count up from 0, reported four symptoms:

- **(a)** values they expect are missing
- **(b)** values arrive out of order
- **(c)** source timestamps are not the expected ~2 s apart
- **(d)** an old value arrives shortly after a new one

## Verdict

A deterministic reproduction was built **before** touching any product code, so each symptom could be confirmed or ruled out on evidence.

| Symptom | Verdict | Evidence |
| --- | --- | --- |
| (a) missing values | **Not reproduced** | `MissingValues = 0` at 500 and 3000 nodes; `IngressNotificationsDropped`, `EncoderNotificationsDropped`, `OutgressInputBufferDropped` and `ServerQueueOverflows` all zero |
| (b) out of order | **Not reproduced** | `0` in both samples and PubSub mode, including a queued-values run at ~1000 values/s where every publish carries four queued values per item |
| (c) timestamp spacing | **Reproduced** | 313–18 490 zero-length gaps — but **value-to-value** spacing was perfect, so the publisher does not distort timestamps |
| (d) old value after a new one | **Reproduced** | 14 887 stale repeats at 500 nodes over 3 min, **100 % of them heartbeats** |

## Root cause

`EnableHeartbeatTimer` restarts the countdown when a value is *processed*, so it elapses exactly one heartbeat interval later — while the next value can only arrive one publishing interval after the previous one **plus** the round trip and processing time. With a heartbeat interval at or below the publishing interval the watchdog wins that race on roughly **six out of ten cycles** and re-sends the previous value with its now stale `SourceTimestamp`.

That is what a consumer sees as (d), and because the repeat carries the same source timestamp as its predecessor it is also the entire cause of (c).

This contradicts the documented contract:

> Heartbeat acts like a watchdog which fires after the heartbeat interval has passed **and no new value has yet been received**.

So this is a bug, not a behaviour change.

## Fix

`OpcUaMonitoredItem.Heartbeat.IsWatchdogDue(...)` — a pure, unit-testable helper — now requires the item to have been idle for `heartbeatInterval + min(publishingInterval, heartbeatInterval)` before a heartbeat is due. Values can only be delivered on publish boundaries, so the absence of data cannot be established any earlier than one publishing interval after the heartbeat interval expired.

- The grace is **capped at the heartbeat interval**, so a heartbeat deliberately configured much shorter than the publishing interval keeps its cadence.
- When not yet due the timer is re-armed for exactly the remaining time via the new `TimerEx.Rearm(TimeSpan)`, so the first heartbeat after values genuinely stop is not delayed to twice the interval. (Assigning `Interval` restarts a full countdown, which is why a new method was needed.)
- Scoped strictly to the `Watchdog*` behaviours — `PeriodicLKV` / `PeriodicLKG` still fire on a fixed period by design.

## Results

| Scenario | Before | After |
| --- | --- | --- |
| 500 nodes, FullSamples, 3 min | 14 887 heartbeats, 14 887 stale repeats | passes |
| 500 nodes, PubSub, 3 min | 22 004 heartbeats, 18 490 stale repeats | passes |
| 500 nodes, queued values (~1000 values/s) | — | passes |
| **3000 nodes (customer scale), 5 min** | — | **540 000 value changes, 0 heartbeats, 0 missing, 0 out of order, 0 timestamp violations, 0 repeats** |
| Existing heartbeat integration tests | 10 passing | 10 passing |

Also green: 2166 `Azure.IIoT.OpcUa` tests, 905 `Azure.IIoT.OpcUa.Publisher` tests, 58 reference-server integration tests, 27 new unit tests.

## Test infrastructure added

- **Deterministic counter OPC UA test server** (`Counter` node manager + fixture) — N variables counting up by exactly one per tick, with source timestamps from a *monotonic schedule* rather than a wall clock, so the value is its own sequence number and any deviation observed downstream is provably publisher-induced.
- **Shared `TelemetryQualityValidator`** — turns each reported symptom into a counter that is either zero or not, with bounded memory so it can run for hours. Lives in a neutral shared folder and is linked into both test projects, so there is one source of truth and neither project gains a dependency on the other.
- **In-process soak tests** behind a `LongRunning` trait, excluded from the PR build (`--filter "Category!=LongRunning"`) and run by a new nightly `soak.yml` workflow (3 parallel scenarios, 500 nodes × 30 min, plus an opt-in 3000-node job).
- **Two IoT Edge end-to-end soaks** that run **in parallel** with the A&E job:
  - `PublisherMode=soakcounters` — the customer configuration against nodes counting up every 2 s. Heartbeats must **never** fire.
  - `PublisherMode=soakheartbeat` — nodes counting up every **2 minutes** with a 10 s heartbeat. Heartbeats **must** fire, at the right cadence, never before the grace period, always flagged, never altering the source timestamp — and the real value stream must still be complete, ordered and exactly 2 minutes apart.

  Runtime is configurable via the `soak_minutes` / `soak_nodes` workflow inputs, defaulting to **30 minutes** and 100 nodes.

### Why the E2E tests reuse the existing infrastructure

They share the resource group, IoT Hub and IoT Edge VM rather than standing up a second environment. `deploy_test_resources` alone has a 90-minute timeout and is dominated by IoT Hub provisioning and edge VM cloud-init; duplicating it would roughly double Azure spend and the resource-leak surface `e2e-gc.yml` has to reap, for **zero additional coverage** — the code under test is the publisher module, not the hub. Everything that could actually interfere is isolated per scenario instead: own publisher module identity, layered deployment, `--pf` file and `--pki` folder; own OPC PLC container (distinct name, DNS label and sizing); own writer group/id; and own Event Hub consumer group. Telemetry is attributed by the `iothub-connection-module-id` system property.

Node count is bounded by the **IoT Hub S1 daily message quota** (shared with the A&E job) and the 2 vCPU edge VM — scale itself is already covered by the in-process soak at 3000 nodes.

### Two concurrency fixes this required

Making three test jobs share one IoT Edge device surfaced two latent hazards:

- `UpdateTagAsync` patched the device twin using the **read etag**. Three jobs applying an identical tag patch would have left all but one failing a precondition check. Now patches unconditionally.
- `Configuration` has no value equality, so `CreateOrUpdateConfigurationAsync` **removed and re-added** the *shared* base deployment on every call — restarting edgeAgent, edgeHub and with them every parallel job's modules. It now leaves an existing shared deployment alone.

## Documentation

- `docs/opc-publisher/readme.md` — new *Watchdog grace period* section.
- `docs/opc-publisher/troubleshooting.md` — new *Duplicated, stale or unevenly spaced values* section, explaining that heartbeats are indistinguishable from real values unless the heartbeat indicator is enabled (`--mm=FullSamples` / `--fm=True`), plus the diagnostics counters that rule out real data loss.
- `e2e-tests/readme.md` — the new soak tests, their traits and knobs, and the infrastructure-sharing rationale.

## Notes for reviewers

- The E2E soaks cannot run locally — they need a deployed resource group, IoT Hub and edge VM. Pre-merge validation was compilation, the shared validator unit tests, trait-filter discovery (`soakcounters` → 3, `soakheartbeat` → 3, `AE` → 41 unchanged) and workflow YAML/job-graph checks. **First real signal is a `workflow_dispatch` run of `e2e-standalone.yml`.**
- In the E2E tests, *correctness* assertions (missing, out of order, unflagged repeats, altered heartbeat timestamps) are strict at zero; *timing* assertions carry a 1 % budget, because the simulator derives timestamps from a wall-clock timer and shares a 2 vCPU VM and one IoT Hub with the other jobs. The regression being guarded showed at ~60 %, so the budget still catches it with a 60× margin.
- `BasicSamplesIntegrationTests.CanSendDeadbandItemsToIoTHubTestAsync` failed once and passed on re-run during validation. Its configuration has no `HeartbeatInterval`, so the item is a plain `DataChange` and never touches the changed code — pre-existing flakiness, not a regression.
