### PR TITLE
Fix per-node duplicate suppression and cover publishing below the data rate

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -76,6 +76,8 @@ jobs:
             test: SlowSourceUpdatedTimestampHeartbeatsShiftTimestampsAsync
           - name: SourceTimestampFidelity
             test: SourceTimestampFidelityTests
+          - name: PublishingFasterThanSource
+            test: PublishingFasterThanTheSourceDoesNotTriggerHeartbeatsAsync
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/opc-publisher/troubleshooting.md
+++ b/docs/opc-publisher/troubleshooting.md
@@ -18,6 +18,7 @@ In this document you find information about
     - [IoT Hub Metrics](#iot-hub-metrics)
       - [Use Azure IoT Explorer](#use-azure-iot-explorer)
   - [Duplicated, stale or unevenly spaced values](#duplicated-stale-or-unevenly-spaced-values)
+    - [Sizing the heartbeat interval](#sizing-the-heartbeat-interval)
     - [Jittered timestamps without duplicates](#jittered-timestamps-without-duplicates)
     - [Quantized timestamp displacement with no heartbeats](#quantized-timestamp-displacement-with-no-heartbeats)
 - [Restart the module](#restart-the-module)
@@ -180,6 +181,26 @@ To rule out that values were actually dropped or that the server queue overflowe
 | `serverQueueOverflows` | The OPC UA server dropped queued values. Increase `QueueSize` or the publishing interval. |
 
 If all of these are zero, no value was lost inside OPC Publisher.
+
+#### Sizing the heartbeat interval
+
+A heartbeat exists to answer "has this node stopped reporting", so it must be configured well *above* the rate at which the node normally changes. Setting the heartbeat interval equal to the sampling interval - a common mistake, because both numbers describe the same node - makes the heartbeat race the data instead of watching it, and every value that is merely late then produces a duplicate.
+
+The watchdog reports once a node has been silent for
+
+```text
+HeartbeatInterval + min(PublishingInterval, HeartbeatInterval)
+```
+
+so the publishing interval sets how much lateness is tolerated. Note the direction: a *smaller* publishing interval gives a *smaller* grace period. With a two second heartbeat and a two second publishing interval a value may be up to two seconds late; halve the publishing interval to one second and one second of lateness is enough to emit a duplicate. Publishing faster than the source changes therefore costs tolerance without gaining anything.
+
+Rules of thumb:
+
+- Set `HeartbeatInterval` to several times the rate at which the value actually changes, not to the sampling interval. If the value must be reported at least once a minute, configure sixty seconds - not two.
+- Do not configure the publishing interval below the rate at which the server produces values. Extra publish cycles carry no data and shrink the grace period.
+- If duplicates appear only under load, the values are arriving late rather than not at all. Raising the heartbeat interval is the correct response; it is what distinguishes "late" from "stopped".
+
+Duplicates caused this way are recognisable: they are *exact* duplicates, repeating the value, the `SourceTimestamp` and the `ServerTimestamp` of the message before them, and they appear at the same instant across many nodes at once, because a late publish response delays every node in the subscription together. Random redelivery by the transport, by contrast, affects individual messages independently.
 
 #### Jittered timestamps without duplicates
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
@@ -118,6 +118,49 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         }
 
         /// <summary>
+        /// <para>
+        /// The field configuration behind the duplicate reports: a publishing
+        /// interval <em>below</em> the rate at which the source changes.
+        /// </para>
+        /// <para>
+        /// This matters because the watchdog grace period is
+        /// <c>min(publishingInterval, heartbeatInterval)</c>. Every other arm
+        /// in this suite publishes at the data rate, which yields a two
+        /// second grace on a two second heartbeat. Halving the publishing
+        /// interval halves the grace to one second, so a value only has to be
+        /// one second late for the watchdog to win - the tightest deadline
+        /// the product will produce for this heartbeat interval, and until
+        /// now untested.
+        /// </para>
+        /// <para>
+        /// A heartbeat here is not harmless: the default <c>WatchdogLKV</c>
+        /// behaviour resends the last value with its original timestamps, so
+        /// a consumer that cannot read the heartbeat indicator sees an exact
+        /// duplicate - same value, same source timestamp, same server
+        /// timestamp - and counts it as a data quality defect.
+        /// </para>
+        /// </summary>
+        [SkippableFact]
+        public async Task PublishingFasterThanTheSourceDoesNotTriggerHeartbeatsAsync()
+        {
+            SkipUnlessEnabled();
+            var report = await RunScenarioAsync(
+                nameof(PublishingFasterThanTheSourceDoesNotTriggerHeartbeatsAsync),
+                MessagingMode.FullSamples, NodeCount, kInterval,
+                publishingInterval: TimeSpan.FromMilliseconds(kInterval.TotalMilliseconds / 2),
+                samplingInterval: kInterval, queueSize: kQueueSize,
+                heartbeatSeconds: (int)kInterval.TotalSeconds,
+                duration: RunDuration).ConfigureAwait(false);
+
+            AssertClean(report);
+
+            // A duplicate is what the consumer actually complains about.
+            Assert.True(report.RepeatedValues == 0,
+                $"{report.RepeatedValues} value(s) were delivered twice although the " +
+                $"source produced a new value on every cycle.\n{report}");
+        }
+
+        /// <summary>
         /// The customer scenario at the reported scale of three thousand
         /// nodes. Opt in because it needs a machine that can host the server
         /// and the publisher side by side.

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
@@ -350,21 +350,40 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         }
 
         /// <summary>
+        /// <para>
         /// Whether the sample was already seen. Delivery is at least once, so
         /// a redelivered message must not be reported as a repeated value.
+        /// </para>
+        /// <para>
+        /// The key must include the node. A writer sequence number identifies
+        /// a notification within its writer, not within the whole stream, so
+        /// keying on the number alone makes the samples of different nodes
+        /// collide - with thousands of nodes that silently discards most of
+        /// the stream instead of just the redeliveries.
+        /// </para>
+        /// <para>
+        /// Heartbeats are never suppressed. A heartbeat resends the last
+        /// known value <em>including its sequence number</em>, so it collides
+        /// with the value it repeats by construction, and suppressing it
+        /// would hide the very thing these tests measure. The cost is that a
+        /// genuinely redelivered heartbeat is counted twice, which errs
+        /// towards over reporting rather than towards hiding a defect.
+        /// </para>
         /// </summary>
         /// <param name="sample"></param>
         private bool IsDuplicate(TelemetrySample sample)
         {
-            if (!_options.SuppressDuplicates || sample.SequenceNumber == null)
+            if (!_options.SuppressDuplicates || sample.SequenceNumber == null ||
+                sample.IsHeartbeat)
             {
                 return false;
             }
-            if (!_seenSequenceNumbers.Add(sample.SequenceNumber.Value))
+            var key = (sample.NodeId, sample.SequenceNumber.Value);
+            if (!_seenSequenceNumbers.Add(key))
             {
                 return true;
             }
-            _seenSequenceNumberOrder.Enqueue(sample.SequenceNumber.Value);
+            _seenSequenceNumberOrder.Enqueue(key);
             while (_seenSequenceNumberOrder.Count > _options.DuplicateWindow)
             {
                 _seenSequenceNumbers.Remove(_seenSequenceNumberOrder.Dequeue());
@@ -522,8 +541,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         private readonly TelemetryQualityOptions _options;
         private readonly Dictionary<string, NodeState> _nodes = [];
         private readonly List<string> _examples = [];
-        private readonly HashSet<uint> _seenSequenceNumbers = [];
-        private readonly Queue<uint> _seenSequenceNumberOrder = new();
+        private readonly HashSet<(string, uint)> _seenSequenceNumbers = [];
+        private readonly Queue<(string, uint)> _seenSequenceNumberOrder = new();
         private readonly TimeSpan _tolerance;
         private readonly TimeSpan _heartbeatTolerance;
         private readonly TimeSpan? _earliestHeartbeat;


### PR DESCRIPTION
A customer reported duplicate values on a 3000 tag, two second stream and
supplied a support bundle plus an export of the offending rows. The duplicates
turned out to be heartbeats rather than lost, repeated or reordered data.
Investigating that exposed two gaps in this repository.

## What the field data showed

Of 9,669 flagged rows, 9,541 (98.7 %) were *exact* duplicates - identical
value, identical `SourceTimestamp` **and** identical `ServerTimestamp`, so
`diff_ms = 0` and `diffValue = 0`. Four independent lines of evidence identify
them as heartbeats rather than transport redelivery:

- the support bundle reports `# Heartbeat/ing: 3000/3000`, so every node had an
  active heartbeat timer;
- the default `WatchdogLKV` behaviour resends the last `DataValue` untouched,
  which is an exact duplicate by construction;
- the 9,541 duplicates occur in only **94 distinct 100 ms instants**, with up
  to **264 of 264 tags at the same instant** - a late publish response delays
  every node in the subscription together, whereas redelivery affects
  individual messages independently;
- **100.0 %** of the per-tag gaps between duplicates are even multiples of the
  two second data cadence, and the minimum gap is 3.99 s, never ~2 s, so a
  heartbeat never repeated and the data always resumed.

The remaining 128 rows were 40 to 46 ms away from 2000 ms against a +/-40 ms
band - grazing the threshold, not malfunctioning.

## The publisher is not misfiring

The field configuration publishes at 1000 ms while the source changes every
2000 ms. That is worth stating explicitly because the watchdog deadline is

```text
HeartbeatInterval + min(PublishingInterval, HeartbeatInterval)
```

so halving the publishing interval *halves* the grace period rather than
enlarging it. At 2 s heartbeat and 1000 ms publishing a value only has to be
one second late for the watchdog to win.

Reproduced at exactly that configuration - 3000 nodes, 1000 ms publishing,
2000 ms data, 2 s heartbeat - against a well behaved server:

```
450,000 values, 0 heartbeats, 0 missing, 0 out of order, 0 duplicates
hb too early: 0
```

So the watchdog does not misfire at the tightest deadline the product will
produce for this heartbeat interval. The duplicates in the field come from the
server not delivering inside the deadline.

## Fix 1: duplicate suppression collided across nodes

`TelemetryQualityValidator.IsDuplicate` keyed on the writer sequence number
alone. A sequence number identifies a notification within its writer, not
within the whole stream, so with thousands of nodes the samples of different
nodes collide.

Measured at 3000 nodes before the fix:

```
Samples : 150000   Nodes : 1000 seen, 2000 never reported   redelivered : 300000
```

Two thirds of the stream was silently discarded and 2000 nodes were reported as
having never sent a value. After the fix, the same run:

```
Samples : 450000   Nodes : 3000 seen, 0 never reported      redelivered : 0
```

`CustomerScenarioAtFullScaleAsync` runs at 3000 nodes and was affected by this.

A heartbeat additionally resends the sequence number of the value it repeats,
so the suppression also hid heartbeats - the very thing these tests measure.
Heartbeats are now never suppressed. The cost is that a genuinely redelivered
heartbeat would be counted twice, which errs towards over reporting rather than
towards hiding a defect.

## Fix 2: publishing below the data rate was untested

Every existing arm publishes *at* the data rate, which yields the largest grace
period the watchdog will ever apply. Adds
`PublishingFasterThanTheSourceDoesNotTriggerHeartbeatsAsync`, which publishes at
half the data rate to exercise the smallest one, and asserts that no value is
delivered twice.

## Documentation

Adds a *Sizing the heartbeat interval* section covering the deadline formula,
the counter-intuitive direction of the publishing interval, and how to
recognise heartbeat duplicates - exact repeats of value and both timestamps,
appearing across many nodes at the same instant.

## Validation

No product code changes. All ten long running arms pass locally.
