### PR TITLE
Stop a rejected command line from killing the test host

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/FailTestNotHostCommandLineLogger.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/FailTestNotHostCommandLineLogger.cs
@@ -1,0 +1,75 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
+{
+    using Azure.IIoT.OpcUa.Publisher.Module.Runtime;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// A <see cref="CommandLineLogger"/> that turns a fatal command line error
+    /// into a failure of the test that caused it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CommandLine"/> ends the process when it cannot parse its
+    /// arguments, which is right for the module and wrong here: the
+    /// integration fixture hosts the publisher inside the test host, so the
+    /// default logger takes the whole run down with it.
+    /// </para>
+    /// <para>
+    /// The failure mode is deliberately nasty. The run aborts with
+    /// "Test host process crashed", the results file records the tests that
+    /// had already finished as passed and records no failure at all, and the
+    /// test named as running at the time is whichever one the host happened to
+    /// be on - which is frequently not the one that passed the bad argument.
+    /// It has now cost two separate investigations: once when
+    /// MqttConfigurationIntegrationTests still passed the removed
+    /// <c>--mm=FullSamples</c>, and again when the Counter soaks did.
+    /// </para>
+    /// <para>
+    /// Throwing instead keeps the diagnosis local: the offending test fails,
+    /// names the option, and the rest of the run continues.
+    /// </para>
+    /// </remarks>
+    internal sealed class FailTestNotHostCommandLineLogger : CommandLineLogger
+    {
+        /// <inheritdoc/>
+        public override void ExitProcess(int exitCode)
+        {
+            if (exitCode == 0)
+            {
+                //
+                // --help and --help-env exit zero after writing their output.
+                // No test passes them, and if one ever does it wants the text,
+                // not a torn down host.
+                //
+                return;
+            }
+            throw new InvalidOperationException(
+                $"The publisher rejected its command line and would have exited " +
+                $"with code {exitCode}, terminating the test host. " +
+                $"Reported: {string.Join("; ", _warnings)}");
+        }
+
+        /// <inheritdoc/>
+        public override void Warning(string messageTemplate)
+        {
+            _warnings.Add(messageTemplate);
+            base.Warning(messageTemplate);
+        }
+
+        /// <inheritdoc/>
+        public override void Warning<T0>(string messageTemplate, T0 propertyValue0)
+        {
+            _warnings.Add(messageTemplate.Replace("{0}",
+                propertyValue0?.ToString() ?? "null", StringComparison.Ordinal));
+            base.Warning(messageTemplate, propertyValue0);
+        }
+
+        private readonly List<string> _warnings = [];
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherModule.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Fixtures/PublisherModule.cs
@@ -195,7 +195,8 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures
                 {
                     { "PkiRootPath", ClientPkiRootPath }
                 })
-                .AddInMemoryCollection(new CommandLine(arguments))
+                .AddInMemoryCollection(new CommandLine(arguments,
+                    new FailTestNotHostCommandLineLogger()))
                 ;
 
             _config = configBuilder.Build();

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/FailTestNotHostCommandLineLoggerTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Runtime/FailTestNotHostCommandLineLoggerTests.cs
@@ -1,0 +1,69 @@
+// ------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All rights reserved.
+//  Licensed under the MIT License (MIT). See License.txt in the repo root for license information.
+// ------------------------------------------------------------
+
+namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Runtime
+{
+    using Azure.IIoT.OpcUa.Publisher.Module.Runtime;
+    using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
+    using System;
+    using Xunit;
+
+    /// <summary>
+    /// Locks the contract that keeps a bad command line from taking the whole
+    /// test run down with it.
+    /// </summary>
+    public sealed class FailTestNotHostCommandLineLoggerTests
+    {
+        [Theory]
+        [InlineData("--mm=FullSamples")]
+        [InlineData("--mm=Samples")]
+        [InlineData("--bs=not-a-number")]
+        public void RejectedOptionThrowsInsteadOfEndingTheProcess(string argument)
+        {
+            // The default logger calls Runtime.Exit here, which inside the
+            // integration fixture kills the test host: the run aborts, the
+            // finished tests are recorded as passed, no failure is recorded,
+            // and the test blamed is whichever one happened to be running.
+            var logger = new FailTestNotHostCommandLineLogger();
+
+            var thrown = Assert.Throws<InvalidOperationException>(
+                () => new CommandLine([argument], logger));
+
+            // The message has to carry the reason, otherwise it just moves the
+            // mystery rather than solving it.
+            Assert.Contains("terminating the test host", thrown.Message,
+                StringComparison.Ordinal);
+            Assert.Contains("Reported:", thrown.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public void AcceptedCommandLineDoesNotThrow()
+        {
+            var logger = new FailTestNotHostCommandLineLogger();
+
+            var commandLine = new CommandLine(
+                ["--mm=FullNetworkMessages", "--me=Json"], logger);
+
+            Assert.NotEmpty(commandLine);
+        }
+
+        // Every messaging mode the Counter soaks and jitter diagnostics drive
+        // the publisher with must still be a mode the publisher accepts. These
+        // are passed as strings, so the compiler cannot catch a removal the way
+        // it caught the MessagingMode.FullSamples uses, and a rejected value
+        // aborts the whole run rather than failing one test.
+        [Theory]
+        [InlineData("FullNetworkMessages")]
+        [InlineData("PubSub")]
+        public void MessagingModesUsedByTheSoaksAreStillAccepted(string mode)
+        {
+            var logger = new FailTestNotHostCommandLineLogger();
+
+            var commandLine = new CommandLine([$"--mm={mode}"], logger);
+
+            Assert.NotEmpty(commandLine);
+        }
+    }
+}

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/SourceTimestampFidelityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/SourceTimestampFidelityTests.cs
@@ -7,6 +7,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
 {
     using Azure.IIoT.OpcUa.Publisher.Module.Tests.Fixtures;
     using Azure.IIoT.OpcUa.Publisher.Testing.Fixtures;
+    using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
     using Azure.IIoT.OpcUa.Core.Logging;
     using Microsoft.Extensions.Logging;
     using System;
@@ -203,7 +204,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
             {
                 var arguments = new List<string>
                 {
-                    "--mm=FullSamples", "--me=Json", "--bs=50", "--bi=10000"
+                    "--mm=FullNetworkMessages", "--me=Json", "--bs=50", "--bi=10000"
                 };
                 if (heartbeatBehavior != null)
                 {
@@ -226,22 +227,27 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
                     {
                         return;
                     }
-                    if (!message.TryGetProperty("NodeId", out var n) ||
-                        n.ValueKind != JsonValueKind.String ||
-                        !message.TryGetProperty("Value", out var dv) ||
-                        !dv.TryGetProperty("SourceTimestamp", out var ts) ||
-                        !ts.TryGetDateTime(out var parsed) ||
-                        !dv.TryGetProperty("Value", out var raw) ||
-                        !raw.TryGetInt64(out var value))
+                    //
+                    // 3.0 emits OPC UA PubSub network messages. The counter
+                    // value and its source timestamp live in each data set
+                    // message's payload, keyed by the field name, rather than
+                    // in the flat NodeId/Value shape the removed Samples mode
+                    // produced. Decoding is shared with TelemetryQualityValidator
+                    // so both read the wire identically.
+                    //
+                    foreach (var (id, value, sourceTimestamp) in
+                        TelemetryQualityValidator.ReadCounterSamples(message))
                     {
-                        return;
+                        if (sourceTimestamp == null)
+                        {
+                            continue;
+                        }
+                        if (!received.TryGetValue(id, out var list))
+                        {
+                            received.Add(id, list = []);
+                        }
+                        list.Add((value, sourceTimestamp.Value));
                     }
-                    var id = n.GetString()!;
-                    if (!received.TryGetValue(id, out var list))
-                    {
-                        received.Add(id, list = []);
-                    }
-                    list.Add((value, parsed.ToUniversalTime()));
                 }, Ct).ConfigureAwait(false);
 
                 var report = Evaluate(label, received, server, slotSlip, interval);

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TimestampJitterDiagnosticTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TimestampJitterDiagnosticTests.cs
@@ -138,7 +138,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
             {
                 var args = new List<string>
                 {
-                    "--mm=FullSamples", "--me=Json", "--bs=50", "--bi=10000"
+                    "--mm=FullNetworkMessages", "--me=Json", "--bs=50", "--bi=10000"
                 };
                 if (heartbeatBehavior != null)
                 {

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
@@ -81,6 +81,64 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         }
 
         /// <summary>
+        /// Enumerate the counter samples a message carries, accepting either a
+        /// PubSub network message or a bare data set message.
+        /// </summary>
+        /// <remarks>
+        /// Exposed so tests that analyse samples differently - comparing them
+        /// against what the server recorded stamping, rather than scoring
+        /// stream quality - decode the wire the same way this validator does.
+        /// The decoding is not obvious: a field is a bare number under raw
+        /// encoding, an object under DataValue encoding, wrapped once more in a
+        /// Type/Body variant under reversible encoding, and a 64 bit integer
+        /// arrives as a JSON string because its range exceeds an IEEE-754
+        /// double. A second, independent parser would get some of that wrong.
+        /// </remarks>
+        /// <param name="message"></param>
+        public static IEnumerable<(string NodeId, long Value, DateTime? SourceTimestamp)>
+            ReadCounterSamples(JsonElement message)
+        {
+            if (message.ValueKind != JsonValueKind.Object)
+            {
+                yield break;
+            }
+            if (message.TryGetProperty("Messages", out var messages) &&
+                messages.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var dataSetMessage in messages.EnumerateArray())
+                {
+                    foreach (var sample in ReadDataSetSamples(dataSetMessage))
+                    {
+                        yield return sample;
+                    }
+                }
+                yield break;
+            }
+            foreach (var sample in ReadDataSetSamples(message))
+            {
+                yield return sample;
+            }
+        }
+
+        private static IEnumerable<(string, long, DateTime?)> ReadDataSetSamples(
+            JsonElement dataSetMessage)
+        {
+            if (dataSetMessage.ValueKind != JsonValueKind.Object ||
+                !dataSetMessage.TryGetProperty("Payload", out var payload) ||
+                payload.ValueKind != JsonValueKind.Object)
+            {
+                yield break;
+            }
+            foreach (var field in payload.EnumerateObject())
+            {
+                if (TryReadDataValue(field.Value, out var value, out var sourceTimestamp))
+                {
+                    yield return (field.Name, value, sourceTimestamp);
+                }
+            }
+        }
+
+        /// <summary>
         /// Add a sample to the analysis.
         /// </summary>
         /// <param name="sample"></param>


### PR DESCRIPTION
Fixes the `Telemetry quality smoke` job, which failed on every ubuntu run while reporting **no failing test** — the results file recorded 7 passed, 0 failed, then `Test host process crashed`.

The log gives the cause one line before the abort:

```
Parse args exception Could not convert value 'FullSamples' for option 'mm|messagingmode=|MessagingMode='.
```

3.0 removed `Samples`/`FullSamples` and rejects them by design. Two Counter tests still asked for `FullSamples` as a **string**, so the compiler could not catch them the way it caught the `MessagingMode.FullSamples` enum uses. `CommandLine` ends the process on a parse failure — correct for the module, fatal here, because the integration fixture hosts the publisher *inside* the test host.

### Changes

1. `SourceTimestampFidelityTests` and `TimestampJitterDiagnosticTests` now ask for `FullNetworkMessages`, the documented replacement.
2. `SourceTimestampFidelityTests` also parsed the **removed wire shape** (flat `NodeId` + `Value.SourceTimestamp`), so with the mode fixed it ran and found nothing — `No sample could be compared against the server's record`, 0/0 nodes. It now reads PubSub payload fields via `TelemetryQualityValidator.ReadCounterSamples` rather than a second parser, because that decoding has four easy-to-get-wrong cases (bare number, DataValue object, `Type`/`Body` variant, and 64-bit integers arriving as JSON strings).
3. **The fixture no longer lets this class of mistake take the run down.** `PublisherModule` supplies a `CommandLineLogger` that throws instead of exiting, so a fatal command line fails the test that caused it and names the option.

Point 3 matters most: the failure mode hides itself. No failure is recorded, and the test blamed is whichever the host happened to reach — not the one at fault. It has now cost two separate investigations, the first when `MqttConfigurationIntegrationTests` carried the same argument.

### Validation

| | Before | After |
|---|---|---|
| Soak (CI config) | 7 passed, host crash, exit 1 | **10 passed, 4 skipped, exit 0** |
| Full Module suite | 1661 passed | **1667 passed, 79 skipped** |

`FailTestNotHostCommandLineLoggerTests` locks the new behaviour, including that the message carries the reason.
