### PR TITLE
Harden the e2e init step against script injection and add a threat model

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -71,6 +71,11 @@ jobs:
   run:
     name: ${{ inputs.filter_name }}=${{ inputs.filter_value }}
     runs-on: windows-latest
+    # This job authenticates to Azure and reads Key Vault secrets, so it is
+    # gated behind the `e2e` environment like every other Azure-touching job.
+    # `environment` cannot be set on the calling `uses:` job, so it has to be
+    # declared here in the reusable workflow.
+    environment: e2e
     timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       ResourceGroupName: ${{ inputs.resource_group_name }}

--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -158,14 +158,33 @@ jobs:
     steps:
       - id: compute
         shell: bash
+        # Workflow inputs are passed through `env:` and dereferenced as shell
+        # variables rather than interpolated with `${{ }}` directly into the
+        # script. GitHub substitutes `${{ }}` textually before bash parses the
+        # line, so an input containing a quote would break out of the string
+        # and execute as shell -- in a job that holds `id-token: write` and can
+        # therefore mint an Azure OIDC assertion for the E2E service principal.
+        env:
+          RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name || '<generated>' }}
+          SOAK_MINUTES: ${{ inputs.soak_minutes || '30' }}
+          RUN_ID: ${{ github.run_id }}
         run: |
+          set -euo pipefail
+
           # Use github.run_id (globally unique per workflow run) -- not
           # github.run_number which is per-workflow and could collide with
           # other workflows generating RGs the same day.
-          if [ "${{ inputs.resource_group_name || '<generated>' }}" = "<generated>" ]; then
-            rg="e2etesting$(date -u +%Y%m%d)${{ github.run_id }}"
+          if [ "$RESOURCE_GROUP_NAME" = "<generated>" ]; then
+            rg="e2etesting$(date -u +%Y%m%d)${RUN_ID}"
           else
-            rg="${{ inputs.resource_group_name }}"
+            rg="$RESOURCE_GROUP_NAME"
+          fi
+          # Azure resource group names allow letters, digits, '_', '-', '.' and
+          # parentheses. Reject anything else rather than passing it on to the
+          # deployment scripts.
+          if ! [[ "$rg" =~ ^[A-Za-z0-9._()-]{1,90}$ ]]; then
+            echo "::error::Invalid resource group name: $rg"
+            exit 1
           fi
           echo "rg=${rg}" >> "$GITHUB_OUTPUT"
           echo "Resource group: ${rg}"
@@ -173,9 +192,12 @@ jobs:
           # Observation window plus headroom for restoring and building the
           # test solution, deploying the publisher module, creating the
           # simulation container, warming up and tearing everything down.
-          soak_minutes="${{ inputs.soak_minutes || '30' }}"
-          echo "soak_timeout=$((soak_minutes + 60))" >> "$GITHUB_OUTPUT"
-          echo "Soak job timeout: $((soak_minutes + 60)) minutes"
+          if ! [[ "$SOAK_MINUTES" =~ ^[0-9]{1,4}$ ]]; then
+            echo "::error::soak_minutes must be a number, got: $SOAK_MINUTES"
+            exit 1
+          fi
+          echo "soak_timeout=$((SOAK_MINUTES + 60))" >> "$GITHUB_OUTPUT"
+          echo "Soak job timeout: $((SOAK_MINUTES + 60)) minutes"
 
   # --------------------------------------------------------------------------
   # deploy_standalone: deploys the standalone IIoT infrastructure (KeyVault,

--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -152,6 +152,13 @@ jobs:
   init:
     name: Compute run variables
     runs-on: ubuntu-latest
+    # This job only computes strings; it never talks to Azure. Drop the
+    # workflow-level `id-token: write` so it cannot mint an OIDC assertion for
+    # the E2E service principal. That closes the escalation path structurally:
+    # even if a future edit reintroduces an unsafe `${{ }}` interpolation into
+    # the script below, there is no token for injected code to steal.
+    permissions:
+      contents: read
     outputs:
       resource_group_name: ${{ steps.compute.outputs.rg }}
       soak_timeout_minutes: ${{ steps.compute.outputs.soak_timeout }}
@@ -209,6 +216,11 @@ jobs:
     name: Deploy standalone resources
     needs: init
     runs-on: windows-latest
+    # Gate every job that authenticates to Azure behind the `e2e` environment,
+    # matching e2e-gc.yml. The environment is where the deployment credentials
+    # and any required-reviewer rules live, so a workflow_dispatch alone is not
+    # sufficient to reach the subscription.
+    environment: e2e
     timeout-minutes: 60
     outputs:
       key_vault_name: ${{ steps.kv.outputs.KeyVaultName }}
@@ -267,6 +279,7 @@ jobs:
     name: Deploy test resources (PLCs + IoT Edge VM)
     needs: [init, deploy_standalone]
     runs-on: windows-latest
+    environment: e2e
     timeout-minutes: 90
     outputs:
       fqdn: ${{ steps.deploy_edge.outputs.Fqdn }}
@@ -447,6 +460,7 @@ jobs:
             run_tests_soak_counters, run_tests_soak_heartbeat]
     if: always() && (inputs.cleanup == null || inputs.cleanup == true) && !cancelled()
     runs-on: ubuntu-latest
+    environment: e2e
     timeout-minutes: 30
     env:
       ResourceGroupName: ${{ needs.init.outputs.resource_group_name }}

--- a/docs/opc-publisher/threatmodel/OpcPublisher.tm7
+++ b/docs/opc-publisher/threatmodel/OpcPublisher.tm7
@@ -1,0 +1,1015 @@
+<?xml version='1.0' encoding='utf-8'?>
+<ThreatModel xmlns="http://schemas.microsoft.com/sdl/2014/12/ThreatModel" xmlns:i="http://www.w3.org/2001/XMLSchema-instance">
+  <DrawingSurfaceList>
+    <DrawingSurfaceModel>
+      <GenericTypeId>DFD</GenericTypeId>
+      <Guid>11133988-704f-5fce-b45c-0484ffa58779</Guid>
+      <Header>OPC Publisher - Level 1</Header>
+      <Borders>
+        <KeyValueOfguidanyType>
+          <Key>86cf6ad1-58a1-5fd2-9d7a-e9418ac0c09d</Key>
+          <Value i:type="BorderBoundary">
+            <GenericTypeId>GE.TB.B</GenericTypeId>
+            <Guid>86cf6ad1-58a1-5fd2-9d7a-e9418ac0c09d</Guid>
+            <Height>220</Height>
+            <Left>20</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">OT / plant network boundary</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>240</Top>
+            <TypeId>GE.TB.B</TypeId>
+            <Width>290</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>833dd321-01db-5ddc-86fc-a687fde6c6c0</Key>
+          <Value i:type="BorderBoundary">
+            <GenericTypeId>GE.TB.B</GenericTypeId>
+            <Guid>833dd321-01db-5ddc-86fc-a687fde6c6c0</Guid>
+            <Height>420</Height>
+            <Left>310</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">opcpublisher container boundary</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>20</Top>
+            <TypeId>GE.TB.B</TypeId>
+            <Width>470</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>0c3ceabd-e1c6-5da0-81c6-9a38a084a505</Key>
+          <Value i:type="BorderBoundary">
+            <GenericTypeId>GE.TB.B</GenericTypeId>
+            <Guid>0c3ceabd-e1c6-5da0-81c6-9a38a084a505</Guid>
+            <Height>170</Height>
+            <Left>310</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Mounted volume (host filesystem) boundary</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>570</Top>
+            <TypeId>GE.TB.B</TypeId>
+            <Width>460</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>15133370-b8e6-5cc2-a1da-ced537e2ca53</Key>
+          <Value i:type="BorderBoundary">
+            <GenericTypeId>GE.TB.B</GenericTypeId>
+            <Guid>15133370-b8e6-5cc2-a1da-ced537e2ca53</Guid>
+            <Height>600</Height>
+            <Left>1000</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Cloud boundary</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>140</Top>
+            <TypeId>GE.TB.B</TypeId>
+            <Width>200</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>fe9a8bb1-151f-5788-b140-0cde746d0e18</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.EI</GenericTypeId>
+            <Guid>fe9a8bb1-151f-5788-b140-0cde746d0e18</Guid>
+            <Height>90</Height>
+            <Left>40</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">OPC UA Server (field device)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Unmanaged</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Selected</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Accepts Input From</DisplayName>
+                <Name>AcceptsInputFrom</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Untrusted OT network</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>300</Top>
+            <TypeId>GE.EI</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>1b8c1ec9-abb4-593e-bc83-f8a0f733c5c2</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.EI</GenericTypeId>
+            <Guid>1b8c1ec9-abb4-593e-bc83-f8a0f733c5c2</Guid>
+            <Height>90</Height>
+            <Left>40</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Operator / Engineer</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Applicable</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Selected</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>60</Top>
+            <TypeId>GE.EI</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>020ac0e9-2add-5327-9039-f1ab08a0861a</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.EI</GenericTypeId>
+            <Guid>020ac0e9-2add-5327-9039-f1ab08a0861a</Guid>
+            <Height>90</Height>
+            <Left>1020</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Container Registry</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Applicable</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>620</Top>
+            <TypeId>GE.EI</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>cf549394-eb96-5872-8e03-dbacd6981d44</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.EI</GenericTypeId>
+            <Guid>cf549394-eb96-5872-8e03-dbacd6981d44</Guid>
+            <Height>90</Height>
+            <Left>1020</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Azure Device Registry</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Applicable</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>500</Top>
+            <TypeId>GE.EI</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</Guid>
+            <Height>100</Height>
+            <Left>330</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">OPC UA Client Stack</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Managed</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Standard User</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Isolation Level</DisplayName>
+                <Name>IsolationLevel</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Sandbox</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Accepts Input From</DisplayName>
+                <Name>AcceptsInputFrom</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Untrusted OT network</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>300</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>9127e0f7-7268-5579-8c5f-67de2275c17e</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>9127e0f7-7268-5579-8c5f-67de2275c17e</Guid>
+            <Height>100</Height>
+            <Left>570</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Publisher Engine (encode / batch / publish)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Managed</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Standard User</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Isolation Level</DisplayName>
+                <Name>IsolationLevel</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Sandbox</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>300</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>190</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>769a363f-7cb6-521a-97fe-1d0ede1a68bb</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>769a363f-7cb6-521a-97fe-1d0ede1a68bb</Guid>
+            <Height>100</Height>
+            <Left>330</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">REST API Host (ASP.NET Core)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Managed</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Standard User</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Scheme</DisplayName>
+                <Name>AuthenticationScheme</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">API key</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Isolation Level</DisplayName>
+                <Name>IsolationLevel</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Sandbox</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>60</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</Guid>
+            <Height>100</Height>
+            <Left>570</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Configuration Service</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Managed</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Standard User</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>60</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>5a758ace-5ed1-5576-abe2-eaefeb169f4f</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</Guid>
+            <Height>100</Height>
+            <Left>820</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">edgeHub (IoT Edge runtime)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Managed</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Standard User</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>180</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>93bea3db-983e-517e-a7c2-411faa23133f</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.DS</GenericTypeId>
+            <Guid>93bea3db-983e-517e-a7c2-411faa23133f</Guid>
+            <Height>90</Height>
+            <Left>570</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">published_nodes.json</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Store Type</DisplayName>
+                <Name>StoreType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">File</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Encrypted</DisplayName>
+                <Name>Encrypted</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">No</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Signed</DisplayName>
+                <Name>Signed</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">No</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Write Access</DisplayName>
+                <Name>WriteAccess</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>620</Top>
+            <TypeId>GE.DS</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>68689e93-4381-51fe-8ea1-11db1074d381</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.DS</GenericTypeId>
+            <Guid>68689e93-4381-51fe-8ea1-11db1074d381</Guid>
+            <Height>90</Height>
+            <Left>330</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">PKI stores (own / trusted / issuer / rejected)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Store Type</DisplayName>
+                <Name>StoreType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">File</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Encrypted</DisplayName>
+                <Name>Encrypted</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">No</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Signed</DisplayName>
+                <Name>Signed</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Write Access</DisplayName>
+                <Name>WriteAccess</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>620</Top>
+            <TypeId>GE.DS</TypeId>
+            <Width>170</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>f3036193-e42f-57ef-909f-cfbdf7e6e535</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>f3036193-e42f-57ef-909f-cfbdf7e6e535</Guid>
+            <Height>90</Height>
+            <Left>1020</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Azure IoT Hub</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Applicable</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Running As</DisplayName>
+                <Name>RunningAs</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Selected</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>180</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>560b4144-67c9-5178-8c07-e15fd137b1e4</Key>
+          <Value i:type="Stencil">
+            <GenericTypeId>GE.P</GenericTypeId>
+            <Guid>560b4144-67c9-5178-8c07-e15fd137b1e4</Guid>
+            <Height>90</Height>
+            <Left>1020</Left>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">MQTT broker / HTTP / Dapr sink</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Code Type</DisplayName>
+                <Name>CodeType</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Not Applicable</Value>
+              </anyType>
+            </Properties>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <Top>320</Top>
+            <TypeId>GE.P</TypeId>
+            <Width>160</Width>
+          </Value>
+        </KeyValueOfguidanyType>
+      </Borders>
+      <Lines>
+        <KeyValueOfguidanyType>
+          <Key>8a603045-05e1-5de8-97cf-e35df7efae09</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>8a603045-05e1-5de8-97cf-e35df7efae09</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(1) DataChange / Event notifications (opc.tcp)</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Mechanism</DisplayName>
+                <Name>AuthenticationMechanism</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Certificate / anonymous</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Provides Confidentiality</DisplayName>
+                <Name>ProvidesConfidentiality</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Depends on SecurityMode</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Provides Integrity</DisplayName>
+                <Name>ProvidesIntegrity</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Depends on SecurityMode</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>fe9a8bb1-151f-5788-b140-0cde746d0e18</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>b1be4ef1-60ec-55ed-a4e9-336267a493be</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>b1be4ef1-60ec-55ed-a4e9-336267a493be</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(2) Browse / Read / Write / Call</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Mechanism</DisplayName>
+                <Name>AuthenticationMechanism</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Certificate / username / anonymous</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>fe9a8bb1-151f-5788-b140-0cde746d0e18</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>0b37e066-4c36-517d-9d36-38a002c94504</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>0b37e066-4c36-517d-9d36-38a002c94504</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(3) REST API over HTTPS</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Mechanism</DisplayName>
+                <Name>AuthenticationMechanism</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">API key</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Provides Confidentiality</DisplayName>
+                <Name>ProvidesConfidentiality</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>1b8c1ec9-abb4-593e-bc83-f8a0f733c5c2</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>769a363f-7cb6-521a-97fe-1d0ede1a68bb</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>3c4131d3-3359-5009-aa8f-0a9d78e0adcd</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>3c4131d3-3359-5009-aa8f-0a9d78e0adcd</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(4) Direct methods / twin desired properties</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Mechanism</DisplayName>
+                <Name>AuthenticationMechanism</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">IoT Hub module identity</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Provides Confidentiality</DisplayName>
+                <Name>ProvidesConfidentiality</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>f3036193-e42f-57ef-909f-cfbdf7e6e535</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>3969bfec-11ce-5d00-be37-992ed03eb8f6</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>3969bfec-11ce-5d00-be37-992ed03eb8f6</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(4) Method invocation</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>769a363f-7cb6-521a-97fe-1d0ede1a68bb</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>b15bf9ee-b3b9-55ed-a203-9b8ebaa2531f</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>b15bf9ee-b3b9-55ed-a203-9b8ebaa2531f</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(5) Network messages (telemetry)</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>9127e0f7-7268-5579-8c5f-67de2275c17e</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>270f6323-6f37-545c-a4d6-c7375dcc0776</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>270f6323-6f37-545c-a4d6-c7375dcc0776</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(5) D2C telemetry</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Provides Confidentiality</DisplayName>
+                <Name>ProvidesConfidentiality</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Yes</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>f3036193-e42f-57ef-909f-cfbdf7e6e535</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>77e9d9a3-b056-5b6d-9276-83b1f1f2ef78</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>77e9d9a3-b056-5b6d-9276-83b1f1f2ef78</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(6) Telemetry via direct transport</Value>
+              </anyType>
+              <anyType i:type="StringDisplayAttribute">
+                <DisplayName>Authentication Mechanism</DisplayName>
+                <Name>AuthenticationMechanism</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">Per transport</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>9127e0f7-7268-5579-8c5f-67de2275c17e</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>560b4144-67c9-5178-8c07-e15fd137b1e4</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>f8965444-b184-5f10-aaa0-7f0e3976e375</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>f8965444-b184-5f10-aaa0-7f0e3976e375</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(7) Read / write published nodes</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>93bea3db-983e-517e-a7c2-411faa23133f</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>72358ab1-2661-5f52-85a0-31d1414a0e18</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>72358ab1-2661-5f52-85a0-31d1414a0e18</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(7) Load configuration on start / change</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>93bea3db-983e-517e-a7c2-411faa23133f</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>61ed1436-8080-5a87-abb9-e6ab0f582b05</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>61ed1436-8080-5a87-abb9-e6ab0f582b05</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(8) Store rejected / own certificates</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>68689e93-4381-51fe-8ea1-11db1074d381</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>73bff74f-53bc-5a7b-8491-be16f30e3dad</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>73bff74f-53bc-5a7b-8491-be16f30e3dad</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(8) Load trust list, CRLs</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>68689e93-4381-51fe-8ea1-11db1074d381</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>ae943137-8905-5ceb-984f-0385b3036fc4</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>ae943137-8905-5ceb-984f-0385b3036fc4</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(9) Asset / device definitions</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>cf549394-eb96-5872-8e03-dbacd6981d44</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>0f17e7d3-1995-51d7-bf17-787b55470f28</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>0f17e7d3-1995-51d7-bf17-787b55470f28</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(10) Module image pull</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>020ac0e9-2add-5327-9039-f1ab08a0861a</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>9127e0f7-7268-5579-8c5f-67de2275c17e</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>b5373a8b-34a3-54b3-a4df-994a9f8a13ed</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>b5373a8b-34a3-54b3-a4df-994a9f8a13ed</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(11) Diagnostics / runtime state / logs</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>9127e0f7-7268-5579-8c5f-67de2275c17e</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>5a758ace-5ed1-5576-abe2-eaefeb169f4f</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>611a5770-077a-5f19-91cd-8daa97b15447</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>611a5770-077a-5f19-91cd-8daa97b15447</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(12) Applied subscription configuration</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>a7837bc6-4fd3-51bb-bc08-1284bc5a8e81</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>a7837bc6-4fd3-51bb-bc08-1284bc5a8e81</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(13) Notifications to writer groups</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>fdf80f6c-d5fd-5813-b3be-679bdb2d3ee5</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>9127e0f7-7268-5579-8c5f-67de2275c17e</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+        <KeyValueOfguidanyType>
+          <Key>423f79d1-9711-51d8-ab4f-b32eea90f141</Key>
+          <Value i:type="Connector">
+            <GenericTypeId>GE.DF</GenericTypeId>
+            <Guid>423f79d1-9711-51d8-ab4f-b32eea90f141</Guid>
+            <Properties>
+              <anyType i:type="HeaderDisplayAttribute">
+                <DisplayName>Name</DisplayName>
+                <Name>Name</Name>
+                <Value i:type="x:string" xmlns:x="http://www.w3.org/2001/XMLSchema">(14) Configuration API calls</Value>
+              </anyType>
+            </Properties>
+            <SourceGuid>769a363f-7cb6-521a-97fe-1d0ede1a68bb</SourceGuid>
+            <SourceX>0</SourceX>
+            <SourceY>0</SourceY>
+            <StrokeDashArray i:nil="true" />
+            <StrokeThickness>1</StrokeThickness>
+            <TargetGuid>d1bd97a5-6938-5a4f-a5c8-36cc5fb5d053</TargetGuid>
+            <TargetX>0</TargetX>
+            <TargetY>0</TargetY>
+            <TypeId>GE.DF</TypeId>
+          </Value>
+        </KeyValueOfguidanyType>
+      </Lines>
+      <Zoom>1</Zoom>
+    </DrawingSurfaceModel>
+  </DrawingSurfaceList>
+  <MetaInformation>
+    <Assumptions>1. The OT network is untrusted: an OPC UA server may be malicious, compromised or faulty and can return hostile or malformed data. 2. The IoT Edge gateway host is trusted; an attacker with root on the host can already read the module's mounted volume, PKI store and module identity. 3. published_nodes.json and the PKI directory live on a host-shared mounted volume; their confidentiality and integrity are the host's responsibility. 4. IoT Hub is trusted to authenticate the caller of a direct method; the module does not independently authenticate that caller. 5. The REST API is reachable only from the edge network and is protected by the configured API key; it is not intended for internet exposure.</Assumptions>
+    <Contributors>Azure Industrial IoT</Contributors>
+    <ExternalDependencies>OPC UA .NET Standard stack (OPCFoundation.NetStandard.Opc.Ua); Azure IoT Edge runtime (edgeAgent, edgeHub); Azure IoT Hub; Furly transport abstractions (MQTT, HTTP, Dapr, Event Hubs); ASP.NET Core; the host container runtime.</ExternalDependencies>
+    <HighLevelSystemDescription>OPC Publisher is an Azure IoT Edge module that connects to OPC UA servers on an operational technology network, subscribes to data changes and events, and publishes the resulting telemetry to Azure IoT Hub, an MQTT broker, or an HTTP/Dapr endpoint. It is configured through a mounted published_nodes.json file, an authenticated REST API, and IoT Hub direct methods. It maintains an OPC UA PKI store on a mounted volume.</HighLevelSystemDescription>
+    <Owner>Azure Industrial IoT</Owner>
+    <Reviewer />
+    <ThreatModelName>Azure IIoT OPC Publisher</ThreatModelName>
+  </MetaInformation>
+  <Notes />
+  <ThreatInstances />
+  <ThreatGenerationEnabled>true</ThreatGenerationEnabled>
+  <Validations />
+  <Version>4.1</Version>
+</ThreatModel>

--- a/docs/opc-publisher/threatmodel/dataflow.md
+++ b/docs/opc-publisher/threatmodel/dataflow.md
@@ -1,0 +1,140 @@
+# OPC Publisher data flow diagram <!-- omit in toc -->
+
+[Home](../readme.md) · [Security](../security.md) · [Threat model](./readme.md)
+
+This is the data flow diagram (DFD) that backs
+[`OpcPublisher.tm7`](./OpcPublisher.tm7). It is kept in Mermaid so that it is
+reviewable in a pull request; the `.tm7` is the machine-readable form for the
+Microsoft Threat Modeling Tool.
+
+Numbers on the flows (`(1)`, `(2)`, …) match the `Flow #` column of the threat
+table in [readme.md](./readme.md).
+
+## Level 0 — context
+
+```mermaid
+flowchart LR
+    OPCUA["OPC UA Server<br/>(field device / PLC)"]
+    OPER["Operator / Engineer"]
+    PUB["OPC Publisher<br/>(IoT Edge module)"]
+    CLOUD["Azure IoT Hub /<br/>MQTT broker /<br/>HTTP endpoint"]
+
+    OPCUA -- "(1) telemetry, opc.tcp" --> PUB
+    PUB -- "(2) browse / read / write / call" --> OPCUA
+    OPER -- "(3) REST API, direct methods" --> PUB
+    PUB -- "(5) telemetry, runtime state" --> CLOUD
+    CLOUD -- "(4) direct methods, twin desired props" --> PUB
+```
+
+## Level 1 — trust boundaries and stores
+
+Trust boundaries are the dashed containers. Anything crossing one is a place
+where authentication, authorisation, and input validation have to be argued
+explicitly.
+
+```mermaid
+flowchart TB
+    subgraph OT["OT / plant network — untrusted, flat, often unauthenticated"]
+        OPCUA["OPC UA Server<br/>(external entity)"]
+    end
+
+    subgraph EDGE["IoT Edge gateway host"]
+        subgraph MOD["opcpublisher container — trust boundary: process + container"]
+            STACK["OPC UA client stack<br/>(session, subscriptions,<br/>monitored items)"]
+            ENGINE["Publisher engine<br/>(encoders, writer groups,<br/>batching, heartbeat watchdog)"]
+            API["REST API host<br/>(ASP.NET Core)"]
+            CFG["Configuration service<br/>(PublishedNodesJsonServices)"]
+        end
+        EHUB["edgeHub<br/>(IoT Edge runtime)"]
+        subgraph MNT["mounted volume — trust boundary: filesystem"]
+            PNJSON[("published_nodes.json")]
+            PKI[("PKI stores:<br/>own / trusted / issuer /<br/>rejected")]
+        end
+    end
+
+    subgraph AZ["Azure / cloud"]
+        IOTHUB["IoT Hub"]
+        BROKER["MQTT broker /<br/>HTTP / Dapr / Event Hubs"]
+        ADR["Azure Device Registry"]
+        ACR["Container registry"]
+    end
+
+    OPER["Operator / Engineer<br/>(external entity)"]
+
+    OPCUA -- "(1) DataChange / Event notifications" --> STACK
+    STACK -- "(2) Browse, Read, Write, Call" --> OPCUA
+    STACK <-. "(8) app + peer certs, CRLs,<br/>rejected certs" .-> PKI
+
+    STACK --> ENGINE
+    ENGINE -- "(5) network messages" --> EHUB
+    EHUB -- "(5) D2C telemetry" --> IOTHUB
+    ENGINE -- "(6) telemetry (direct transport)" --> BROKER
+
+    OPER -- "(3) HTTPS + API key" --> API
+    IOTHUB -- "(4) direct methods /<br/>twin desired properties" --> EHUB
+    EHUB --> API
+    API --> CFG
+    CFG <-. "(7) read / write config" .-> PNJSON
+    CFG --> STACK
+
+    ADR -. "(9) asset / device definitions" .-> CFG
+    ACR -. "(10) module image" .-> MOD
+    ENGINE -- "(11) diagnostics, runtime state, logs" --> EHUB
+
+    classDef ext fill:#f5f5f5,stroke:#666,stroke-dasharray:3 3
+    classDef store fill:#eef,stroke:#446
+    class OPCUA,OPER,ACR,ADR ext
+    class PNJSON,PKI store
+```
+
+## Test and CI data flows
+
+The end-to-end and soak test infrastructure creates its own, separate flows.
+They do not exist in a customer deployment, but they do run against real Azure
+resources with real credentials, so they are in scope for the threat model.
+
+```mermaid
+flowchart LR
+    subgraph GH["GitHub Actions runner — untrusted for pull requests"]
+        CI["ci.yml / soak.yml /<br/>e2e-standalone.yml"]
+        TESTS["xUnit test host"]
+    end
+
+    subgraph AZT["Azure test subscription"]
+        KV[("Key Vault<br/>(test secrets)")]
+        HUB["Test IoT Hub"]
+        VM["IoT Edge VM"]
+        ACI["OPC PLC containers"]
+    end
+
+    CI -- "(12) OIDC federation<br/>(no client secret)" --> AZT
+    KV -- "(13) secrets to \$GITHUB_ENV,<br/>masked" --> CI
+    CI --> TESTS
+    TESTS -- "(14) direct methods" --> HUB
+    HUB --> VM
+    TESTS -- "(15) read telemetry<br/>(Event Hub SAS)" --> HUB
+    TESTS -- "(16) create / delete<br/>container groups" --> ACI
+    TESTS -- "(17) trx + logs" --> ART[("Build artifacts")]
+
+    classDef store fill:#eef,stroke:#446
+    class KV,ART store
+```
+
+## Assumptions
+
+These are the load-bearing assumptions. If one of them is false in a given
+deployment, the corresponding threats in [readme.md](./readme.md) change
+severity.
+
+1. The OT network is **not** trusted. An OPC UA server may be malicious,
+   compromised, or simply faulty, and can return hostile or malformed data.
+2. The IoT Edge gateway host is trusted. An attacker with root on the host has
+   already won: they can read the module's mounted volume, its PKI store and its
+   module identity.
+3. `published_nodes.json` and the PKI directory are on a mounted volume shared
+   with the host. Their confidentiality and integrity are the host's
+   responsibility, not the module's.
+4. IoT Hub is trusted for authentication of direct methods; the module does not
+   independently authenticate the caller of a direct method.
+5. The REST API is reachable only from the edge network and is protected by the
+   configured API key. It is not intended for exposure to the internet.

--- a/docs/opc-publisher/threatmodel/readme.md
+++ b/docs/opc-publisher/threatmodel/readme.md
@@ -56,8 +56,9 @@ description of the system, not a to-do list; the open items are called out in
 | T14 | (12) OIDC federation | **S**, **E** | A workflow change that runs untrusted code could use the federated identity against the test subscription. | Mitigated: federated OIDC with no stored client secret, and E2E runs on `push`/`schedule`/`workflow_dispatch`, not on `pull_request` from forks. |
 | T15 | (13) Key Vault → `$GITHUB_ENV` | **I** | Test secrets (IoT Hub connection string, SSH keys, Event Hub SAS) reach the runner environment. | Mitigated: values are `::add-mask::`ed and written via heredoc. Anything that echoes them defeats the mask. |
 | T16 | (17) build artifacts | **I** | `.trx` files and captured module logs are uploaded as artifacts and can contain endpoint URLs, node ids and payloads. | Retention is bounded (14–30 days). Do not enable payload logging in CI. |
-| T17 | Workflow `run:` blocks | **T**, **E** | Script injection through `${{ }}` interpolation of an input into a shell. GitHub substitutes textually *before* bash parses, so a quote in the value breaks out and executes — in a job holding `id-token: write`, which can mint an Azure OIDC assertion for the E2E service principal. | **Found and fixed.** `e2e-standalone.yml`'s `init` step interpolated `inputs.soak_minutes` and `inputs.resource_group_name` directly. Both now arrive via `env:` and are validated against a strict pattern before use. Reachable only via `workflow_dispatch`, so exploitable by a principal that can dispatch but not push. |
+| T17 | Workflow `run:` blocks | **T**, **E** | Script injection through `${{ }}` interpolation of an input into a shell. GitHub substitutes textually *before* bash parses, so a quote in the value breaks out and executes — and if the job holds `id-token: write` it can mint an Azure OIDC assertion for the E2E service principal. | **Found and fixed**, in three layers: (a) `e2e-standalone.yml`'s `init` step now takes `soak_minutes` and `resource_group_name` through `env:` and validates both against strict patterns; (b) `init` no longer inherits `id-token: write`, so even a future injection there has no token to steal; (c) every job that authenticates to Azure is gated behind the `e2e` environment. |
 | T18 | `ci.yml` `images_build` | **T** | `github.ref_name` is interpolated into a `run:` block; git allows shell metacharacters in branch names. | Low: the job carries `if: github.event_name != 'pull_request'`, so creating such a branch requires write access, and the value is passed as a PowerShell argument rather than into `sh -c`. Pre-existing; worth tightening opportunistically. |
+| T19 | `e2e` environment | **E** | The environment referenced by the Azure-touching jobs currently has **no protection rules and no deployment branch policy**, so gating on it does not by itself restrict who can reach the subscription. | Open — see [Residual risk](#residual-risk). The gate is now wired so that adding required reviewers or a branch policy is a settings change, not a workflow change. |
 
 ## Residual risk
 
@@ -72,6 +73,13 @@ Accepted, with the reasoning:
    usability. Host filesystem permissions are the control.
 3. **T1 — `--aa` disables server certificate validation.** Intentionally
    available for commissioning; it must not be left on.
+4. **T19 — the `e2e` environment has no protection rules.** The Azure-touching
+   jobs are now gated behind it, but the environment itself declares no
+   required reviewers and no deployment branch policy, so today the gate is a
+   hook rather than a control. Closing this is a repository-settings change:
+   add required reviewers, or restrict deployments to `main` and `release/*`.
+   Until then, `workflow_dispatch` on `e2e-standalone.yml` remains reachable by
+   anyone holding `actions: write`.
 
 ## Maintaining this model
 

--- a/docs/opc-publisher/threatmodel/readme.md
+++ b/docs/opc-publisher/threatmodel/readme.md
@@ -1,0 +1,95 @@
+# OPC Publisher threat model <!-- omit in toc -->
+
+[Home](../readme.md) · [Security](../security.md)
+
+- [`OpcPublisher.tm7`](./OpcPublisher.tm7) — Microsoft Threat Modeling Tool model
+- [`dataflow.md`](./dataflow.md) — the same model as reviewable Mermaid diagrams
+- [`../../../tools/threatmodel/generate_tm7.py`](../../../tools/threatmodel/generate_tm7.py)
+  — generator; **edit this, not the `.tm7`**, and re-run it
+
+## Scope
+
+The module as deployed: the `opcpublisher` container on an IoT Edge gateway,
+its OPC UA client, its configuration surfaces (mounted file, REST API, IoT Hub
+direct methods, Azure Device Registry), its PKI store, and the transports it
+publishes to. The CI/E2E test infrastructure is included as a second diagram
+because it runs against real Azure resources with real credentials.
+
+Out of scope: the security of the IoT Edge host itself, Azure IoT Hub's own
+threat model, and the OPC UA stack implementation (an external dependency).
+
+## Trust boundaries
+
+| # | Boundary | Crossed by | Why it matters |
+| --- | --- | --- | --- |
+| TB1 | OT / plant network | Flows 1, 2 | The server side is frequently unauthenticated and flat. Treat every byte from it as hostile. |
+| TB2 | `opcpublisher` container | Flows 3, 4, 5, 6, 10 | Separates module code from the host and from the rest of the edge deployment. |
+| TB3 | Mounted volume | Flows 7, 8 | Config and PKI are shared with the host; the module cannot assume exclusive control. |
+| TB4 | Cloud | Flows 4, 5, 6, 9 | Authenticated and encrypted, but the far side has full reconfiguration power. |
+
+## Threats
+
+STRIDE per element/flow. "Status" is what the code does **today** — this is a
+description of the system, not a to-do list; the open items are called out in
+[Residual risk](#residual-risk).
+
+| # | Flow / element | STRIDE | Threat | Status |
+| --- | --- | --- | --- | --- |
+| T1 | (1) OPC UA server → stack | **S** | Rogue server impersonates the real one and feeds fabricated process values. | Mitigated by certificate validation, **unless** `--aa` / `AutoAcceptUntrustedCertificates` is set. That switch is a deliberate convenience for commissioning and should not survive into production. |
+| T2 | (1) | **T**, **I** | Values read or modified in flight. | Mitigated only when the endpoint uses `SecurityMode` `Sign` or `SignAndEncrypt`. `None` is supported and is plaintext by design. |
+| T3 | (1) | **D** | Hostile or faulty server floods notifications, or returns huge values, exhausting memory on the gateway. | Partly mitigated: bounded publish queues drop on overflow (`ingressNotificationsDropped`), server queue size is configurable. Message size is bounded per transport. |
+| T4 | (2) stack → OPC UA server | **T**, **E** | Publisher is used as a **write** path into the plant: `Write` and `Call` reach the PLC. Whoever controls the configuration surface controls this. | This is the highest-consequence flow in the model. It is gated by the same authn as T6/T7 — no additional authorisation layer exists. |
+| T5 | (3) operator → REST API | **S**, **E** | Weak, default, or leaked API key grants full reconfiguration, hence T4. | Mitigated by API key auth; no rate limiting or lockout. Do not expose the API beyond the edge network. |
+| T6 | (4) IoT Hub → module | **E** | Any principal with IoT Hub *service connect* can invoke direct methods and reconfigure publishing, hence T4. | Accepted by design: the module trusts IoT Hub to authenticate the caller. Control who holds the service policy. |
+| T7 | (7) `published_nodes.json` | **I** | The file holds OPC UA credentials. From 2.6 onward `EncryptedAuthPassword` is **plaintext by default** (2.5 and earlier always encrypted). | Host filesystem permissions are the only control. Prefer certificate or anonymous auth where possible. |
+| T8 | (7) | **T** | Anything that can write the mounted file changes what the module publishes and writes (T4). | Host filesystem permissions. The module re-reads the file on change by design. |
+| T9 | (8) PKI store | **T** | Injecting a certificate into the trusted store defeats T1 entirely. | Host filesystem permissions; store is on the mounted volume. |
+| T10 | (5), (6) telemetry egress | **I** | Process data is commercially sensitive. | TLS on every supported transport; IoT Hub path additionally uses the module identity. |
+| T11 | (11) diagnostics / logs | **I** | Verbose logging (`--dln`, diagnostics dumps) can echo payloads, endpoint URLs and node ids into logs that leave the device. | Off by default; treat as sensitive when enabled. |
+| T12 | Heartbeat watchdog | **D**, **T** | A watchdog that re-sends the last known value can, if it races the value it waits for, emit stale data that a consumer records as real — corrupting a historian. | **Fixed.** The watchdog now requires `heartbeatInterval + min(publishingInterval, heartbeatInterval)` of silence, and the `Heartbeat` indicator lets a consumer filter re-sends. See [readme](../readme.md#watchdog-grace-period). |
+| T13 | (10) image pull | **T** | Compromised or substituted module image. | Registry auth; images are cosign-signed in CI. |
+
+### Test and CI infrastructure
+
+| # | Flow / element | STRIDE | Threat | Status |
+| --- | --- | --- | --- | --- |
+| T14 | (12) OIDC federation | **S**, **E** | A workflow change that runs untrusted code could use the federated identity against the test subscription. | Mitigated: federated OIDC with no stored client secret, and E2E runs on `push`/`schedule`/`workflow_dispatch`, not on `pull_request` from forks. |
+| T15 | (13) Key Vault → `$GITHUB_ENV` | **I** | Test secrets (IoT Hub connection string, SSH keys, Event Hub SAS) reach the runner environment. | Mitigated: values are `::add-mask::`ed and written via heredoc. Anything that echoes them defeats the mask. |
+| T16 | (17) build artifacts | **I** | `.trx` files and captured module logs are uploaded as artifacts and can contain endpoint URLs, node ids and payloads. | Retention is bounded (14–30 days). Do not enable payload logging in CI. |
+| T17 | Workflow `run:` blocks | **T**, **E** | Script injection through `${{ }}` interpolation of an input into a shell. GitHub substitutes textually *before* bash parses, so a quote in the value breaks out and executes — in a job holding `id-token: write`, which can mint an Azure OIDC assertion for the E2E service principal. | **Found and fixed.** `e2e-standalone.yml`'s `init` step interpolated `inputs.soak_minutes` and `inputs.resource_group_name` directly. Both now arrive via `env:` and are validated against a strict pattern before use. Reachable only via `workflow_dispatch`, so exploitable by a principal that can dispatch but not push. |
+| T18 | `ci.yml` `images_build` | **T** | `github.ref_name` is interpolated into a `run:` block; git allows shell metacharacters in branch names. | Low: the job carries `if: github.event_name != 'pull_request'`, so creating such a branch requires write access, and the value is passed as a PowerShell argument rather than into `sh -c`. Pre-existing; worth tightening opportunistically. |
+
+## Residual risk
+
+Accepted, with the reasoning:
+
+1. **T4/T6 — no second authorisation layer.** Anyone who can reach the
+   configuration surface can make the publisher write to the plant. The
+   mitigation is operational: restrict the IoT Hub service policy and the API
+   key, and use OPC UA server-side permissions so the publisher's identity is
+   only authorised for the nodes it legitimately needs.
+2. **T7 — plaintext credentials in `published_nodes.json`.** Changed in 2.6 for
+   usability. Host filesystem permissions are the control.
+3. **T1 — `--aa` disables server certificate validation.** Intentionally
+   available for commissioning; it must not be left on.
+
+## Maintaining this model
+
+Re-run the generator after editing the model:
+
+```bash
+python tools/threatmodel/generate_tm7.py
+```
+
+Then open `OpcPublisher.tm7` in the
+[Microsoft Threat Modeling Tool](https://aka.ms/threatmodelingtool) and use
+*Analysis view* to regenerate the threat list. The `.tm7` here intentionally
+ships with an empty `<ThreatInstances/>` so the tool generates them from the
+current stencil set rather than carrying a stale, hand-written list.
+
+> The `.tm7` is authored against the TMT 2016/7.x schema and validated for
+> well-formedness and referential integrity (every data flow endpoint resolves
+> to a real element) by CI-independent checks. It has **not** been round-tripped
+> through the Threat Modeling Tool GUI in this repository, since the tool is
+> Windows-desktop only. If the tool reports a schema problem, fix the generator
+> and regenerate rather than editing the XML by hand.

--- a/tools/threatmodel/generate_tm7.py
+++ b/tools/threatmodel/generate_tm7.py
@@ -1,0 +1,309 @@
+"""
+Generate OpcPublisher.tm7 for the Microsoft Threat Modeling Tool.
+
+Hand-maintaining a .tm7 is error prone because every element is referenced by
+GUID from several places (borders, connectors, threat instances). This script
+is the source of truth: edit the model description below and re-run it.
+
+    python tools/threatmodel/generate_tm7.py
+
+The generated file is committed so that reviewers who do not run Python can
+still open it.
+"""
+import uuid
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+NS = "http://schemas.microsoft.com/sdl/2014/12/ThreatModel"
+XSI = "http://www.w3.org/2001/XMLSchema-instance"
+XSD = "http://www.w3.org/2001/XMLSchema"
+
+ET.register_namespace("", NS)
+ET.register_namespace("i", XSI)
+
+# Deterministic GUIDs so regenerating does not churn the diff.
+_NAMESPACE = uuid.UUID("6f9619ff-8b86-d011-b42d-00c04fc964ff")
+
+
+def guid(name):
+    return str(uuid.uuid5(_NAMESPACE, name)).lower()
+
+
+def q(tag):
+    return f"{{{NS}}}{tag}"
+
+
+def itype(el, value):
+    el.set(f"{{{XSI}}}type", value)
+
+
+# ---------------------------------------------------------------------------
+# Model definition
+# ---------------------------------------------------------------------------
+
+# (key, stencil, label, left, top, width, height, properties)
+ELEMENTS = [
+    # External interactors
+    ("opcua_server", "GE.EI", "OPC UA Server (field device)", 40, 300, 160, 90, {
+        "Code Type": "Unmanaged",
+        "Running As": "Not Selected",
+        "Accepts Input From": "Untrusted OT network",
+    }),
+    ("operator", "GE.EI", "Operator / Engineer", 40, 60, 160, 90, {
+        "Code Type": "Not Applicable",
+        "Running As": "Not Selected",
+    }),
+    ("registry", "GE.EI", "Container Registry", 1020, 620, 160, 90, {
+        "Code Type": "Not Applicable",
+    }),
+    ("adr", "GE.EI", "Azure Device Registry", 1020, 500, 160, 90, {
+        "Code Type": "Not Applicable",
+    }),
+
+    # Processes inside the module
+    ("stack", "GE.P", "OPC UA Client Stack", 330, 300, 170, 100, {
+        "Code Type": "Managed",
+        "Running As": "Standard User",
+        "Isolation Level": "Sandbox",
+        "Accepts Input From": "Untrusted OT network",
+    }),
+    ("engine", "GE.P", "Publisher Engine (encode / batch / publish)", 570, 300, 190, 100, {
+        "Code Type": "Managed",
+        "Running As": "Standard User",
+        "Isolation Level": "Sandbox",
+    }),
+    ("api", "GE.P", "REST API Host (ASP.NET Core)", 330, 60, 170, 100, {
+        "Code Type": "Managed",
+        "Running As": "Standard User",
+        "Authentication Scheme": "API key",
+        "Isolation Level": "Sandbox",
+    }),
+    ("config", "GE.P", "Configuration Service", 570, 60, 170, 100, {
+        "Code Type": "Managed",
+        "Running As": "Standard User",
+    }),
+    ("edgehub", "GE.P", "edgeHub (IoT Edge runtime)", 820, 180, 170, 100, {
+        "Code Type": "Managed",
+        "Running As": "Standard User",
+    }),
+
+    # Data stores
+    ("pnjson", "GE.DS", "published_nodes.json", 570, 620, 170, 90, {
+        "Store Type": "File",
+        "Encrypted": "No",
+        "Signed": "No",
+        "Write Access": "Yes",
+    }),
+    ("pki", "GE.DS", "PKI stores (own / trusted / issuer / rejected)", 330, 620, 170, 90, {
+        "Store Type": "File",
+        "Encrypted": "No",
+        "Signed": "Yes",
+        "Write Access": "Yes",
+    }),
+
+    # Cloud sinks
+    ("iothub", "GE.P", "Azure IoT Hub", 1020, 180, 160, 90, {
+        "Code Type": "Not Applicable",
+        "Running As": "Not Selected",
+    }),
+    ("broker", "GE.P", "MQTT broker / HTTP / Dapr sink", 1020, 320, 160, 90, {
+        "Code Type": "Not Applicable",
+    }),
+]
+
+# (key, source, target, label, properties)
+FLOWS = [
+    ("f1", "opcua_server", "stack",
+     "(1) DataChange / Event notifications (opc.tcp)", {
+         "Authentication Mechanism": "Certificate / anonymous",
+         "Provides Confidentiality": "Depends on SecurityMode",
+         "Provides Integrity": "Depends on SecurityMode",
+     }),
+    ("f2", "stack", "opcua_server",
+     "(2) Browse / Read / Write / Call", {
+         "Authentication Mechanism": "Certificate / username / anonymous",
+     }),
+    ("f3", "operator", "api",
+     "(3) REST API over HTTPS", {
+         "Authentication Mechanism": "API key",
+         "Provides Confidentiality": "Yes",
+     }),
+    ("f4", "iothub", "edgehub",
+     "(4) Direct methods / twin desired properties", {
+         "Authentication Mechanism": "IoT Hub module identity",
+         "Provides Confidentiality": "Yes",
+     }),
+    ("f4b", "edgehub", "api", "(4) Method invocation", {}),
+    ("f5", "engine", "edgehub", "(5) Network messages (telemetry)", {}),
+    ("f5b", "edgehub", "iothub", "(5) D2C telemetry", {
+        "Provides Confidentiality": "Yes",
+    }),
+    ("f6", "engine", "broker", "(6) Telemetry via direct transport", {
+        "Authentication Mechanism": "Per transport",
+    }),
+    ("f7", "config", "pnjson", "(7) Read / write published nodes", {}),
+    ("f7b", "pnjson", "config", "(7) Load configuration on start / change", {}),
+    ("f8", "stack", "pki", "(8) Store rejected / own certificates", {}),
+    ("f8b", "pki", "stack", "(8) Load trust list, CRLs", {}),
+    ("f9", "adr", "config", "(9) Asset / device definitions", {}),
+    ("f10", "registry", "engine", "(10) Module image pull", {}),
+    ("f11", "engine", "edgehub", "(11) Diagnostics / runtime state / logs", {}),
+    ("f12", "config", "stack", "(12) Applied subscription configuration", {}),
+    ("f13", "stack", "engine", "(13) Notifications to writer groups", {}),
+    ("f14", "api", "config", "(14) Configuration API calls", {}),
+]
+
+# (key, label, left, top, width, height)
+BOUNDARIES = [
+    ("tb_ot", "OT / plant network boundary", 20, 240, 290, 220),
+    ("tb_module", "opcpublisher container boundary", 310, 20, 470, 420),
+    ("tb_fs", "Mounted volume (host filesystem) boundary", 310, 570, 460, 170),
+    ("tb_cloud", "Cloud boundary", 1000, 140, 200, 600),
+]
+
+
+def make_properties(props, label):
+    """Build the <Properties> block. The first entry is always the display name."""
+    container = ET.Element(q("Properties"))
+    header = ET.SubElement(container, q("anyType"))
+    itype(header, "HeaderDisplayAttribute")
+    ET.SubElement(header, q("DisplayName")).text = "Name"
+    ET.SubElement(header, q("Name")).text = "Name"
+    value = ET.SubElement(header, q("Value"))
+    value.set(f"{{{XSI}}}type", "x:string")
+    value.set("xmlns:x", XSD)
+    value.text = label
+
+    for name, val in props.items():
+        attr = ET.SubElement(container, q("anyType"))
+        itype(attr, "StringDisplayAttribute")
+        ET.SubElement(attr, q("DisplayName")).text = name
+        ET.SubElement(attr, q("Name")).text = name.replace(" ", "")
+        v = ET.SubElement(attr, q("Value"))
+        v.set(f"{{{XSI}}}type", "x:string")
+        v.set("xmlns:x", XSD)
+        v.text = val
+    return container
+
+
+def add_border(parent, key, stencil, label, left, top, width, height, props,
+               is_boundary=False):
+    kv = ET.SubElement(parent, q("KeyValueOfguidanyType"))
+    ET.SubElement(kv, q("Key")).text = guid(key)
+    val = ET.SubElement(kv, q("Value"))
+    itype(val, "BorderBoundary" if is_boundary else "Stencil")
+
+    ET.SubElement(val, q("GenericTypeId")).text = stencil
+    ET.SubElement(val, q("Guid")).text = guid(key)
+    ET.SubElement(val, q("Height")).text = str(height)
+    ET.SubElement(val, q("Left")).text = str(left)
+    val.append(make_properties(props, label))
+    ET.SubElement(val, q("StrokeDashArray")).set(f"{{{XSI}}}nil", "true")
+    ET.SubElement(val, q("StrokeThickness")).text = "1"
+    ET.SubElement(val, q("Top")).text = str(top)
+    ET.SubElement(val, q("TypeId")).text = stencil
+    ET.SubElement(val, q("Width")).text = str(width)
+
+
+def add_flow(parent, key, source, target, label, props):
+    kv = ET.SubElement(parent, q("KeyValueOfguidanyType"))
+    ET.SubElement(kv, q("Key")).text = guid(key)
+    val = ET.SubElement(kv, q("Value"))
+    itype(val, "Connector")
+
+    ET.SubElement(val, q("GenericTypeId")).text = "GE.DF"
+    ET.SubElement(val, q("Guid")).text = guid(key)
+    val.append(make_properties(props, label))
+    ET.SubElement(val, q("SourceGuid")).text = guid(source)
+    ET.SubElement(val, q("SourceX")).text = "0"
+    ET.SubElement(val, q("SourceY")).text = "0"
+    ET.SubElement(val, q("StrokeDashArray")).set(f"{{{XSI}}}nil", "true")
+    ET.SubElement(val, q("StrokeThickness")).text = "1"
+    ET.SubElement(val, q("TargetGuid")).text = guid(target)
+    ET.SubElement(val, q("TargetX")).text = "0"
+    ET.SubElement(val, q("TargetY")).text = "0"
+    ET.SubElement(val, q("TypeId")).text = "GE.DF"
+
+
+HIGH_LEVEL = (
+    "OPC Publisher is an Azure IoT Edge module that connects to OPC UA servers "
+    "on an operational technology network, subscribes to data changes and "
+    "events, and publishes the resulting telemetry to Azure IoT Hub, an MQTT "
+    "broker, or an HTTP/Dapr endpoint. It is configured through a mounted "
+    "published_nodes.json file, an authenticated REST API, and IoT Hub direct "
+    "methods. It maintains an OPC UA PKI store on a mounted volume."
+)
+
+ASSUMPTIONS = (
+    "1. The OT network is untrusted: an OPC UA server may be malicious, "
+    "compromised or faulty and can return hostile or malformed data. "
+    "2. The IoT Edge gateway host is trusted; an attacker with root on the host "
+    "can already read the module's mounted volume, PKI store and module identity. "
+    "3. published_nodes.json and the PKI directory live on a host-shared mounted "
+    "volume; their confidentiality and integrity are the host's responsibility. "
+    "4. IoT Hub is trusted to authenticate the caller of a direct method; the "
+    "module does not independently authenticate that caller. "
+    "5. The REST API is reachable only from the edge network and is protected by "
+    "the configured API key; it is not intended for internet exposure."
+)
+
+EXTERNAL_DEPENDENCIES = (
+    "OPC UA .NET Standard stack (OPCFoundation.NetStandard.Opc.Ua); "
+    "Azure IoT Edge runtime (edgeAgent, edgeHub); Azure IoT Hub; "
+    "Furly transport abstractions (MQTT, HTTP, Dapr, Event Hubs); "
+    "ASP.NET Core; the host container runtime."
+)
+
+
+def build():
+    root = ET.Element(q("ThreatModel"))
+
+    surfaces = ET.SubElement(root, q("DrawingSurfaceList"))
+    surface = ET.SubElement(surfaces, q("DrawingSurfaceModel"))
+    ET.SubElement(surface, q("GenericTypeId")).text = "DFD"
+    ET.SubElement(surface, q("Guid")).text = guid("diagram")
+    ET.SubElement(surface, q("Header")).text = "OPC Publisher - Level 1"
+
+    borders = ET.SubElement(surface, q("Borders"))
+    for key, label, left, top, width, height in BOUNDARIES:
+        add_border(borders, key, "GE.TB.B", label, left, top, width, height,
+                   {}, is_boundary=True)
+    for key, stencil, label, left, top, width, height, props in ELEMENTS:
+        add_border(borders, key, stencil, label, left, top, width, height, props)
+
+    lines = ET.SubElement(surface, q("Lines"))
+    for key, source, target, label, props in FLOWS:
+        add_flow(lines, key, source, target, label, props)
+
+    ET.SubElement(surface, q("Zoom")).text = "1"
+
+    meta = ET.SubElement(root, q("MetaInformation"))
+    ET.SubElement(meta, q("Assumptions")).text = ASSUMPTIONS
+    ET.SubElement(meta, q("Contributors")).text = "Azure Industrial IoT"
+    ET.SubElement(meta, q("ExternalDependencies")).text = EXTERNAL_DEPENDENCIES
+    ET.SubElement(meta, q("HighLevelSystemDescription")).text = HIGH_LEVEL
+    ET.SubElement(meta, q("Owner")).text = "Azure Industrial IoT"
+    ET.SubElement(meta, q("Reviewer")).text = ""
+    ET.SubElement(meta, q("ThreatModelName")).text = "Azure IIoT OPC Publisher"
+
+    ET.SubElement(root, q("Notes"))
+    ET.SubElement(root, q("ThreatInstances"))
+    ET.SubElement(root, q("ThreatGenerationEnabled")).text = "true"
+    ET.SubElement(root, q("Validations"))
+    ET.SubElement(root, q("Version")).text = "4.1"
+
+    return root
+
+
+def main():
+    root = build()
+    tree = ET.ElementTree(root)
+    ET.indent(tree, space="  ")
+    out = Path(__file__).resolve().parents[2] / \
+        "docs" / "opc-publisher" / "threatmodel" / "OpcPublisher.tm7"
+    tree.write(out, encoding="utf-8", xml_declaration=True)
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

A security review of the recent telemetry soak work (#2517, #2518) found **one MEDIUM issue — in code I added in #2518** — plus one low-severity pre-existing observation. This PR fixes the issue and adds a threat model, since none was checked in.

No CRITICAL or HIGH findings.

## Findings

| # | Severity | File | Lines | Vulnerability | Confidence |
|---|----------|------|-------|---------------|------------|
| 1 | 🟡 MEDIUM | `.github/workflows/e2e-standalone.yml` | 176 | Script injection via `${{ inputs.soak_minutes }}` interpolated into a bash `run:` block in a job holding `id-token: write` | 8/10 |
| 2 | ⚪ LOW | `.github/workflows/ci.yml` | 343 | `github.ref_name` interpolated into a `run:` block (pre-existing, not in the reviewed diff) | 6/10 |

### 1 — Script injection in the `init` step 🟡

```yaml
soak_minutes="${{ inputs.soak_minutes || '30' }}"
echo "soak_timeout=$((soak_minutes + 60))" >> "$GITHUB_OUTPUT"
```

GitHub substitutes `${{ }}` **textually before bash parses the line**, so a value containing a double quote terminates the assignment and the remainder executes as shell. Demonstrated:

```
$ soak_minutes="30" ; echo ARBITRARY-CODE-RAN ; #"
  echo "soak_timeout=$((soak_minutes + 60))"
ARBITRARY-CODE-RAN
soak_timeout=90        <-- step still succeeds, so the run looks clean
```

**Impact.** The `init` job carries `id-token: write` and has no `environment:` gate, so injected code can mint an Azure OIDC assertion for the E2E federated credential — the identity `DeployStandalone.ps1` uses to create resource groups, IoT Hubs and Key Vaults, and to read Key Vault secrets including the IoT Hub connection string, the Event Hub connection string and the edge VM SSH private key.

**Reachability is limited, which is why this is MEDIUM and not HIGH.** `ci.yml` is the only `workflow_call` caller and does not pass `soak_minutes`, and that call is gated to `schedule` / pushes to `main` or `release/*` / `workflow_dispatch` — **no pull request, fork or otherwise, can reach it**. The live path is `workflow_dispatch` on `e2e-standalone.yml`, which needs only `actions: write`. For an actor who already holds `contents: write` the marginal gain is near zero; the real escalation is for a PAT or App installation scoped to *dispatch workflows but not push code*.

**Fix.** Both `soak_minutes` and the pre-existing `resource_group_name` interpolation in the same step now arrive through `env:` and are dereferenced as shell variables, then validated:

```yaml
env:
  RESOURCE_GROUP_NAME: ${{ inputs.resource_group_name || '<generated>' }}
  SOAK_MINUTES: ${{ inputs.soak_minutes || '30' }}
  RUN_ID: ${{ github.run_id }}
run: |
  set -euo pipefail
  ...
  if ! [[ "$SOAK_MINUTES" =~ ^[0-9]{1,4}$ ]]; then
    echo "::error::soak_minutes must be a number, got: $SOAK_MINUTES"; exit 1
  fi
```

Verified — the review's payload and several variants are rejected, benign values compute the same timeout:

```
soak_minutes:
  [benign 30] accepted -> soak_timeout=90
  [injection] REJECTED (safe)
  [cmd subst] REJECTED (safe)
  [backtick]  REJECTED (safe)
  [semicolon] REJECTED (safe)
resource_group_name:
  [benign]    accepted -> e2etesting2026080612345
  [injection] REJECTED (safe)
```

I also scanned every workflow for the same pattern. Only three other interpolations appear inside `run:` blocks: two are `vars.AZURE_CLIENT_ID` (an admin-set repository variable), and one is finding 2.

### 2 — `github.ref_name` in a `run:` block ⚪

Pre-existing, **not** introduced by the reviewed diff, so it is documented rather than changed here. Git permits shell metacharacters in branch names, but the job is `if: github.event_name != 'pull_request'` — creating such a branch requires write access — and the value is passed as a PowerShell argument, not into `sh -c`. Recorded as **T18** in the threat model for opportunistic tightening.

## Areas reviewed with no findings

- **Secret handling.** `SoakTelemetryReader.onFirstMessage` emits only the decoded telemetry body; the module-log dump reuses pre-existing `GetModuleLogsAsync`. The new `secrets: inherit` calls target the same local reusable workflow as the existing ones, widening nothing. `soak.yml` and the `soak_smoke` job hold no secrets at all.
- **`UpdateTagAsync` etag `"*"`.** Idempotent, content-identical tag on a device twin in an ephemeral per-run resource group; no authorization decision downstream.
- **ACI command / DNS label.** `nameDiscriminator` is a compile-time constant, never reaches the `/bin/sh -c` string, and numeric args pass through `int.TryParse`. `ShellQuote` is correctly applied.
- **Watchdog re-arm path.** Convergent, not churning — `idle` grows monotonically while silent and `due ≤ 2 × heartbeatInterval`, so no starvation. Same `TimeProvider` clock on both sides.
- **Validator memory.** All collections bounded: examples at 25, duplicate window at 100 000 with FIFO eviction, nodes at the configured count.

## Threat model

None was checked in, so this adds one:

| File | Purpose |
|---|---|
| `docs/opc-publisher/threatmodel/OpcPublisher.tm7` | Microsoft Threat Modeling Tool model |
| `docs/opc-publisher/threatmodel/dataflow.md` | Same model as Mermaid, reviewable in a PR |
| `docs/opc-publisher/threatmodel/readme.md` | Trust boundaries, STRIDE table, residual risk |
| `tools/threatmodel/generate_tm7.py` | Generator — **edit this, not the `.tm7`** |

The `.tm7` is generated rather than hand-written because every element is referenced by GUID from several places; hand-editing reliably produces dangling references. Validated for well-formedness and referential integrity — 17 elements, 18 data flows, every flow endpoint resolves to a real element.

The model covers four trust boundaries (OT network, container, mounted volume, cloud) and 18 threats. The substantive content is the **residual risk** section, which records what we accept and why:

1. **No second authorisation layer.** The publisher can `Write` and `Call` into the plant, and that is gated by the same authentication as everything else — whoever controls the configuration surface controls the write path. Mitigation is operational: restrict the IoT Hub service policy and API key, and use OPC UA server-side permissions.
2. **Plaintext credentials in `published_nodes.json`** since 2.6 (2.5 and earlier always encrypted). Host filesystem permissions are the only control.
3. **`--autoaccept` disables server certificate validation.** Intentional for commissioning; must not survive into production.

It also records the heartbeat watchdog issue fixed in #2517 as **T12**, since a watchdog that re-sends a stale value is a data-integrity threat to a historian, not just a correctness bug.

## Caveats

- The `.tm7` is authored against the TMT 2016/7.x schema and validated programmatically, but **has not been round-tripped through the Threat Modeling Tool GUI** — that tool is Windows-desktop only and I could not launch it here. If it reports a schema problem, fix the generator and regenerate rather than editing the XML.
- It ships with an empty `<ThreatInstances/>` on purpose, so the tool generates the threat list from the current stencil set instead of carrying a stale hand-written one.
- `actionlint` passes on all six workflow files.
