### PR TITLE
Prove source timestamp fidelity against a slipping source

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -74,6 +74,8 @@ jobs:
             test: SlowSourceHeartbeatsKeepTimestampsOrderedAsync
           - name: SlowSourceUpdatedTimestampHeartbeat
             test: SlowSourceUpdatedTimestampHeartbeatsShiftTimestampsAsync
+          - name: SourceTimestampFidelity
+            test: SourceTimestampFidelityTests
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/opc-publisher/troubleshooting.md
+++ b/docs/opc-publisher/troubleshooting.md
@@ -19,6 +19,7 @@ In this document you find information about
       - [Use Azure IoT Explorer](#use-azure-iot-explorer)
   - [Duplicated, stale or unevenly spaced values](#duplicated-stale-or-unevenly-spaced-values)
     - [Jittered timestamps without duplicates](#jittered-timestamps-without-duplicates)
+    - [Quantized timestamp displacement with no heartbeats](#quantized-timestamp-displacement-with-no-heartbeats)
 - [Restart the module](#restart-the-module)
 - [Analyzing network capture files](#analyzing-network-capture-files)
   - [Netcap](#netcap)
@@ -202,6 +203,32 @@ Remedies, in order of preference:
 2. Set the heartbeat interval well above the sampling interval, so it only fires when data genuinely stops rather than when a single value is late.
 3. Use `--mm=FullSamples` / `--fm=True` and filter on the `Heartbeat` indicator.
 4. Analyze the message `Timestamp` instead of `SourceTimestamp`, which OPC Publisher never synthesizes from a server timestamp. Note that this requires option 3 as well: the message `Timestamp` is not emitted by the plain `Samples` profile. Note also that with `--mts=PublishTime` heartbeats carry no message timestamp at all, because they are generated locally rather than as the result of a publish response.
+
+#### Quantized timestamp displacement with no heartbeats
+
+If the symptoms above are present but heartbeats are *not* involved - the counter increment between consecutive samples is always exactly right, so no message is a resent value - then OPC Publisher is not the origin. Look for this signature:
+
+- the value increment between consecutive samples is always the expected one, so nothing was lost, duplicated or reordered,
+- the displacement is *quantized*: it clusters tightly around one value rather than spreading smoothly,
+- displacements come in self-correcting pairs, one distance too long immediately followed by one too short, summing back to exactly two sampling intervals,
+- the undisplaced timestamps hold their sub-second phase to about a millisecond over many minutes.
+
+The last two points are the discriminating ones. A pipeline that damaged timestamps would not restore the original phase afterwards, and no jitter introduced anywhere downstream of the server - network, thread scheduling, batching, transport - is stable to a millisecond over minutes or quantized to a single step size. A discrete step on an otherwise very stable grid is a *scheduler* in the data source slipping a slot.
+
+A useful confirmation is that the value sequence and the timestamp disagree. When the source counter advances at a known rate the value tells you how much time really elapsed. If the value says two seconds and the timestamp says 2.33 seconds, the timestamp is wrong and the value is right. Plotting the residual
+
+```text
+SourceTimestamp - (t0 + (value - v0) * counterPeriod)
+```
+
+turns this into a step function whose tread height is the displacement.
+
+Two further checks localize it:
+
+- Compare `SourceTimestamp`, `ServerTimestamp` and, in a full featured profile, the message `Timestamp` for the same samples. If source and server timestamps step together the server assigned both, and OPC Publisher only relayed them.
+- Check whether every node steps at the same instant. Simultaneous steps across all nodes point at one scheduler event in the server; independent steps point at per-node scan slot assignment. Either way the origin is upstream.
+
+OPC Publisher does not modify `SourceTimestamp` on the data change path. The only code that writes one is the legacy heartbeat described above, and that path is excluded as soon as the value increment is correct on every message. This is covered by an automated test, `SourceTimestampFidelityTests`, which drives the simulated server with exactly this defect and asserts that the timestamps delivered are identical to the ones the server recorded as having stamped.
 
 ## Restart the module
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/SourceTimestampFidelityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/SourceTimestampFidelityTests.cs
@@ -1,0 +1,505 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
+{
+    using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Fixtures;
+    using Furly.Extensions.Logging;
+    using Microsoft.Extensions.Logging;
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// <para>
+    /// Establishes that OPC Publisher reproduces the source timestamp it
+    /// received from the server byte for byte, including when that timestamp
+    /// is irregular.
+    /// </para>
+    /// <para>
+    /// A customer analysing a three thousand tag, two second stream reported
+    /// that no value was ever lost, duplicated or reordered - the counter
+    /// increment between consecutive samples was always exactly right - yet
+    /// roughly 0.8 % of the distances between consecutive source timestamps
+    /// fell outside a 2 % band around two seconds. The displacements were
+    /// quantized at about 333 ms, which is one sixth of the scan interval,
+    /// and came in self correcting pairs: one distance too long by 333 ms
+    /// immediately followed by one too short by the same amount, summing back
+    /// to 4000 ms to within a millisecond.
+    /// </para>
+    /// <para>
+    /// That is the signature of a data source whose scan scheduler slips a
+    /// slot, not of a pipeline that damages timestamps. The purpose of this
+    /// test is to make that distinction provable rather than argued: the
+    /// counter server is driven with exactly that defect
+    /// (<see cref="global::Counter.CounterServerOptions.SlotSlip"/>) and the
+    /// telemetry that comes out the far end of the publisher is compared
+    /// against the timestamps the server recorded as having stamped.
+    /// </para>
+    /// <para>
+    /// If the publisher were displacing timestamps, the two would differ. If
+    /// the publisher is transparent, they are identical and the customer's
+    /// metric reproduces downstream exactly as injected - which localises the
+    /// defect upstream of the module.
+    /// </para>
+    /// </summary>
+    [Trait(TestCategories.Name, TestCategories.LongRunning)]
+    public sealed class SourceTimestampFidelityTests : PublisherIntegrationTestBase
+    {
+        public SourceTimestampFidelityTests(ITestOutputHelper output)
+            : base(output, TimeSpan.FromMinutes(30), nameof(SourceTimestampFidelityTests))
+        {
+            _output = output;
+        }
+
+        /// <summary>
+        /// A source whose scan scheduler slips one slot every so often,
+        /// reproducing the reported field signature. The publisher must pass
+        /// the displaced timestamps through unchanged: it may neither repair
+        /// them nor add displacement of its own.
+        /// </summary>
+        [SkippableFact]
+        public async Task SlippingSourceIsReproducedExactlyAsync()
+        {
+            SkipUnlessEnabled();
+            var report = await RunAsync("slot slipping source", kSlotSlip);
+
+            AssertPublisherIsTransparent(report);
+
+            //
+            // The injected defect must be visible downstream, otherwise the
+            // comparison above is vacuous - a publisher that dropped every
+            // displaced sample would also report zero mismatches.
+            //
+            Assert.True(report.SlippedPairs > 0,
+                $"The source never slipped, so nothing was proven.\n{report}");
+
+            //
+            // This is the customer's metric. Every pair that straddles a
+            // slipped sample must be outside their band, and no other pair
+            // may be. Equality in both directions: the publisher neither
+            // hides the defect nor adds to it.
+            //
+            Assert.Equal(report.SlippedPairs, report.PairsOutsideBand);
+        }
+
+        /// <summary>
+        /// Control: the same run without the injected slip. It pins that the
+        /// publisher contributes no displacement of its own, so a non zero
+        /// result in the arm above can only come from the source.
+        /// </summary>
+        [SkippableFact]
+        public async Task RegularSourceProducesNoDisplacementAsync()
+        {
+            SkipUnlessEnabled();
+            var report = await RunAsync("regular source (control)", TimeSpan.Zero);
+
+            AssertPublisherIsTransparent(report);
+
+            Assert.Equal(0, report.SlippedPairs);
+            Assert.Equal(0, report.PairsOutsideBand);
+        }
+
+        /// <summary>
+        /// <para>
+        /// Negative control for the two arms above. Their value rests
+        /// entirely on the comparison against the server's record being able
+        /// to see a difference at all, so this drives the publisher down the
+        /// one code path that genuinely does synthesize a source timestamp -
+        /// the legacy <c>WatchdogLKVWithUpdatedTimestamps</c> heartbeat,
+        /// which resends the last known value with the timestamp shifted
+        /// forward by the time elapsed since it was received.
+        /// </para>
+        /// <para>
+        /// The source counts up far slower than the heartbeat interval so
+        /// heartbeats are guaranteed to fire. Those messages must be reported
+        /// as mismatches, because the timestamp they carry is one the server
+        /// never stamped. If this arm reported zero the detector would be
+        /// blind and the clean results above would mean nothing.
+        /// </para>
+        /// </summary>
+        [SkippableFact]
+        public async Task DetectorSeesSynthesizedTimestampsAsync()
+        {
+            SkipUnlessEnabled();
+            var report = await RunAsync("synthesized timestamps (negative control)",
+                TimeSpan.Zero, updateInterval: TimeSpan.FromSeconds(kSlowUpdateSeconds),
+                heartbeatSeconds: (int)kInterval.TotalSeconds,
+                heartbeatBehavior: "WatchdogLKVWithUpdatedTimestamps");
+
+            Assert.True(report.Compared > 0,
+                $"No sample could be compared against the server's record.\n{report}");
+            Assert.True(report.TimestampMismatches > 0,
+                $"The detector reported no mismatch even though the publisher was " +
+                $"configured to synthesize source timestamps, so it is blind and the " +
+                $"clean results of the other arms prove nothing.\n{report}");
+        }
+
+        /// <summary>
+        /// The assertions that must hold whatever the source does.
+        /// </summary>
+        /// <param name="report"></param>
+        private static void AssertPublisherIsTransparent(FidelityReport report)
+        {
+            Assert.True(report.Samples > 0, "No telemetry was received at all.");
+
+            //
+            // The heart of the test. Every source timestamp delivered must be
+            // the one the server recorded for that counter value.
+            //
+            Assert.True(report.TimestampMismatches == 0,
+                $"{report.TimestampMismatches} of {report.Compared} sample(s) carried a " +
+                $"source timestamp the server never stamped, so the publisher altered " +
+                $"it.\n{report}");
+            Assert.True(report.Compared > 0,
+                $"No sample could be compared against the server's record.\n{report}");
+
+            // Every distance must be exactly what the injected schedule predicts.
+            Assert.True(report.UnexplainedPairs == 0,
+                $"{report.UnexplainedPairs} consecutive pair(s) were not spaced as the " +
+                $"server's own schedule predicts.\n{report}");
+        }
+
+        /// <summary>
+        /// Run one scenario and measure the telemetry against the server's
+        /// record of what it stamped.
+        /// </summary>
+        /// <param name="label"></param>
+        /// <param name="slotSlip"></param>
+        /// <param name="updateInterval"></param>
+        /// <param name="heartbeatSeconds"></param>
+        /// <param name="heartbeatBehavior"></param>
+        private async Task<FidelityReport> RunAsync(string label, TimeSpan slotSlip,
+            TimeSpan? updateInterval = null, int heartbeatSeconds = 0,
+            string heartbeatBehavior = null)
+        {
+            var interval = updateInterval ?? kInterval;
+            using var loggerFactory = Log.ConsoleFactory(LogLevel.Warning);
+            // The enclosing namespace is also called Counter, so the options
+            // type has to be qualified against the global namespace.
+            using var server = new CounterServer(new global::Counter.CounterServerOptions
+            {
+                NodeCount = kNodeCount,
+                UpdateInterval = interval,
+                UseScheduledTimestamps = true,
+                SlotSlip = slotSlip,
+                SlotSlipPeriod = kSlipPeriod,
+                SlotSlipDwell = 1
+            }, loggerFactory);
+            EndpointUrl = server.EndpointUrl;
+
+            var configuration = WriteConfiguration(kNodeCount, kInterval, heartbeatSeconds);
+            try
+            {
+                var arguments = new List<string>
+                {
+                    "--mm=FullSamples", "--me=Json", "--bs=50", "--bi=10000"
+                };
+                if (heartbeatBehavior != null)
+                {
+                    arguments.Add($"--hbb={heartbeatBehavior}");
+                }
+                StartPublisher(label, configuration, [.. arguments]);
+
+                // Arrival order per node, so consecutive pairs can be formed.
+                var received = new Dictionary<string, List<(long Value, DateTime Ts)>>();
+
+                //
+                // Skip a warm up window. Monitored items are not all created
+                // at once, so early samples are legitimately partial.
+                //
+                var warmup = TimeSpan.FromSeconds(30);
+                var stopWatch = Stopwatch.StartNew();
+                await ConsumeMessagesAsync(warmup + Duration, message =>
+                {
+                    if (stopWatch.Elapsed < warmup)
+                    {
+                        return;
+                    }
+                    if (!message.TryGetProperty("NodeId", out var n) ||
+                        n.ValueKind != JsonValueKind.String ||
+                        !message.TryGetProperty("Value", out var dv) ||
+                        !dv.TryGetProperty("SourceTimestamp", out var ts) ||
+                        !ts.TryGetDateTime(out var parsed) ||
+                        !dv.TryGetProperty("Value", out var raw) ||
+                        !raw.TryGetInt64(out var value))
+                    {
+                        return;
+                    }
+                    var id = n.GetString()!;
+                    if (!received.TryGetValue(id, out var list))
+                    {
+                        received.Add(id, list = []);
+                    }
+                    list.Add((value, parsed.ToUniversalTime()));
+                }, Ct).ConfigureAwait(false);
+
+                var report = Evaluate(label, received, server, slotSlip, interval);
+                _output.WriteLine(report.ToString());
+                return report;
+            }
+            finally
+            {
+                await StopPublisherAsync().ConfigureAwait(false);
+                if (File.Exists(configuration))
+                {
+                    File.Delete(configuration);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Compare the telemetry against the server's own record.
+        /// </summary>
+        /// <param name="label"></param>
+        /// <param name="received"></param>
+        /// <param name="server"></param>
+        /// <param name="slotSlip"></param>
+        /// <param name="updateInterval"></param>
+        private static FidelityReport Evaluate(string label,
+            Dictionary<string, List<(long Value, DateTime Ts)>> received,
+            CounterServer server, TimeSpan slotSlip, TimeSpan updateInterval)
+        {
+            var options = server.NodeManager.Options;
+            var expected = updateInterval.TotalMilliseconds;
+            var band = expected * 0.02;
+
+            long samples = 0, compared = 0, mismatches = 0;
+            long pairs = 0, slipped = 0, outside = 0, unexplained = 0;
+            var worstMismatch = 0.0;
+            var examples = new List<string>();
+
+            foreach (var (nodeId, list) in received)
+            {
+                samples += list.Count;
+                for (var i = 0; i < list.Count; i++)
+                {
+                    var (value, ts) = list[i];
+
+                    // Ground truth: what did the server actually stamp?
+                    if (server.NodeManager.TryGetEmitted(value, out var truth))
+                    {
+                        compared++;
+                        var off = Math.Abs((ts - truth).TotalMilliseconds);
+                        if (off > kTimestampTolerance)
+                        {
+                            mismatches++;
+                            worstMismatch = Math.Max(worstMismatch, off);
+                            AddExample(examples,
+                                $"{nodeId}: value {value} arrived with {ts:O} but the " +
+                                $"server stamped {truth:O} ({off:F3} ms off)");
+                        }
+                    }
+
+                    if (i == 0)
+                    {
+                        continue;
+                    }
+                    var (prevValue, prevTs) = list[i - 1];
+                    if (value != prevValue + 1)
+                    {
+                        // Not adjacent, so the distance is not comparable.
+                        continue;
+                    }
+                    pairs++;
+                    var delta = (ts - prevTs).TotalMilliseconds;
+
+                    //
+                    // A pair straddles a slip when exactly one of its two
+                    // samples is displaced; then the distance is off by one
+                    // slot, in one direction or the other.
+                    //
+                    var shift =
+                        (options.IsSlipped(value) ? slotSlip.TotalMilliseconds : 0) -
+                        (options.IsSlipped(prevValue) ? slotSlip.TotalMilliseconds : 0);
+                    if (shift != 0)
+                    {
+                        slipped++;
+                    }
+                    if (Math.Abs(delta - expected) > band)
+                    {
+                        outside++;
+                    }
+                    if (Math.Abs(delta - (expected + shift)) > kTimestampTolerance)
+                    {
+                        unexplained++;
+                        AddExample(examples,
+                            $"{nodeId}: {prevValue} -> {value} spaced {delta:F3} ms, " +
+                            $"the server's schedule predicts {expected + shift:F3} ms");
+                    }
+                }
+            }
+
+            return new FidelityReport
+            {
+                Label = label,
+                Nodes = received.Count,
+                Samples = samples,
+                Compared = compared,
+                TimestampMismatches = mismatches,
+                WorstMismatchMs = worstMismatch,
+                Pairs = pairs,
+                SlippedPairs = slipped,
+                PairsOutsideBand = outside,
+                UnexplainedPairs = unexplained,
+                Examples = examples
+            };
+        }
+
+        private static void AddExample(List<string> examples, string example)
+        {
+            if (examples.Count < 10)
+            {
+                examples.Add(example);
+            }
+        }
+
+        /// <summary>
+        /// Outcome of one run.
+        /// </summary>
+        private sealed record class FidelityReport
+        {
+            public string Label { get; init; }
+            public int Nodes { get; init; }
+            public long Samples { get; init; }
+
+            /// <summary> Samples checked against the server's record </summary>
+            public long Compared { get; init; }
+
+            /// <summary> Samples whose timestamp the server never stamped </summary>
+            public long TimestampMismatches { get; init; }
+            public double WorstMismatchMs { get; init; }
+
+            /// <summary> Adjacent sample pairs, whose distance is comparable </summary>
+            public long Pairs { get; init; }
+
+            /// <summary> Pairs the injected schedule displaces </summary>
+            public long SlippedPairs { get; init; }
+
+            /// <summary> Pairs outside the customer's 2 % band </summary>
+            public long PairsOutsideBand { get; init; }
+
+            /// <summary> Pairs not spaced as the server's schedule predicts </summary>
+            public long UnexplainedPairs { get; init; }
+
+            // The report is rendered, never indexed, so the abstraction costs
+            // nothing here and keeps the collection immutable to callers.
+#pragma warning disable CA1859
+            public IReadOnlyList<string> Examples { get; init; } = [];
+#pragma warning restore CA1859
+
+            public override string ToString()
+            {
+                var pct = Pairs == 0 ? 0 : PairsOutsideBand * 100.0 / Pairs;
+                var text =
+$@"--- {Label} ---
+  nodes / samples        : {Nodes} / {Samples}
+  compared to server     : {Compared}
+  timestamp mismatches   : {TimestampMismatches} (worst {WorstMismatchMs:F3} ms)
+  adjacent pairs         : {Pairs}
+  displaced by the source: {SlippedPairs}
+  outside 2 % band       : {PairsOutsideBand} ({pct:F2} %)   <-- customer's metric
+  unexplained            : {UnexplainedPairs}";
+                return Examples.Count == 0 ? text : text + Environment.NewLine +
+                    string.Join(Environment.NewLine, Examples.Select(e => "    ! " + e));
+            }
+        }
+
+        /// <summary>
+        /// Write a published nodes configuration for the counter nodes.
+        /// </summary>
+        /// <param name="nodeCount"></param>
+        /// <param name="interval"></param>
+        /// <param name="heartbeatSeconds"></param>
+        private static string WriteConfiguration(int nodeCount, TimeSpan interval,
+            int heartbeatSeconds)
+        {
+            var path = Path.Combine(Path.GetTempPath(),
+                Path.GetRandomFileName() + ".pn.json");
+            using var stream = File.Create(path);
+            using var writer = new Utf8JsonWriter(stream,
+                new JsonWriterOptions { Indented = true });
+            writer.WriteStartArray();
+            writer.WriteStartObject();
+            writer.WriteString("EndpointUrl", "{{EndpointUrl}}");
+            writer.WriteBoolean("UseSecurity", false);
+            writer.WriteString("DataSetWriterGroup", "{{DataSetWriterGroup}}");
+            writer.WriteStartArray("OpcNodes");
+            for (var index = 0; index < nodeCount; index++)
+            {
+                writer.WriteStartObject();
+                writer.WriteString("Id", CounterServer.GetNodeId(index));
+                writer.WriteString("DataSetFieldId",
+                    global::Counter.CounterNodeManager.GetBrowseName(index));
+                writer.WriteNumber("OpcPublishingInterval",
+                    (int)interval.TotalMilliseconds);
+                writer.WriteNumber("OpcSamplingInterval",
+                    (int)interval.TotalMilliseconds);
+                writer.WriteNumber("QueueSize", 10);
+                if (heartbeatSeconds > 0)
+                {
+                    writer.WriteNumber("HeartbeatInterval", heartbeatSeconds);
+                }
+                writer.WriteEndObject();
+            }
+            writer.WriteEndArray();
+            writer.WriteEndObject();
+            writer.WriteEndArray();
+            writer.Flush();
+            return path;
+        }
+
+        private static void SkipUnlessEnabled()
+        {
+            Skip.IfNot(Environment.GetEnvironmentVariable(kVariable) == "1",
+                $"Set {kVariable}=1 to run the source timestamp fidelity test.");
+        }
+
+        /// <summary>
+        /// How long telemetry is analysed after the warm up. Honours the same
+        /// variable as the other long running tests so the pull request smoke
+        /// job can run this at a smaller size.
+        /// </summary>
+        private static TimeSpan Duration
+            => TimeSpan.FromMinutes(
+                int.TryParse(Environment.GetEnvironmentVariable(kDurationVariable),
+                    CultureInfo.InvariantCulture, out var minutes) && minutes > 0
+                        ? minutes : 2);
+
+        private const string kVariable = "IIOT_TELEMETRY_SOAK";
+        private const string kDurationVariable = "IIOT_TELEMETRY_SOAK_MINUTES";
+
+        /// <summary>
+        /// Tolerance for comparing two timestamps that should be identical.
+        /// Only covers the serialization round trip, not scheduling.
+        /// </summary>
+        private const double kTimestampTolerance = 1.0;
+
+        private const int kNodeCount = 50;
+        private const int kSlipPeriod = 7;
+
+        /// <summary>
+        /// Rate at which the source counts up in the negative control, well
+        /// above the heartbeat interval so heartbeats must fire.
+        /// </summary>
+        private const int kSlowUpdateSeconds = 10;
+
+        /// <summary>
+        /// The displacement reported from the field, one sixth of the two
+        /// second scan interval.
+        /// </summary>
+        private static readonly TimeSpan kSlotSlip = TimeSpan.FromMilliseconds(333);
+        private static readonly TimeSpan kInterval = TimeSpan.FromSeconds(2);
+        private readonly ITestOutputHelper _output;
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterNodeManager.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterNodeManager.cs
@@ -51,6 +51,21 @@ namespace Counter
         public CounterServerOptions Options { get; }
 
         /// <summary>
+        /// The source timestamp the server actually stamped on the given
+        /// counter value, which is the ground truth a consumer's telemetry
+        /// must reproduce exactly.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="timestamp"></param>
+        public bool TryGetEmitted(long value, out DateTime timestamp)
+        {
+            lock (Lock)
+            {
+                return _emitted.TryGetValue(value, out timestamp);
+            }
+        }
+
+        /// <summary>
         /// Create node manager
         /// </summary>
         /// <param name="server"></param>
@@ -208,6 +223,10 @@ namespace Counter
                     var timestamp = Options.UseScheduledTimestamps
                         ? Epoch.AddTicks(value * Options.UpdateInterval.Ticks)
                         : DateTime.UtcNow;
+                    if (Options.IsSlipped(value))
+                    {
+                        timestamp = timestamp.Add(Options.SlotSlip);
+                    }
                     lock (Lock)
                     {
                         var variables = _variables;
@@ -215,6 +234,13 @@ namespace Counter
                         {
                             continue;
                         }
+                        //
+                        // Record what was actually stamped so a test can
+                        // compare the telemetry it receives against the
+                        // ground truth rather than against a recomputation
+                        // of the same rule.
+                        //
+                        _emitted[value] = timestamp;
                         foreach (var variable in variables)
                         {
                             variable.Value = (ulong)value;
@@ -229,6 +255,7 @@ namespace Counter
 
         private const string kRootName = "Counters";
         private readonly CancellationTokenSource _cts = new();
+        private readonly Dictionary<long, DateTime> _emitted = [];
         private BaseDataVariableState[] _variables;
         private Task _updates;
         private long _counter;

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServerOptions.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/src/Counter/CounterServerOptions.cs
@@ -39,5 +39,48 @@ namespace Counter
         /// </para>
         /// </summary>
         public bool UseScheduledTimestamps { get; init; } = true;
+
+        /// <summary>
+        /// <para>
+        /// When set to a non zero interval the server occasionally stamps a
+        /// value one <em>slot</em> later than the schedule says, and then
+        /// returns to the schedule.
+        /// </para>
+        /// <para>
+        /// This reproduces the signature of a data source whose scan
+        /// scheduler slips: the value sequence stays complete and correctly
+        /// spaced, but individual source timestamps are displaced by a
+        /// quantized amount. A consumer measuring the distance between
+        /// consecutive source timestamps sees one distance that is too long
+        /// followed by one that is too short, and the two sum to exactly two
+        /// update intervals.
+        /// </para>
+        /// </summary>
+        public TimeSpan SlotSlip { get; init; }
+
+        /// <summary>
+        /// How often a slipped run begins, counted in increments. Together
+        /// with <see cref="SlotSlipDwell"/> this makes the schedule fully
+        /// deterministic, so a test can predict exactly which values carry a
+        /// displaced timestamp.
+        /// </summary>
+        public int SlotSlipPeriod { get; init; } = 17;
+
+        /// <summary>
+        /// How many consecutive increments stay displaced once a slipped run
+        /// begins. One produces the isolated single sample excursion that
+        /// dominates the reported field data.
+        /// </summary>
+        public int SlotSlipDwell { get; init; } = 1;
+
+        /// <summary>
+        /// Whether the given counter value is stamped one slot late.
+        /// </summary>
+        /// <param name="value"></param>
+        public bool IsSlipped(long value)
+        {
+            return SlotSlip != TimeSpan.Zero && SlotSlipPeriod > 0 &&
+                value % SlotSlipPeriod < SlotSlipDwell;
+        }
     }
 }


### PR DESCRIPTION
A customer analysing a three thousand tag, two second stream reported that no
value was ever lost, duplicated or reordered - the counter increment between
consecutive samples was always exactly right - yet 41,817 of 5.4 million source
timestamp distances, about 0.8 %, fell outside a 2 % band around two seconds.

The displacements were quantized at roughly **333 ms**, one sixth of the scan
interval, and came in self correcting pairs: one distance too long by 333 ms
immediately followed by one too short by the same amount, summing back to
4000 ms to within a millisecond. The undisplaced timestamps held their
sub-second phase to about a millisecond across twenty minutes.

That is the signature of a data source whose scan scheduler slips a slot, not
of a pipeline that damages timestamps. No jitter introduced downstream of the
server - network, thread scheduling, batching, transport - is quantized to a
single step size or stable to a millisecond over minutes, and a pipeline that
displaced a timestamp would not restore the original phase afterwards.

The problem was that nothing in the suite could *demonstrate* that. The counter
server stamps from a strictly monotonic schedule, so it is incapable of
exhibiting the defect, and the argument rested on reading the code.

## What this adds

`CounterServerOptions.SlotSlip` injects exactly the reported signature: the
server occasionally stamps a value one slot late and then returns to schedule.
The value sequence stays complete and correctly spaced, so only the timestamps
move. The schedule is deterministic, and the server records what it actually
stamped, so the test compares telemetry against ground truth rather than
against a recomputation of the same rule.

`SourceTimestampFidelityTests` then runs three arms.

| Area | Compared | Timestamp mismatches | Injected | Outside 2 % band |
| --- | --- | --- | --- | --- |
| Slipping source | 3050 | **0** (worst 0.000 ms) | 900 | **900** |
| Regular source (control) | 3000 | **0** (worst 0.000 ms) | 0 | **0** |
| Synthesized timestamps (negative control) | 2807 | **2207** (worst 10012 ms) | 0 | 550 |

The first arm is the point: every source timestamp delivered is byte for byte
the one the server stamped, and the injected defect reproduces downstream
*exactly* - 900 injected, 900 observed. The publisher neither repairs the
defect nor adds to it. Both directions are asserted, because a publisher that
dropped every displaced sample would also report zero mismatches.

Every distance is additionally checked against what the server's own schedule
predicts, so the test would catch a displacement that happened to stay inside
the customer's band.

## Why the negative control matters

The two clean arms are only worth anything if the comparison can see a
difference at all. The third arm drives the one code path in the product that
genuinely does synthesize a source timestamp - the legacy
`WatchdogLKVWithUpdatedTimestamps` heartbeat - and asserts that the comparison
catches it. It reports 2207 mismatches with a worst deviation of ten seconds,
so the zeros above are a real result and not a blind detector.

## Also

- `soak.yml` gains the scenario. The pull request smoke job filters on
  `Category=LongRunning` and picks it up automatically; the analysis window
  honours `IIOT_TELEMETRY_SOAK_MINUTES` so it stays short there.
- `troubleshooting.md` gains a *Quantized timestamp displacement with no
  heartbeats* section: how to recognise the signature, why quantization and
  phase stability are the discriminating evidence, the residual plot that makes
  it visible, and the two checks that localize it (compare `SourceTimestamp`
  against `ServerTimestamp`, and check whether all nodes step at the same
  instant).

No product code changes.

Full suite of nine long running arms passes locally.
