### PR TITLE
Update NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Azure SDK">
-    <PackageVersion Include="Azure.Core" Version="1.60.0" />
+    <PackageVersion Include="Azure.Core" Version="1.61.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageVersion Include="Azure.ResourceManager" Version="1.14.0" />
@@ -69,13 +69,13 @@
   </ItemGroup>
 
   <ItemGroup Label="OpenTelemetry">
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.17.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test and build tooling">
@@ -87,8 +87,8 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.91" />
     <PackageVersion Include="Neovolve.Logging.Xunit" Version="6.3.0" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.16.0" />
+    <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.16.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.assert" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
@@ -100,7 +100,7 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="Irony" Version="1.5.3" />
     <PackageVersion Include="Json.More.Net" Version="3.0.1" />
-    <PackageVersion Include="JsonSchema.Net" Version="9.2.2" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <PackageVersion Include="KubernetesClient" Version="19.0.2" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="Microsoft.Json.Schema" Version="2.3.0" />
@@ -109,7 +109,7 @@
     <PackageVersion Include="MQTTnet.Extensions.Rpc" Version="5.2.0.1603" />
     <PackageVersion Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageVersion Include="SharpPcap" Version="6.3.1" />
-    <PackageVersion Include="SSH.NET" Version="2025.1.0" />
+    <PackageVersion Include="SSH.NET" Version="2026.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Routine dependency refresh. Everything that was behind and safe to move has
been moved; everything left behind is left behind on purpose.

## Updated

| Package | From | To |
| --- | --- | --- |
| `Azure.Core` | 1.60.0 | 1.61.0 |
| `JsonSchema.Net` | 9.2.2 | 9.4.0 |
| `OpenTelemetry.*` (6 packages) | 1.16.0 | 1.17.0 |
| `OpenTelemetry.Exporter.Prometheus.AspNetCore` | 1.16.0-beta.1 | 1.17.0-beta.1 |
| `Roslynator.Analyzers`, `Roslynator.Formatting.Analyzers` | 4.15.0 | 4.16.0 |
| `SSH.NET` | 2025.1.0 | 2026.0.0 |

The seven OpenTelemetry packages move together. The Prometheus exporter has no
stable release at all, so it stays on the beta channel and tracks the same
1.17.0 line as the rest.

Everything else in `Directory.Packages.props` was already at the latest
published version, including Furly, the OPC Foundation stack, the
`Microsoft.Extensions` packages, `KubernetesClient` and `MQTTnet`.

## Deliberately not updated

- `FluentAssertions` `[7.2.0]` -> 8.10.0. Version 8 moved to a commercial
  license.
- `Moq` `[4.20.2]` -> 4.20.72. Versions after 4.20.2 pulled in SponsorLink.

Both are pinned with exact version brackets and both reasons are already
recorded in the file under a "do not upgrade without team approval" comment, so
this leaves them as they are.

## The one judgement call

`SSH.NET` is a major version bump. Its documented breaking change is that
recursive *directory* upload now fails when the remote path does not already
exist, rather than creating it.

The only use of the library in this repository is the *stream* overload,
`scpClient.Upload(stream, path)`, in the end to end test helper, so the change
does not apply. The package also targets `net10.0` natively, which matches the
target framework of the only project that consumes it.

## Validation

- Solution restores and builds clean.
- No `RCS` diagnostics at all, so the Roslynator bump introduces no new
  analyzer warnings. The existing `CA` and `CS` warnings are unchanged - those
  come from the SDK analyzers, which this does not touch.
- Unit tests pass: 2270 Models, 2166 OpcUa, 905 Publisher, 1489
  Publisher.Module.
- The two projects outside the solution, `e2e-tests` and `samples/Netcap`,
  build clean. That matters here because `e2e-tests` is the only consumer of
  `SSH.NET`.
- `dotnet list package --vulnerable --include-transitive` reports no vulnerable
  packages across all thirteen projects.

No source changes were needed.
