### PR TITLE
Gate the telemetry soak behind an opt-in and exercise it on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,68 @@ jobs:
           retention-days: 14
 
   # --------------------------------------------------------------------------
+  # soak_smoke: run the telemetry quality soaks at a deliberately small size
+  # so the heartbeat watchdog is actually exercised on every pull request.
+  #
+  # build_test excludes Category=LongRunning, so without this job the soaks
+  # would compile but never execute here, and a regression in the watchdog
+  # would only be caught by the nightly soak (or, as happened once, by the
+  # internal build which cannot be filtered).
+  #
+  # 50 nodes x 1 minute is enough: with the pre-fix watchdog this
+  # configuration reports ~900 early heartbeats per scenario, so the signal
+  # is three orders of magnitude above the noise floor of zero. The full
+  # 500-node / 30-minute runs stay in soak.yml.
+  #
+  # The assertions this job relies on are load independent -- it asserts that
+  # no heartbeat fired *before* the watchdog deadline, which a busy runner
+  # cannot cause -- so a shared GitHub runner is a valid host for it.
+  # --------------------------------------------------------------------------
+  soak_smoke:
+    name: Telemetry quality smoke
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      PROJECT: src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+      - name: Restore
+        run: dotnet restore "$PROJECT" -s https://api.nuget.org/v3/index.json
+        shell: bash
+      - name: Build
+        run: dotnet build "$PROJECT" -c Release --no-restore
+        shell: bash
+      - name: Soak (smoke)
+        shell: bash
+        env:
+          IIOT_TELEMETRY_SOAK: '1'
+          IIOT_TELEMETRY_SOAK_NODES: '50'
+          IIOT_TELEMETRY_SOAK_MINUTES: '1'
+        run: |
+          dotnet test "$PROJECT" --no-build -c Release \
+            --blame-hang-timeout 30m --blame-hang-dump-type none \
+            --filter "Category=LongRunning" \
+            --logger "trx;LogFileName=soak-smoke.trx" \
+            --logger "console;verbosity=detailed" \
+            --results-directory ./testresults/soak-smoke
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testresults-soak-smoke
+          path: ./testresults
+          if-no-files-found: warn
+          retention-days: 14
+
+  # --------------------------------------------------------------------------
   # coverage_report: merge all per-shard cobertura files into a single
   # report, render a markdown summary into $GITHUB_STEP_SUMMARY, and
   # upload the merged HTML report as an artifact.

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -87,6 +87,7 @@ jobs:
         shell: bash
       - name: Soak
         env:
+          IIOT_TELEMETRY_SOAK: '1'
           IIOT_TELEMETRY_SOAK_NODES: ${{ inputs.nodes || '500' }}
           IIOT_TELEMETRY_SOAK_MINUTES: ${{ inputs.minutes || '30' }}
         shell: bash
@@ -137,6 +138,7 @@ jobs:
         shell: bash
       - name: Soak
         env:
+          IIOT_TELEMETRY_SOAK: '1'
           IIOT_TELEMETRY_SOAK_FULLSCALE: '1'
           IIOT_TELEMETRY_SOAK_MINUTES: ${{ inputs.minutes || '30' }}
         shell: bash

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityCountersTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityCountersTestTheory.cs
@@ -133,38 +133,51 @@ namespace OpcPublisherAEE2ETests.Standalone
             // Timing assertions. A real deployment can stall briefly - the
             // simulator derives its source timestamps from a wall clock timer
             // and shares a two vCPU edge VM and an IoT Hub with the other
-            // test jobs - so these carry a small budget instead of demanding
-            // a perfect run. The regression being guarded here produced a
-            // heartbeat on roughly six out of ten cycles, so a budget of one
-            // percent still catches it with a sixty fold margin.
+            // test jobs - so these must not demand a perfect run.
             //
-            AssertWithinBudget(report.HeartbeatSamples, report.ValueSamples,
+            // The precise, load independent signal for the regression this
+            // test guards is EarlyHeartbeats: a heartbeat that fired before
+            // the item had been silent for the heartbeat interval plus one
+            // publishing interval is always a defect, because that is the
+            // earliest point at which the absence of data can be
+            // established. A stalled edge VM produces heartbeats whose idle
+            // time genuinely exceeds the deadline, and those do not count.
+            //
+            Assert.True(report.EarlyHeartbeats == 0,
+                $"{report.EarlyHeartbeats} heartbeat(s) fired before the item had been " +
+                $"silent for the heartbeat interval plus one publishing interval." +
+                $"{Environment.NewLine}{report}");
+
+            //
+            // Values arrive on every publish cycle, so heartbeats should be
+            // rare. A generous ceiling still catches a systematic regression
+            // (the bug emitted one on roughly six out of ten cycles) while
+            // tolerating the occasional genuine stall.
+            //
+            AssertWithinBudget(report.HeartbeatSamples, report.ValueSamples, 4,
                 "heartbeat(s) were emitted although a value arrived on every publish cycle",
                 report);
-            AssertWithinBudget(report.RepeatedValues, report.ValueSamples,
-                "message(s) repeated an already delivered value", report);
-            AssertWithinBudget(report.ValueIntervalViolations, report.ValueSamples,
+            AssertWithinBudget(report.ValueIntervalViolations, report.ValueSamples, 100,
                 $"value(s) were not {updateInterval} apart from their predecessor", report);
-            AssertWithinBudget(report.MessageIntervalViolations, report.ValueSamples,
-                "message(s) broke the expected source timestamp cadence", report);
         }
 
         /// <summary>
-        /// Assert that an observation stayed inside a small fraction of the
-        /// total, so an occasional hiccup on shared infrastructure does not
-        /// fail the run while a systematic defect still does.
+        /// Assert that an observation stayed inside a fraction of the total,
+        /// so an occasional hiccup on shared infrastructure does not fail the
+        /// run while a systematic defect still does.
         /// </summary>
         /// <param name="observed"></param>
         /// <param name="total"></param>
+        /// <param name="divisor">Denominator of the tolerated fraction</param>
         /// <param name="what"></param>
         /// <param name="report"></param>
-        private static void AssertWithinBudget(long observed, long total, string what,
-            TelemetryQualityReport report)
+        private static void AssertWithinBudget(long observed, long total, int divisor,
+            string what, TelemetryQualityReport report)
         {
-            var budget = Math.Max(kMinimumBudget, total / 100);
+            var budget = Math.Max(kMinimumBudget, total / divisor);
             Assert.True(observed <= budget,
                 $"{observed} {what}, which exceeds the budget of {budget} " +
-                $"(1% of {total} value samples).{Environment.NewLine}{report}");
+                $"(1/{divisor} of {total} value samples).{Environment.NewLine}{report}");
         }
 
         [Fact, PriorityOrder(998)]

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityHeartbeatTestTheory.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/F_TelemetryQualityHeartbeatTestTheory.cs
@@ -154,16 +154,22 @@ namespace OpcPublisherAEE2ETests.Standalone
                 $"timestamp.{Environment.NewLine}{report}");
 
             //
-            // Timing assertions carry a small budget: the simulator derives
-            // its source timestamps from a wall clock timer and shares the
-            // edge VM and IoT Hub with the other test jobs.
+            // A heartbeat that fired before the item had been silent for the
+            // heartbeat interval plus one publishing interval is always a
+            // defect, and unlike the counters below this is independent of
+            // how loaded the machine is: a stall only ever makes the idle
+            // time longer, never shorter. So this one is strict.
             //
+            Assert.True(report.EarlyHeartbeats == 0,
+                $"{report.EarlyHeartbeats} heartbeat(s) arrived before the watchdog grace " +
+                $"period elapsed.{Environment.NewLine}{report}");
 
-            // Heartbeats must never arrive before the watchdog grace period.
-            AssertWithinBudget(report.EarlyHeartbeats, report.HeartbeatSamples,
-                "heartbeat(s) arrived before the watchdog grace period elapsed", report);
-
-            // ... and must keep the configured cadence once they do.
+            //
+            // The remaining timing assertions carry a budget: the simulator
+            // derives its source timestamps from a wall clock timer and
+            // shares the edge VM and IoT Hub with the other test jobs, so a
+            // heartbeat or a value can legitimately arrive late.
+            //
             AssertWithinBudget(report.HeartbeatCadenceViolations, report.HeartbeatSamples,
                 $"gap(s) between consecutive heartbeats did not match the configured " +
                 $"{heartbeatInterval}", report);

--- a/e2e-tests/readme.md
+++ b/e2e-tests/readme.md
@@ -92,6 +92,12 @@ them instead.
 Both are surfaced as the `soak_minutes` and `soak_nodes` inputs of
 `.github/workflows/e2e-standalone.yml`.
 
+> The in-process soak (`src/Azure.IIoT.OpcUa.Publisher.Module/tests`) is gated separately and
+> skips unless `IIOT_TELEMETRY_SOAK=1` (or a node count / duration / full-scale override) is
+> set. It runs for minutes and is sensitive to machine load, so it must not run as part of an
+> ordinary solution-wide test pass — in particular the internal build, which runs the whole
+> solution and cannot be filtered from this repository.
+
 > The node count is bounded by the **IoT Hub S1 daily message quota**, which is shared
 > with the A&E job, and by the two vCPU IoT Edge VM. At the default of 100 nodes the soak
 > produces roughly one network message per second. Raising it much above 250 needs an IoT

--- a/e2e-tests/readme.md
+++ b/e2e-tests/readme.md
@@ -97,6 +97,12 @@ Both are surfaced as the `soak_minutes` and `soak_nodes` inputs of
 > set. It runs for minutes and is sensitive to machine load, so it must not run as part of an
 > ordinary solution-wide test pass — in particular the internal build, which runs the whole
 > solution and cannot be filtered from this repository.
+>
+> It is still exercised on every pull request by the `soak_smoke` job in
+> `.github/workflows/ci.yml`, at a deliberately small 50-node / 1-minute size (~5 minutes).
+> That is ample signal: with the pre-fix watchdog this configuration reports ~900 early
+> heartbeats per scenario against an expected zero. The full 500-node / 30-minute runs stay
+> in the nightly `soak.yml`.
 
 > The node count is bounded by the **IoT Hub S1 daily message quota**, which is shared
 > with the A&E job, and by the two vCPU IoT Edge VM. At the default of 100 nodes the soak

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
@@ -58,9 +58,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         /// size larger than one, against a server whose variables count up
         /// every two seconds.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync()
         {
+            SkipUnlessEnabled();
             var report = await RunScenarioAsync(
                 nameof(SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync),
                 MessagingMode.FullSamples, NodeCount, kInterval, kInterval, kInterval,
@@ -72,13 +73,20 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         /// <summary>
         /// The same scenario in PubSub encoding, as a control that the
         /// behaviour is not specific to the legacy samples encoder.
+        /// <see cref="MessagingMode.FullNetworkMessages"/> rather than
+        /// <see cref="MessagingMode.PubSub"/> because only the full featured
+        /// profiles carry the heartbeat indicator
+        /// (<c>MessagingProfile.BuildDataSetFieldContentMask</c>); without it
+        /// a heartbeat is indistinguishable from a repeated value and the
+        /// assertions below could not tell the two apart.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync()
         {
+            SkipUnlessEnabled();
             var report = await RunScenarioAsync(
                 nameof(PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync),
-                MessagingMode.PubSub, NodeCount, kInterval, kInterval, kInterval,
+                MessagingMode.FullNetworkMessages, NodeCount, kInterval, kInterval, kInterval,
                 kQueueSize, (int)kInterval.TotalSeconds, RunDuration).ConfigureAwait(false);
 
             AssertClean(report);
@@ -91,9 +99,10 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         /// size larger than one is actually for and it exercises the
         /// ordering of queued values through the encoder.
         /// </summary>
-        [Fact]
+        [SkippableFact]
         public async Task QueuedValuesArriveCompleteAndInOrderAsync()
         {
+            SkipUnlessEnabled();
             var updateInterval = TimeSpan.FromMilliseconds(500);
             var report = await RunScenarioAsync(
                 nameof(QueuedValuesArriveCompleteAndInOrderAsync),
@@ -214,7 +223,31 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         }
 
         /// <summary>
+        /// <para>
         /// Assert that none of the four reported symptoms occurred.
+        /// </para>
+        /// <para>
+        /// Note what is deliberately <em>not</em> asserted: that no heartbeat
+        /// fired at all. A heartbeat is correct behaviour whenever a value
+        /// genuinely fails to arrive within the watchdog deadline, and on a
+        /// loaded shared build agent that does happen - the agent runs the
+        /// whole solution, and the counter server, the publisher and every
+        /// other test compete for the same cores. Demanding zero heartbeats
+        /// therefore asserts something about the machine, not about the
+        /// product.
+        /// </para>
+        /// <para>
+        /// The precise, load independent signal for the regression this suite
+        /// guards is <see cref="TelemetryQualityReport.EarlyHeartbeats"/>: a
+        /// heartbeat that fired <em>before</em> the item had been silent for
+        /// the heartbeat interval plus one publishing interval is always a
+        /// defect, because that is the earliest point at which the absence of
+        /// data can be established. The bug produced heartbeats roughly two
+        /// seconds after a value while the deadline was four, so every one of
+        /// them counts here; a stalled machine, by contrast, produces
+        /// heartbeats whose idle time genuinely exceeds the deadline and none
+        /// of them count.
+        /// </para>
         /// </summary>
         /// <param name="report"></param>
         private static void AssertClean(TelemetryQualityReport report)
@@ -234,21 +267,47 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
                 $"{report.OutOfOrderIncludingHeartbeats} message(s) carried a value older " +
                 $"than one already delivered.\n{report}");
 
-            // (c) source timestamps not one interval apart
+            // (c) real value changes are exactly one update interval apart
             Assert.True(report.SamplesWithoutSourceTimestamp == 0,
                 $"{report.SamplesWithoutSourceTimestamp} message(s) had no source " +
                 $"timestamp.\n{report}");
             Assert.True(report.ValueIntervalViolations == 0,
                 $"{report.ValueIntervalViolations} value(s) were not one update interval " +
                 $"apart from their predecessor.\n{report}");
-            Assert.True(report.MessageIntervalViolations == 0,
-                $"{report.MessageIntervalViolations} message(s) broke the expected source " +
-                $"timestamp cadence.\n{report}");
 
-            // (d) an old value shortly after a new one
-            Assert.True(report.RepeatedValues == 0,
-                $"{report.RepeatedValues} message(s) repeated an already delivered value " +
-                $"({report.RepeatedValuesFromHeartbeat} of them heartbeats).\n{report}");
+            // (d) the watchdog never fires before it is allowed to
+            Assert.True(report.EarlyHeartbeats == 0,
+                $"{report.EarlyHeartbeats} heartbeat(s) fired before the item had been " +
+                $"silent for the heartbeat interval plus one publishing interval.\n{report}");
+
+            // (d) a repeated value always identifies itself as a heartbeat
+            Assert.True(report.UnflaggedRepeats == 0,
+                $"{report.UnflaggedRepeats} value(s) were repeated without the heartbeat " +
+                $"indicator, so a consumer cannot tell them apart from real data.\n{report}");
+
+            //
+            // Values arrive on every publish cycle, so heartbeats should be
+            // rare. A generous ceiling still catches a systematic regression
+            // (the bug emitted one on roughly six out of ten cycles) while
+            // tolerating the occasional genuine stall on a busy agent.
+            //
+            var budget = Math.Max(kMinimumHeartbeatBudget, report.ValueSamples / 4);
+            Assert.True(report.HeartbeatSamples <= budget,
+                $"{report.HeartbeatSamples} heartbeat(s) were emitted although a value was " +
+                $"produced on every publish cycle, which exceeds the ceiling of {budget}.\n{report}");
+        }
+
+        /// <summary>
+        /// Skip unless the soak was explicitly opted into. These tests run for
+        /// minutes and are sensitive to how loaded the machine is, so they
+        /// must not run as part of an ordinary solution wide test pass - in
+        /// particular the internal build, which runs the whole solution and
+        /// cannot be filtered from this repository.
+        /// </summary>
+        private static void SkipUnlessEnabled()
+        {
+            Skip.IfNot(SoakEnabled,
+                $"Set {kSoakVariable}=1 to run the long running telemetry quality soak.");
         }
 
         /// <summary>
@@ -339,14 +398,25 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         /// Number of counter nodes to publish
         /// </summary>
         private static int NodeCount
-            => GetPositiveInt("IIOT_TELEMETRY_SOAK_NODES", kDefaultNodeCount);
+            => GetPositiveInt(kNodeCountVariable, kDefaultNodeCount);
 
         /// <summary>
         /// How long telemetry is analysed after the warm up
         /// </summary>
         private static TimeSpan RunDuration
-            => TimeSpan.FromMinutes(GetPositiveInt("IIOT_TELEMETRY_SOAK_MINUTES",
+            => TimeSpan.FromMinutes(GetPositiveInt(kDurationVariable,
                 kDefaultDurationMinutes));
+
+        /// <summary>
+        /// Whether the soak was opted into. Setting the node count or the
+        /// duration also opts in, so an operator who configures the run does
+        /// not additionally have to remember the switch.
+        /// </summary>
+        private static bool SoakEnabled
+            => Environment.GetEnvironmentVariable(kSoakVariable) == "1" ||
+               Environment.GetEnvironmentVariable(kNodeCountVariable) != null ||
+               Environment.GetEnvironmentVariable(kDurationVariable) != null ||
+               FullScaleEnabled;
 
         /// <summary>
         /// Whether the full scale scenario was opted into
@@ -361,7 +431,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
                     ? value : fallback;
         }
 
+        private const string kSoakVariable = "IIOT_TELEMETRY_SOAK";
+        private const string kNodeCountVariable = "IIOT_TELEMETRY_SOAK_NODES";
+        private const string kDurationVariable = "IIOT_TELEMETRY_SOAK_MINUTES";
         private const string kFullScaleVariable = "IIOT_TELEMETRY_SOAK_FULLSCALE";
+
+        /// <summary>
+        /// Heartbeats tolerated regardless of stream size, so a short run is
+        /// not failed by a single genuine stall.
+        /// </summary>
+        private const int kMinimumHeartbeatBudget = 10;
         private const int kDefaultNodeCount = 500;
         private const int kDefaultDurationMinutes = 2;
         private const int kFullScaleNodeCount = 3000;


### PR DESCRIPTION
## Why the internal build failed but GitHub CI passed

The internal ADO build [175305488](https://msazure.visualstudio.com/One/_build/results?buildId=175305488&view=results) failed on both Linux and Windows after #2517 merged:

```
Failed! - Failed: 2, Passed: 1490, Skipped: 80  (Azure.IIoT.OpcUa.Publisher.Module.Tests.dll)
  TelemetryQualityTests.SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync [FAIL]
  TelemetryQualityTests.PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync  [FAIL]
```

**GitHub CI passed because the soaks never ran there.** The `build_test` job log shows `--filter "Category!=LongRunning"` and contains zero `TelemetryQuality*` result lines — only compiler warnings. They compiled and were excluded. The green check was vacuous.

The internal build runs `dotnet test` over the whole `Industrial-IoT.slnx`, that filter does not apply, and the pipeline is not defined in this repository so it cannot be filtered from here. So the *only* place these tests ever executed was the one place they could not be controlled.

## The failure was not a product defect

Both reports show the value stream was perfect and the watchdog fix behaved as designed:

| | Samples mode | PubSub mode |
|---|---|---|
| Values delivered | 30 500 | 32 579 |
| (a) missing | **0** | **0** |
| (b) out of order | **0** | **0** |
| (c) value-interval violations | **0** | **0** |
| **`hb too early`** | **0** | **0** |
| Heartbeats | 2 230 | 0 *(indicator absent)* |
| Unflagged repeats | 0 | 2 579 |

Exactly 30 000 unique values for 500 nodes over 2 minutes. `hb too early: 0` means **every heartbeat respected the new grace period** — on a saturated agent a value genuinely fails to arrive within the 2 s + 2 s deadline, so the watchdog correctly fired.

Asserting that *no heartbeat may ever fire* asserts something about the machine, not the publisher. That is a defect in my test.

The PubSub row also re-demonstrates the known R2 finding: `MessagingMode.PubSub` is not full-featured, so it carries no `Heartbeat` indicator and the same heartbeats surface as unflagged repeats.

## Changes

**1. Gate the soaks behind an explicit opt-in.** `SkippableFact` + `IIOT_TELEMETRY_SOAK` (or any node-count / duration / full-scale override, so an operator who configures a run needn't also remember the switch) — the pattern `CustomerScenarioAtFullScaleAsync` already used. They now skip in **49 ms** in a solution-wide run.

**2. Assert on the one signal immune to load.** Replaced `MessageIntervalViolations == 0` / `RepeatedValues == 0` / `HeartbeatSamples == 0` with:

```csharp
Assert.True(report.EarlyHeartbeats == 0, ...)
```

A heartbeat that fired *before* the item had been silent for `heartbeatInterval + publishingInterval` is **always** a defect — that is the earliest point at which absence of data can be established, and a stall only ever makes idle time *longer*. The regression emitted heartbeats ~2 s after a value against a 4 s deadline, so every one counts; a busy agent's heartbeats do not.

`UnflaggedRepeats`, `MissingValues`, `OutOfOrderValues` and `ValueIntervalViolations` stay strict — all held even on the saturated agent.

**3. PubSub control → `FullNetworkMessages`**, so the control can actually distinguish a heartbeat from a repeated value.

**4. New `soak_smoke` job in `ci.yml` — the soaks now run on every PR.** Gating alone would have left them unexercised in PR builds, which is what caused this in the first place. 50 nodes × 1 minute, ~5 minutes, parallel with `build_test`.

**5. Same treatment for the IoT Edge E2E soaks**, which had the identical load-sensitive assertion (a 1 % budget on `HeartbeatSamples` that the observed 7.3 % would have blown).

## Verification

I confirmed the smoke config actually catches the bug rather than just passing, by temporarily restoring the pre-fix watchdog:

| Scenario | Pre-fix watchdog | Fixed |
|---|---|---|
| Samples mode | **906 early heartbeats** ❌ | ✅ |
| PubSub mode | **906 early heartbeats** ❌ | ✅ |
| Queued values | **897 early heartbeats** ❌ | ✅ |

~900 against an expected 0 — three orders of magnitude above the noise floor. The temporary change was reverted; `git diff` on the product file is empty.

| Check | Result |
|---|---|
| No env vars (reproduces the ADO condition) | 4 skipped in 49 ms |
| `IIOT_TELEMETRY_SOAK=1`, 50 nodes, 1 min (the PR job) | 3 passed, 1 skipped — 4 m 57 s |
| `IIOT_TELEMETRY_SOAK=1`, 500 nodes, 2 min | 3 passed, 1 skipped — 8 m |
| Module tests + E2E solution build | 0 errors |
| `actionlint` on all workflows | clean |

## Note

The general lesson: a soak whose pass criterion depends on the machine keeping up does not belong in a shared, unfilterable test pass. Gating it is the primary fix; making the assertion load-immune is what lets it run on a shared runner at all — and that is precisely what makes the new PR job possible.
