### PR TITLE
Merge main forward into preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,10 +213,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -307,7 +307,7 @@ jobs:
         shell: bash
       - name: Upload AOT warning inventory
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aot-warning-inventory
           path: artifacts/aot-inventory
@@ -336,10 +336,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -393,7 +393,7 @@ jobs:
         shell: bash
       - name: Upload arm64 AOT logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aot-arm64-logs
           path: artifacts/aot-arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,10 @@ jobs:
       nuget_version: ${{ steps.nbgv.outputs.nuget_version }}
       prerelease: ${{ steps.nbgv.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -127,10 +127,10 @@ jobs:
           - name: Publisher.Module
             path: src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -173,7 +173,7 @@ jobs:
             --collect:"XPlat Code Coverage;Format=cobertura"
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testresults-${{ matrix.os }}-${{ matrix.project.name }}
           path: ./testresults
@@ -206,10 +206,10 @@ jobs:
     env:
       PROJECT: src/Azure.IIoT.OpcUa.Publisher.Module/tests/Azure.IIoT.OpcUa.Publisher.Module.Tests.csproj
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -235,7 +235,7 @@ jobs:
             --results-directory ./testresults/soak-smoke
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testresults-soak-smoke
           path: ./testresults
@@ -255,12 +255,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.0.x
       - name: Download all test results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ./all-testresults
           pattern: testresults-*
@@ -292,7 +292,7 @@ jobs:
         shell: bash
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: ./coverage
@@ -319,10 +319,10 @@ jobs:
       matrix:
         arch: [x64, arm, arm64]
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.0.x
       - name: Build container tarballs
@@ -345,7 +345,7 @@ jobs:
           Get-ChildItem -Recurse -Filter '*.tar.gz' -Path $env:TARBALL_OUT |
             ForEach-Object { Write-Host "  $($_.FullName) ($([math]::Round($_.Length / 1MB, 2)) MB)" }
       - name: Upload tarballs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # IMPORTANT: per-arch artifact name (not merged) because
           # build.ps1 strips the runtime ID from tar filenames, so tarballs
@@ -376,9 +376,9 @@ jobs:
     outputs:
       images: ${{ steps.dockerize.outputs.images }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download all image tarballs
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           # NOTE: do NOT set merge-multiple here -- artifacts must land in
           # arch-specific subdirectories so dockerize.ps1 can find both
@@ -400,15 +400,15 @@ jobs:
             -TarFileInput "${{ runner.temp }}/tarballs" `
             -OutputFolder "${{ runner.temp }}/build-ctx" `
             -MatrixName images
-      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Login to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
       - name: Build, push, and sign multi-arch images
         env:
           IMAGES_JSON: ${{ steps.dockerize.outputs.images }}
@@ -495,10 +495,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -556,7 +556,7 @@ jobs:
             echo "::warning::Expected ${#expected[@]} .nupkg file(s) but found ${actual}. The IsPackable set may have drifted."
           fi
       - name: Upload nupkgs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nupkgs
           path: ./nupkgs
@@ -580,10 +580,10 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: 10.0.x
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nupkgs
           path: ./nupkgs

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,25 +27,25 @@ jobs:
           build-mode: autobuild
     steps:
     - name: Setup .NET
-      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
       with:
         dotnet-version: |
           8.0.x
           10.0.x
     - name: Checkout repository
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Cleanup Nuget.Config
       run: |
         find . -name "Nuget.Config" -type f -delete
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+      uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
       # queries: security-extended,security-and-quality
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/e2e-gc.yml
+++ b/.github/workflows/e2e-gc.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: e2e
     steps:
-      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -81,13 +81,13 @@ jobs:
       ResourceGroupName: ${{ inputs.resource_group_name }}
       KeyVaultName: ${{ inputs.key_vault_name }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Full history is required so Nerdbank.GitVersioning can compute the
           # version height when the E2E test solution builds; a shallow clone
           # fails with "Shallow clone lacks the objects required...".
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -108,7 +108,7 @@ jobs:
       # second attempt is not tolerant, so a genuine credential or permission
       # problem still fails the job.
       # ----------------------------------------------------------------------
-      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         id: azure_login
         continue-on-error: true
         with:
@@ -118,7 +118,7 @@ jobs:
           enable-AzPSSession: true
       - name: Azure login (retry after transient failure)
         if: steps.azure_login.outcome == 'failure'
-        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -220,7 +220,7 @@ jobs:
             --results-directory e2e-tests/results
       - name: Upload TRX results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-results-${{ inputs.result_label }}
           path: e2e-tests/results

--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -228,9 +228,9 @@ jobs:
     env:
       ResourceGroupName: ${{ needs.init.outputs.resource_group_name }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Azure login (OIDC, with PowerShell session)
-        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -290,8 +290,8 @@ jobs:
     env:
       ResourceGroupName: ${{ needs.init.outputs.resource_group_name }}
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
-      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -327,7 +327,7 @@ jobs:
         # Vault) fail with AADSTS700024 ("Client assertion is not within its
         # valid time range"). Re-login to obtain a fresh federated token before
         # the Key Vault writes below.
-        uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+        uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -465,7 +465,7 @@ jobs:
     env:
       ResourceGroupName: ${{ needs.init.outputs.resource_group_name }}
     steps:
-      - uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
+      - uses: azure/login@f5d393ae46f8fde4be8b75f32e3fc50e654ad0ca # v3.0.1
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -79,10 +79,10 @@ jobs:
           - name: PublishingFasterThanSource
             test: PublishingFasterThanTheSourceDoesNotTriggerHeartbeatsAsync
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -112,7 +112,7 @@ jobs:
           exit ${PIPESTATUS[0]}
       - name: Upload soak results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: soak-${{ matrix.scenario.name }}
           path: |
@@ -132,10 +132,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
+      - uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           dotnet-version: |
             8.0.x
@@ -163,7 +163,7 @@ jobs:
           exit ${PIPESTATUS[0]}
       - name: Upload soak results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: soak-fullscale
           path: |

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/ConfigurationBindingTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/ConfigurationBindingTests.cs
@@ -238,12 +238,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
             var options = new FileSystemRpcServerOptions();
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.InitFilePathKey] = @"C:\requests\requests.http"
+                [Configuration.FileSystem.InitFilePathKey] = TestPaths.Rooted("requests", "requests.http")
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\requests\requests.http", options.RequestFilePath);
+            Assert.Equal(TestPaths.Rooted("requests", "requests.http"), options.RequestFilePath);
         }
 
         // When options.RequestFilePath is already set, the ??= operator skips the config
@@ -253,16 +253,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
         {
             var options = new FileSystemRpcServerOptions
             {
-                RequestFilePath = @"C:\preset\requests.http"
+                RequestFilePath = TestPaths.Rooted("preset", "requests.http")
             };
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.InitFilePathKey] = @"C:\other\requests.http"
+                [Configuration.FileSystem.InitFilePathKey] = TestPaths.Rooted("other", "requests.http")
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\preset\requests.http", options.RequestFilePath);
+            Assert.Equal(TestPaths.Rooted("preset", "requests.http"), options.RequestFilePath);
         }
 
         // When options.ResponseFilePath is already set, the ??= operator skips both
@@ -272,19 +272,19 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
         {
             var options = new FileSystemRpcServerOptions
             {
-                ResponseFilePath = @"C:\preset\log.txt"
+                ResponseFilePath = TestPaths.Rooted("preset", "log.txt")
             };
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
                 [PublisherConfig.PublishedNodesFileKey] =
-                    @"C:\publisher\publishednodes.json",
-                [Configuration.FileSystem.InitFilePathKey] = @"C:\publisher\requests.http",
-                [Configuration.FileSystem.InitLogFileKey] = @"C:\other\log.txt"
+                    TestPaths.Rooted("publisher", "publishednodes.json"),
+                [Configuration.FileSystem.InitFilePathKey] = TestPaths.Rooted("publisher", "requests.http"),
+                [Configuration.FileSystem.InitLogFileKey] = TestPaths.Rooted("other", "log.txt")
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\preset\log.txt", options.ResponseFilePath);
+            Assert.Equal(TestPaths.Rooted("preset", "log.txt"), options.ResponseFilePath);
         }
 
         // OutputFolder already set → ??= operator skips config lookup.
@@ -293,16 +293,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
         {
             var options = new FileSystemEventClientOptions
             {
-                OutputFolder = @"C:\preset\output"
+                OutputFolder = TestPaths.Rooted("preset", "output")
             };
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.OutputRootKey] = @"C:\other\output"
+                [Configuration.FileSystem.OutputRootKey] = TestPaths.Rooted("other", "output")
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\preset\output", options.OutputFolder);
+            Assert.Equal(TestPaths.Rooted("preset", "output"), options.OutputFolder);
         }
 
         // ─── MqttBroker ──────────────────────────────────────────────────────────
@@ -1117,7 +1117,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
             var options = new FileSystemRpcServerOptions();
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.InitFilePathKey] = @"C:\publisher\requests.http",
+                [Configuration.FileSystem.InitFilePathKey] = TestPaths.Rooted("publisher", "requests.http"),
                 [Configuration.FileSystem.InitLogFileKey] = "mylog.txt"
             }));
 
@@ -1134,12 +1134,12 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
             var options = new FileSystemRpcServerOptions();
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.InitFilePathKey] = @"C:\publisher\requests.http"
+                [Configuration.FileSystem.InitFilePathKey] = TestPaths.Rooted("publisher", "requests.http")
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\publisher\requests.http.log", options.ResponseFilePath);
+            Assert.Equal(TestPaths.Rooted("publisher", "requests.http.log"), options.ResponseFilePath);
         }
 
         // ─── IoTEdge with IOTEDGE_DEVICEID env var ────────────────────────────────

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/ConfigurationTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/ConfigurationTests.cs
@@ -339,23 +339,23 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
                 [PublisherConfig.PublishedNodesFileKey] =
-                    @"C:\publisher\config\publishednodes.json",
+                    TestPaths.Rooted("publisher", "config", "publishednodes.json"),
                 [Configuration.FileSystem.InitFilePathKey] = "requests.http",
                 [Configuration.FileSystem.InitLogFileKey] = "responses.log"
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\publisher\config\requests.http", options.RequestFilePath);
-            Assert.Equal(@"C:\publisher\config\responses.log", options.ResponseFilePath);
+            Assert.Equal(TestPaths.Rooted("publisher", "config", "requests.http"), options.RequestFilePath);
+            Assert.Equal(TestPaths.Rooted("publisher", "config", "responses.log"), options.ResponseFilePath);
 
             var eventOptions = new FileSystemEventClientOptions();
             new Configuration.FileSystem(CreateConfiguration(new()
             {
-                [Configuration.FileSystem.OutputRootKey] = @"C:\publisher\out"
+                [Configuration.FileSystem.OutputRootKey] = TestPaths.Rooted("publisher", "out")
             })).Configure(null, eventOptions);
 
-            Assert.Equal(@"C:\publisher\out", eventOptions.OutputFolder);
+            Assert.Equal(TestPaths.Rooted("publisher", "out"), eventOptions.OutputFolder);
         }
 
         [Fact]
@@ -365,15 +365,15 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
             var configurator = new Configuration.FileSystem(CreateConfiguration(new()
             {
                 [PublisherConfig.PublishedNodesFileKey] =
-                    @"C:\publisher\config\publishednodes.json",
+                    TestPaths.Rooted("publisher", "config", "publishednodes.json"),
                 [Configuration.FileSystem.InitFilePathKey] = " "
             }));
 
             configurator.Configure(null, options);
 
-            Assert.Equal(@"C:\publisher\config\publishednodes.init",
+            Assert.Equal(TestPaths.Rooted("publisher", "config", "publishednodes.init"),
                 options.RequestFilePath);
-            Assert.Equal(@"C:\publisher\config\publishednodes.init.log",
+            Assert.Equal(TestPaths.Rooted("publisher", "config", "publishednodes.init.log"),
                 options.ResponseFilePath);
         }
 

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/TestPaths.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/TestPaths.cs
@@ -1,0 +1,37 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
+{
+    using System;
+    using System.IO;
+
+    /// <summary>
+    /// Builds absolute paths that are actually absolute on the host operating
+    /// system.
+    /// </summary>
+    /// <remarks>
+    /// The configuration tests exercise how the publisher composes and
+    /// preserves paths, not Windows path syntax. Written with a literal
+    /// <c>C:\publisher\...</c> they only pass on Windows: on Linux that string
+    /// is not rooted, so <see cref="Path.IsPathRooted(string)"/> is false and
+    /// the production code takes its relative-path branch instead, producing a
+    /// path under the working directory and failing the assertion. Building the
+    /// fixture from the platform root keeps the test about the behaviour it
+    /// means to cover on every operating system CI runs.
+    /// </remarks>
+    internal static class TestPaths
+    {
+        /// <summary>
+        /// Combine the segments onto the platform's root, yielding
+        /// <c>C:\a\b</c> on Windows and <c>/a/b</c> elsewhere.
+        /// </summary>
+        public static string Rooted(params string[] segments)
+        {
+            return Path.Combine(OperatingSystem.IsWindows() ? @"C:\" : "/",
+                Path.Combine(segments));
+        }
+    }
+}


### PR DESCRIPTION
Merges `main` (`74265ddbd`) forward into `preview`, which was cut at `b1be170d9`.

Main carried one commit: the dependabot GitHub Actions bump (#2526), touching six workflow files. It auto-merged cleanly, and both sides survived:

- main's SHA bumps are applied;
- this branch's `preview` wiring is intact — `preview` remains in the `ci.yml` push/PR triggers and in the `nuget_publish` and `e2e` gates, and in `codeql.yml`;
- the submodule removal is untouched.

The change is workflow-only; no source file differs from `preview`.

### One gap fixed

The bump pinned every action it could see, but `aot_publish` exists only on this line, so its `checkout`, `setup-dotnet` and `upload-artifact` steps kept floating `@v4` tags and sat outside that supply-chain policy. They are now pinned to the same SHAs the merged workflow already uses. Every action in every workflow is SHA-pinned.

### Validation

All six workflows parse; the `Build & Test` job name is unchanged, so the required status-check contexts on `preview` still match.

Opened as a PR rather than pushed directly, because `preview` was just protected to require one.
