### PR TITLE
Ignore foreign telemetry when reading network messages in e2e tests

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -92,7 +92,33 @@ jobs:
           dotnet-version: |
             8.0.x
             10.0.x
+      # ----------------------------------------------------------------------
+      # azure/login intermittently fails its Azure PowerShell leg with "the
+      # provided account does not have access to subscription <id>" even
+      # though the Azure CLI leg succeeded seconds earlier using the very same
+      # federated token and the very same subscription. Observed in run
+      # 31586188505, where the CLI logged "Azure CLI login succeeds by using
+      # OIDC" and the PowerShell login then failed against the subscription it
+      # had just selected.
+      #
+      # The test job that follows runs for tens of minutes and up to four
+      # hours, and it has already paid for a full infrastructure deployment
+      # that is torn down with the run, so a transient login must not be
+      # allowed to discard it. Attempt the login twice before giving up. The
+      # second attempt is not tolerant, so a genuine credential or permission
+      # problem still fails the job.
+      # ----------------------------------------------------------------------
       - uses: azure/login@v2
+        id: azure_login
+        continue-on-error: true
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          enable-AzPSSession: true
+      - name: Azure login (retry after transient failure)
+        if: steps.azure_login.outcome == 'failure'
+        uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
@@ -946,30 +946,56 @@ namespace OpcPublisherAEE2ETests
                     json = partitionEvent.DeserializeJson<JToken>();
                 }
 
-                if (context?.OutputHelper != null)
+                List<JToken> batchedMessages;
+                if (json is JArray array)
+                {
+                    batchedMessages = array.Cast<JToken>().ToList();
+                }
+                else
+                {
+                    batchedMessages = new List<JToken> { json };
+                }
+
+                //
+                // Only trace what this reader is actually looking at. The
+                // shared hub carries a high volume of foreign telemetry and
+                // dumping all of it would bury the messages under test.
+                //
+                if (context?.OutputHelper != null && batchedMessages
+                    .Any(t => t is JObject o && (string)o["MessageType"] == "ua-data"))
                 {
                     context.OutputHelper.WriteLine(json.ToString(Formatting.Indented));
                 }
 
-                List<dynamic> batchedMessages;
-                if (json is JArray array)
-                {
-                    batchedMessages = array.Cast<dynamic>().ToList();
-                }
-                else
-                {
-                    batchedMessages = new List<dynamic> { json };
-                }
-
                 // Expect all messages to be the same
                 var messageIds = new HashSet<string>();
-                foreach (var message in batchedMessages)
+                var networkMessages = 0;
+                foreach (var token in batchedMessages)
                 {
+                    //
+                    // The IoT Hub is shared. Other publisher modules deployed
+                    // by tests running in parallel, and any leaf traffic
+                    // picked up by the leafToUpstream route, land in the same
+                    // partitions, and every consumer group sees all of it
+                    // regardless of which group it reads from. Only network
+                    // messages can be addressed to the writer under test, so
+                    // anything else is skipped rather than asserted on - a
+                    // samples mode message carries no MessageId at all and
+                    // would otherwise fail the run with a binder exception on
+                    // the dynamic member access below.
+                    //
+                    if (token is not JObject obj ||
+                        (string)obj["MessageType"] != "ua-data")
+                    {
+                        continue;
+                    }
+                    networkMessages++;
+                    dynamic message = obj;
+
                     Assert.NotNull(message.MessageId.Value);
                     Assert.True(messageIds.Add(message.MessageId.Value));
                     var writerGroupId = (string)message.DataSetWriterGroup.Value;
                     Assert.NotNull(writerGroupId);
-                    Assert.Equal("ua-data", message.MessageType.Value);
                     var innerMessages = (JArray)message.Messages;
                     Assert.True(innerMessages.Any(), "Json doesn't contain any messages");
 
@@ -988,7 +1014,13 @@ namespace OpcPublisherAEE2ETests
                     }
                 }
 
-                if (batchedMessages.Count > 0 && --numberOfBatchesToRead == 0)
+                //
+                // Only a batch that actually carried network messages counts
+                // against the budget. Otherwise a burst of foreign traffic
+                // would exhaust it and the caller would be handed far fewer
+                // messages than it asked for.
+                //
+                if (networkMessages > 0 && --numberOfBatchesToRead == 0)
                 {
                     break;
                 }


### PR DESCRIPTION
Run [31575074553](https://github.com/Azure/Industrial-IoT/actions/runs/31575074553)
failed the A&E job with 15 of 41 tests failing. Every one of them died the same
way:

```
Microsoft.CSharp.RuntimeBinder.RuntimeBinderException :
    Cannot perform runtime binding on a null reference
   at OpcPublisherAEE2ETests.TestHelper.ReadMessagesFromWriterIdAsync(...)
      TestHelper.cs:line 968
```

Line 968 is `Assert.NotNull(message.MessageId.Value)`.

## Cause

`ReadMessagesFromWriterIdAsync` assumed that every event in the IoT Hub is a
`ua-data` network message produced by the publisher under test. It asserted on
`MessageId`, `DataSetWriterGroup` and `MessageType` *before* filtering to the
requested `dataSetWriterId`.

That assumption stopped holding when the two telemetry quality soak jobs were
added. They deploy their own publisher modules - `publisher_soak_fast` and
`publisher_soak_slow` - to the same IoT Edge gateway, they are wired to run in
parallel with `run_tests_ae`, and `SoakTestBase` publishes in **Samples** mode
while the A&E tests use **PubSub**.

A samples message has no `MessageId`. `message.MessageId` therefore binds to
null and `.Value` throws on the dynamic member access, before the writer id
filter that would have discarded the message is ever reached.

Dedicated consumer groups do not prevent this. A consumer group is an
independent cursor over the *same* event stream, so every group sees every
event in the hub. Isolating the module identity, the writer group and the
consumer group - which the soak jobs already do - does not isolate the
*content* of the partitions.

The history matches: the last green run on `main` was 2026-07-16, before the
soak jobs existed, and the workflow has failed on every run since they were
introduced.

## Fix

Skip anything that is not a `ua-data` network message. This is not a
workaround: the contract of this reader is to return the messages belonging to
one `dataSetWriterId`, and a message that is not a network message cannot
belong to any writer. It also covers leaf traffic arriving through the
`leafToUpstream` route, which was always a possibility independent of the soak
jobs.

All other assertions are kept for messages that *are* network messages, so
regression coverage of the message shape is unchanged. The
`Assert.Equal("ua-data", ...)` is now the discriminator rather than an
assertion.

Two further defects were fixed while here.

- A batch consisting only of foreign messages still decremented
  `numberOfBatchesToRead`, because the old guard was `batchedMessages.Count > 0`.
  Under load from a parallel soak that would silently hand callers far fewer
  messages than they asked for. Only batches that carried at least one network
  message now count against the budget.
- Every message was written to the test output. With a soak publishing 100
  nodes at 2 s in parallel, that would bury the messages under test. The trace
  is now emitted only for batches the reader actually processes.

## Verification

The infrastructure is not reachable locally, so the root cause and the fix were
verified directly against the Json.NET semantics they depend on, using a
samples message and a network message of the shapes the two publishers emit:

```
== 1. old code on a samples message ==
   Microsoft.CSharp.RuntimeBinder.RuntimeBinderException
   Cannot perform runtime binding on a null reference
== 2. new discriminator ==
   samples  -> skipped
   network  -> processed
== 3. mixed batch, new logic ==
   networkMessages=1 (budget consumed: True)
   yielded=[ae-writer/ae-group]
== 4. batch of only foreign messages ==
   networkMessages=0 -> budget consumed: False (old logic would consume it)
```

Case 1 reproduces the CI exception character for character, which confirms the
diagnosis rather than merely making it plausible.

The project builds clean; the remaining warnings in the file are pre-existing.

A dispatch of the workflow is needed to confirm end to end, since the A&E job
only runs on `workflow_dispatch`.

## Validated end to end

Dispatched as run
[31586188505](https://github.com/Azure/Industrial-IoT/actions/runs/31586188505)
on this branch with the default soak settings, so both soak publishers were
running and publishing samples telemetry into the shared hub for the whole time
the A&E job was reading - the exact condition that produced the failure.

| Job | Before | After |
| --- | --- | --- |
| A&E tests | 26 passed, **15 failed** | **41 passed, 0 failed** |
| Telemetry quality soak (counters) | pass | pass |
| Telemetry quality soak (heartbeat) | pass | pass |

No `RuntimeBinderException` anywhere in the job log.

## Second commit: retry the Azure login

The basic test job of that same validation run failed, but not in a test and
not for this reason. It failed in `azure/login`, before any test executed:

```
Azure CLI login succeeds by using OIDC.
Running Azure PowerShell Login.
Error: 'The provided account *** does not have access to subscription ID
"3fbebda5-..."'
```

The CLI leg of the very same action, using the very same federated token and
the very same subscription, had succeeded seconds earlier, and the other three
jobs in the run logged in to that subscription without trouble. This is a
transient failure in the Azure PowerShell leg.

It is worth hardening regardless of this pull request: these jobs run for tens
of minutes and up to four hours against infrastructure that is deployed and
torn down with the run, so a transient login should not discard all of it. The
login is now attempted twice. The second attempt does not tolerate failure, so
a genuine credential or permission problem still fails the job.