### PR TITLE
Harden the preview workflows: soak, pack, and E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,16 +764,22 @@ jobs:
             /p:ContinuousIntegrationBuild=true
       - name: Validate produced packages
         shell: bash
-        # The three projects that override common.props IsPackable=false:
+        # The two projects that override common.props IsPackable=false:
         #   - Azure.IIoT.OpcUa.Publisher.Models
         #   - Azure.IIoT.OpcUa.Publisher.Sdk
-        #   - Azure.IIoT.OpcUa.Publisher.Testing.Servers
+        #
+        # Azure.IIoT.OpcUa.Publisher.Testing.Servers was packable up to 2.9 and
+        # is deliberately not packable in 3.0. It consumes the Quickstarts
+        # servers through an `Aliases="Quickstarts"` extern alias, and an extern
+        # alias is a compile time construct that does not travel with a package:
+        # a consumer would resolve an unaliased transitive dependency and hit
+        # exactly the type collisions the alias exists to prevent. It would also
+        # make a sample package part of our public dependency graph.
         run: |
           set -euo pipefail
           expected=(
             'Azure.IIoT.OpcUa.Publisher.Models'
             'Azure.IIoT.OpcUa.Publisher.Sdk'
-            'Azure.IIoT.OpcUa.Publisher.Testing.Servers'
           )
           echo "Produced packages:"
           ls -la ./nupkgs
@@ -852,7 +858,16 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.run_e2e)
     uses: ./.github/workflows/e2e-standalone.yml
     with:
-      image_tag: ${{ needs.version.outputs.simple_version }}
+      # The NuGet version, not the simple version. images_push tags every image
+      # with both, but the simple version is just major.minor.patch and is
+      # therefore reused by every prerelease build of the same version: on
+      # preview it is 3.0.0 for all of them. A second push landing while this
+      # run deploys would move that tag, and E2E would silently validate a
+      # different build than the one that triggered it. The NuGet version
+      # carries the prerelease height (3.0.0-rc-0007), so it identifies this
+      # commit's image. When the two are equal images_push pushes the single
+      # tag, and this still resolves.
+      image_tag: ${{ needs.version.outputs.nuget_version }}
       image_registry: ghcr.io
       image_namespace: azure
       region: ${{ github.event_name == 'workflow_dispatch' && inputs.e2e_region || 'northeurope' }}

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -3,12 +3,12 @@ name: Soak
 # ----------------------------------------------------------------------------
 # Long running telemetry quality soak.
 #
-# Reproduces the customer scenario of thousands of variables
-# published with a two second publishing interval, a two second sampling
-# interval, a queue size larger than one and a two second heartbeat, in samples
-# encoding. The counter test server makes the expected stream decidable -- every
-# variable counts up from zero by exactly one every update interval, so the
-# value carries its own sequence number and its own expected source timestamp.
+# Reproduces the customer scenario of thousands of variables published with a
+# two second publishing interval, a two second sampling interval, a queue size
+# larger than one and a two second heartbeat. The counter test server makes the
+# expected stream decidable -- every variable counts up from zero by exactly one
+# every update interval, so the value carries its own sequence number and its
+# own expected source timestamp.
 #
 # The run fails when any of the four symptoms the customer reported reappears:
 #   (a) a counter value is lost
@@ -21,6 +21,13 @@ name: Soak
 # ----------------------------------------------------------------------------
 
 on:
+  push:
+    # preview carries the 3.0 line, where the telemetry path was rewritten onto
+    # the native PubSub runtime. Soak every push there rather than waiting for
+    # the nightly, because that is the branch whose telemetry behaviour is still
+    # moving. Not a pull request trigger: this is eight parallel jobs of 30
+    # minutes each and it gates nothing, so it runs after the merge.
+    branches: [preview]
   schedule:
     # Nightly at 02:00 UTC, well clear of the 10:00 UTC CI build.
     - cron: '0 2 * * *'
@@ -62,8 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         scenario:
-          - name: Samples
-            test: SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync
+          - name: FullNetworkMessages
+            test: FullNetworkMessagesStreamIsCompleteOrderedAndEvenlySpacedAsync
           - name: PubSub
             test: PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync
           - name: QueuedValues

--- a/e2e-tests/OpcPublisher-E2E-Tests/MessagingMode.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/MessagingMode.cs
@@ -6,7 +6,9 @@
 namespace OpcPublisherAEE2ETests
 {
     /// <summary>
-    /// Message modes
+    /// Message modes the E2E deployments can configure on the module. The
+    /// value is passed straight through to the module as <c>--mm</c>, so it
+    /// must name a mode the publisher still accepts.
     /// </summary>
     public enum MessagingMode
     {
@@ -16,8 +18,11 @@ namespace OpcPublisherAEE2ETests
         PubSub,
 
         /// <summary>
-        /// Monitored item samples
+        /// PubSub with the full header set. Replaces the Samples and
+        /// FullSamples modes, which 3.0 removed: they emitted a
+        /// MonitoredItemMessage that has no representation in OPC UA Part 14,
+        /// and a module told to use either refuses to start.
         /// </summary>
-        Samples
+        FullNetworkMessages
     }
 }

--- a/e2e-tests/OpcPublisher-E2E-Tests/RegistryHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/RegistryHelper.cs
@@ -137,7 +137,7 @@ namespace OpcPublisherAEE2ETests
         /// <param name="ct"></param>
         /// <returns></returns>
         public async Task RestartStandalonePublisherAsync(
-            MessagingMode messagingMode = MessagingMode.Samples, bool fullRedeploy = false,
+            MessagingMode messagingMode = MessagingMode.PubSub, bool fullRedeploy = false,
             CancellationToken ct = default)
         {
             var publisher = new IoTHubPublisherDeployment(_context, messagingMode);
@@ -164,7 +164,7 @@ namespace OpcPublisherAEE2ETests
         /// <param name="ct"></param>
         /// <returns></returns>
         public async Task<string> DeployStandalonePublisherAsync(
-            MessagingMode messagingMode = MessagingMode.Samples,
+            MessagingMode messagingMode = MessagingMode.PubSub,
             CancellationToken ct = default)
         {
             // Create base edge deployment.

--- a/e2e-tests/OpcPublisher-E2E-Tests/Standalone/SoakTestBase.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/Standalone/SoakTestBase.cs
@@ -10,9 +10,8 @@ namespace OpcPublisherAEE2ETests.Standalone
     using Azure.IIoT.OpcUa.Publisher.Models;
     using Azure.IIoT.OpcUa.Publisher.Testing.Telemetry;
     using Azure.Messaging.EventHubs.Consumer;
-    using Furly.Extensions.Serializers;
-    using Furly.Extensions.Serializers.Newtonsoft;
     using Microsoft.Azure.Devices;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
@@ -91,11 +90,10 @@ namespace OpcPublisherAEE2ETests.Standalone
             TimeoutToken = _timeoutTokenSource.Token;
 
             WriterId = Guid.NewGuid().ToString();
-            _serializer = new NewtonsoftJsonSerializer();
             _consumer = Context.GetEventHubConsumerClient(consumerGroup);
 
             Deployment = new IoTHubPublisherDeployment(Context,
-                OpcPublisherAEE2ETests.MessagingMode.Samples,
+                OpcPublisherAEE2ETests.MessagingMode.PubSub,
                 moduleName: moduleName,
                 deploymentName: deploymentName,
                 publishedNodesFile: TestConstants.PublishedNodesFolder + "/published_nodes_" + moduleName + ".json",
@@ -186,7 +184,13 @@ namespace OpcPublisherAEE2ETests.Standalone
                     {
                         return;
                     }
-                    validator.AddSamplesMessage(message);
+                    //
+                    // 3.0 publishes OPC UA PubSub network messages. The samples
+                    // encoding this used to read was the MonitoredItemMessage
+                    // format, which was removed with the Samples messaging mode
+                    // because it has no representation in Part 14.
+                    //
+                    validator.AddPubSubMessage(message);
                 },
                 onFirstMessage: json => _output.WriteLine("First message:" +
                     Environment.NewLine + json),
@@ -218,14 +222,14 @@ namespace OpcPublisherAEE2ETests.Standalone
         protected async Task PublishNodesAsync(string json, CancellationToken ct)
         {
             await UnpublishAllNodesAsync(ct).ConfigureAwait(false);
-            var entries = _serializer.Deserialize<PublishedNodesEntryModel[]>(json);
+            var entries = JsonConvert.DeserializeObject<PublishedNodesEntryModel[]>(json);
             foreach (var entry in entries)
             {
                 var result = await CallMethodAsync(
                     new MethodParameterModel
                     {
                         Name = TestConstants.DirectMethodNames.PublishNodes,
-                        JsonPayload = _serializer.SerializeToString(entry)
+                        JsonPayload = JsonConvert.SerializeObject(entry)
                     }, ct).ConfigureAwait(false);
 
                 await AssertMethodStatusOkAsync(result, "PublishNodes", ct).ConfigureAwait(false);
@@ -239,7 +243,7 @@ namespace OpcPublisherAEE2ETests.Standalone
 
             await AssertMethodStatusOkAsync(configured, "GetConfiguredEndpoints", ct)
                 .ConfigureAwait(false);
-            var response = _serializer.Deserialize<GetConfiguredEndpointsResponseModel>(
+            var response = JsonConvert.DeserializeObject<GetConfiguredEndpointsResponseModel>(
                 configured.JsonPayload);
             Assert.Equal(entries.Length, response.Endpoints.Count);
         }
@@ -335,7 +339,6 @@ namespace OpcPublisherAEE2ETests.Standalone
         /// </summary>
         private static readonly TimeSpan kOverhead = TimeSpan.FromMinutes(45);
         private readonly ITestOutputHelper _output;
-        private readonly ISerializer _serializer;
         private readonly ServiceClient _iotHubClient;
         private readonly EventHubConsumerClient _consumer;
         private readonly CancellationTokenSource _timeoutTokenSource;

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Sdk/Counter/TelemetryQualityTests.cs
@@ -97,6 +97,16 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
         /// 3.0 neither profile carries it, so that distinction buys nothing and
         /// the plain profile remains the more useful control.
         /// </para>
+        /// <para>
+        /// PubSub is also the 3.0 default, so it is the profile most
+        /// deployments will actually run. It carries a smaller header set than
+        /// FullNetworkMessages - no data set message Timestamp, DataSetWriterId
+        /// or SequenceNumber - which means the validator cannot fall back on
+        /// the message timestamp or deduplicate by sequence number here. The
+        /// value stream properties this arm asserts are derived from the source
+        /// timestamps and the counter values, both of which the plain profile
+        /// still carries.
+        /// </para>
         /// </summary>
         [SkippableFact]
         public async Task PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync()
@@ -104,7 +114,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
             SkipUnlessEnabled();
             var report = await RunScenarioAsync(
                 nameof(PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync),
-                MessagingMode.FullNetworkMessages, NodeCount, kInterval, kInterval, kInterval,
+                MessagingMode.PubSub, NodeCount, kInterval, kInterval, kInterval,
                 kQueueSize, (int)kInterval.TotalSeconds, RunDuration).ConfigureAwait(false);
 
             AssertClean(report);
@@ -329,10 +339,23 @@ namespace Azure.IIoT.OpcUa.Publisher.Module.Tests.Sdk.Counter
             // Positive control: without this the assertions below would hold
             // vacuously on a build where the shift silently stopped running.
             //
-            Assert.True(report.HeartbeatsWithChangedTimestamp == report.HeartbeatSamples,
-                $"only {report.HeartbeatsWithChangedTimestamp} of {report.HeartbeatSamples} " +
-                $"heartbeat(s) carried a shifted source timestamp, so the shift under test " +
-                $"did not run for all of them.\n{report}");
+            // The denominator is the heartbeats that could be compared against
+            // the value they resend, not every heartbeat. A heartbeat that
+            // fires before its node delivered its first value has nothing to
+            // compare against; monitored items are created over several publish
+            // cycles, so a correct 500 node run produces a few hundred such
+            // samples and comparing against HeartbeatSamples failed the run
+            // over telemetry that was entirely intact.
+            //
+            Assert.True(report.HeartbeatsComparedToLastValue > 0,
+                $"no heartbeat could be compared against the value it resends, so the " +
+                $"shift under test was never exercised.\n{report}");
+            Assert.True(
+                report.HeartbeatsWithChangedTimestamp == report.HeartbeatsComparedToLastValue,
+                $"only {report.HeartbeatsWithChangedTimestamp} of " +
+                $"{report.HeartbeatsComparedToLastValue} comparable heartbeat(s) carried a " +
+                $"shifted source timestamp, so the shift under test did not run for all of " +
+                $"them.\n{report}");
 
             //
             // Whatever the shift does to the timestamps, the value stream

--- a/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Telemetry/TelemetryQualityValidatorTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Module/tests/Telemetry/TelemetryQualityValidatorTests.cs
@@ -331,6 +331,74 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
             Assert.Equal(1, report.HeartbeatSamples);
             Assert.Equal(0, report.UnflaggedRepeats);
             Assert.Equal(1, report.HeartbeatsWithChangedTimestamp);
+            Assert.Equal(1, report.HeartbeatsComparedToLastValue);
+        }
+
+        [Fact]
+        public void HeartbeatBeforeTheFirstValueIsNotCountedAsComparable()
+        {
+            // A node whose watchdog deadline elapses before its first value
+            // reaches the analysis window emits a heartbeat with nothing to
+            // compare against. Counting it in the denominator made a correct
+            // 500 node soak look like the timestamp shift had stopped running
+            // for a few hundred samples, and failed the nightly run 18 times
+            // out of 20 on telemetry that was entirely intact.
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            // Heartbeat first, before this node ever delivered a value.
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(2)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.HeartbeatSamples);
+            Assert.Equal(0, report.HeartbeatsComparedToLastValue);
+            Assert.Equal(0, report.HeartbeatsWithChangedTimestamp);
+        }
+
+        [Fact]
+        public void OnlyHeartbeatsFollowingAValueAreCompared()
+        {
+            // The mixed case the soak actually sees: one warm up heartbeat that
+            // cannot be compared, then a value, then two heartbeats that can.
+            // The shifted-timestamp ratio must be 2 of 2, not 2 of 3.
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            // Resends a value this validator never observed, because the
+            // analysis window opened after the publisher had already read it.
+            validator.Add(Heartbeat(5, kEpoch.AddSeconds(10), kEpoch.AddSeconds(10)));
+            // Value() derives its source timestamp from the counter, so this
+            // carries a different value and timestamp and is a real update.
+            validator.Add(Value(6, messageTimestamp: kEpoch.AddSeconds(12)));
+            validator.Add(Heartbeat(6, kEpoch.AddSeconds(24), kEpoch.AddSeconds(24)));
+            validator.Add(Heartbeat(6, kEpoch.AddSeconds(36), kEpoch.AddSeconds(36)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(3, report.HeartbeatSamples);
+            Assert.Equal(2, report.HeartbeatsComparedToLastValue);
+            Assert.Equal(2, report.HeartbeatsWithChangedTimestamp);
+        }
+
+        [Fact]
+        public void ComparableHeartbeatRepeatingItsTimestampIsNotCountedAsChanged()
+        {
+            // The WatchdogLKV counterpart: the heartbeat resends the value with
+            // its original source timestamp, so it is comparable but unchanged.
+            // Without this, a denominator that merely tracked the numerator
+            // would satisfy the soak's positive control vacuously.
+            var validator = Create(kTwoSeconds, nodes: 1,
+                heartbeatInterval: TimeSpan.FromSeconds(10),
+                heartbeatTolerance: TimeSpan.FromSeconds(1));
+
+            validator.Add(Value(1, messageTimestamp: kEpoch.AddSeconds(2)));
+            validator.Add(Heartbeat(1, kEpoch.AddSeconds(2), kEpoch.AddSeconds(14)));
+
+            var report = validator.CreateReport();
+            Assert.Equal(1, report.HeartbeatSamples);
+            Assert.Equal(1, report.HeartbeatsComparedToLastValue);
+            Assert.Equal(0, report.HeartbeatsWithChangedTimestamp);
         }
 
         [Fact]

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityReport.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityReport.cs
@@ -167,6 +167,25 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         public long HeartbeatsWithChangedTimestamp { get; init; }
 
         /// <summary>
+        /// <para>
+        /// Heartbeats that could be compared against the value they resend,
+        /// i.e. that followed a real value carrying a source timestamp for the
+        /// same node. This is the denominator
+        /// <see cref="HeartbeatsWithChangedTimestamp"/> belongs to.
+        /// </para>
+        /// <para>
+        /// It is not the same as <see cref="HeartbeatSamples"/>. A heartbeat
+        /// that fires before its node ever delivered a value has nothing to
+        /// compare against, which happens during subscription warm up because
+        /// monitored items are created over several publish cycles. Comparing
+        /// the changed count against <see cref="HeartbeatSamples"/> therefore
+        /// reports a shortfall of roughly one per node on a run that is
+        /// entirely correct.
+        /// </para>
+        /// </summary>
+        public long HeartbeatsComparedToLastValue { get; init; }
+
+        /// <summary>
         /// Heartbeats that arrived earlier after the preceding value than the
         /// watchdog grace period allows. A watchdog may only report a node
         /// silent once the heartbeat interval plus one publishing interval
@@ -224,7 +243,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
                 .AppendLine(CultureInfo.InvariantCulture, $"(d) repeated values : {RepeatedValues} ({RepeatedValuesFromHeartbeat} heartbeat, {UnflaggedRepeats} unflagged)")
                 .AppendLine(CultureInfo.InvariantCulture, $"    no timestamp    : {SamplesWithoutSourceTimestamp}")
                 .AppendLine(CultureInfo.InvariantCulture, $"    heartbeats/node : {MinHeartbeatsPerNode} min, {MaxHeartbeatsPerNode} max")
-                .AppendLine(CultureInfo.InvariantCulture, $"    hb timestamp    : {HeartbeatsWithChangedTimestamp} changed")
+                .AppendLine(CultureInfo.InvariantCulture, $"    hb timestamp    : {HeartbeatsWithChangedTimestamp} changed of {HeartbeatsComparedToLastValue} comparable")
                 .AppendLine(CultureInfo.InvariantCulture, $"    hb too early    : {EarlyHeartbeats}")
                 .AppendLine(CultureInfo.InvariantCulture, $"    hb cadence      : {HeartbeatCadenceViolations} violations")
                 .AppendLine(CultureInfo.InvariantCulture, $"    redelivered     : {DuplicateDeliveries}");

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/shared/TelemetryQualityValidator.cs
@@ -444,6 +444,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
                 SourceTimestampRegressions = _sourceTimestampRegressions,
                 SamplesWithoutSourceTimestamp = _samplesWithoutSourceTimestamp,
                 HeartbeatsWithChangedTimestamp = _heartbeatsWithChangedTimestamp,
+                HeartbeatsComparedToLastValue = _heartbeatsComparedToLastValue,
                 EarlyHeartbeats = _earlyHeartbeats,
                 HeartbeatCadenceViolations = _heartbeatCadenceViolations,
                 MinHeartbeatsPerNode = minHeartbeats,
@@ -465,14 +466,27 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         {
             state.Heartbeats++;
 
+            //
+            // Only a heartbeat that follows a real value for the same node can
+            // be compared against the timestamp it is supposed to be resending.
+            // A heartbeat that arrives before this node has ever delivered a
+            // value has nothing to compare against, so it is counted on neither
+            // side of that ratio. That happens during subscription warm up:
+            // monitored items are created over several publish cycles, and a
+            // node whose watchdog deadline elapses before its first value
+            // reaches the analysis window contributes exactly one such sample.
+            //
             if (state.HasValue && state.LastValueTimestamp != null &&
-                sample.SourceTimestamp != null &&
-                sample.SourceTimestamp != state.LastValueTimestamp)
+                sample.SourceTimestamp != null)
             {
-                _heartbeatsWithChangedTimestamp++;
-                AddExample(
-                    $"{sample.NodeId}: heartbeat source timestamp {sample.SourceTimestamp} " +
-                    $"differs from the value it resends ({state.LastValueTimestamp})");
+                _heartbeatsComparedToLastValue++;
+                if (sample.SourceTimestamp != state.LastValueTimestamp)
+                {
+                    _heartbeatsWithChangedTimestamp++;
+                    AddExample(
+                        $"{sample.NodeId}: heartbeat source timestamp {sample.SourceTimestamp} " +
+                        $"differs from the value it resends ({state.LastValueTimestamp})");
+                }
             }
 
             if (sample.MessageTimestamp == null)
@@ -769,6 +783,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Telemetry
         private long _sourceTimestampRegressions;
         private long _samplesWithoutSourceTimestamp;
         private long _heartbeatsWithChangedTimestamp;
+        private long _heartbeatsComparedToLastValue;
         private long _earlyHeartbeats;
         private long _heartbeatCadenceViolations;
         private long _duplicateDeliveries;


### PR DESCRIPTION
Audit of every workflow run against `preview`, and the fixes for what it found. Four defects, three of them observed failing live on the `preview` push [33631310164](https://github.com/Azure/Industrial-IoT/actions/runs/33631310164).

### The E2E suite did not compile

The first E2E run ever to reach `preview` failed in **all four** test jobs, none of which ran a test:

```
SoakTestBase.cs(13,11): error CS0246: The type or namespace name 'Furly' could not be found
```

3.0 re-homed the Furly serializer abstractions and this file was missed, because `e2e-tests` is **not part of `Industrial-IoT.slnx`** — CI never builds it, and the E2E workflow that does had never run on this branch. Replaced with `JsonConvert`, which the rest of the suite already uses and which the Furly serializer wrapped anyway.

Behind that sat a second failure the jobs would have hit next: `SoakTestBase` deployed with `--mm=Samples`, which 3.0 refuses to start on. Now deploys `PubSub` and reads with `AddPubSubMessage`. The suite's own `MessagingMode.Samples` member is replaced by `FullNetworkMessages`, since the value is concatenated straight into `--mm`.

### `Pack NuGet packages` failed on a package 3.0 deliberately dropped

The guard expects three packable projects; 3.0 made `Testing.Servers` non-packable and the guard was not updated. The project is right to be excluded — it consumes Quickstarts through an extern alias, which cannot travel with a package and would put a sample package in our public dependency graph. Expectation corrected to the two that ship, with the reason recorded.

### The Soak never ran on `preview`, and two scenarios were wrong

- GitHub runs schedules from the default branch only, so `preview` was never soaked. Now also runs on push to `preview` (not on PRs — eight 30-minute jobs gate nothing).
- The matrix named `SamplesModeStreamIsCompleteOrderedAndEvenlySpacedAsync`, removed with the Samples mode, so that job **matched no test and passed vacuously**. Now runs the FullNetworkMessages scenario.
- `PubSubModeStreamIsCompleteOrderedAndEvenlySpacedAsync` ran on `FullNetworkMessages`, contradicting its name and its own remark. It was a byte-for-byte duplicate, so the mode 3.0 **defaults to** went unsoaked. Now runs `MessagingMode.PubSub`.

### The nightly Soak's positive control divided by the wrong number

18 of the last 20 nightly runs failed, latterly on one scenario. The telemetry was intact — 90,000 values, no loss, no reordering — and it failed its own control:

```
only 286659 of 287187 heartbeat(s) carried a shifted source timestamp
```

A heartbeat can only be compared against the value it resends if such a value was seen. Monitored items are created over several publish cycles, so a node whose deadline elapses before its first value contributes one incomparable heartbeat; at 500 nodes that is the entire 528 shortfall. Added `HeartbeatsComparedToLastValue` as the denominator that count always belonged to. The numerator's gate is unchanged.

### E2E validated a mutable tag

`image_tag` was `simple_version` (`3.0.0` for every 3.0 prerelease), which `images_push` moves on each push. A second push during a deploy would leave E2E validating a different build, looking like a flaky test. Now `nuget_version` (`3.0.0-rc-0007`).

### Validation

| Check | Result |
|---|---|
| All 6 workflows parse; every action SHA-pinned | pass |
| All 8 soak matrix targets resolve to real tests | pass |
| `e2e-tests/IIoTPlatform-E2E-Tests.slnx` build (CI does not do this) | **0 errors** |
| `dotnet pack` produces exactly Models + Sdk | pass |
| Validator unit tests incl. 3 new | 25/25 |
| Reduced soak: updated-timestamp heartbeat + real PubSub | pass |
| Full Module suite | 1669 passed, 79 skipped |

Two failures during the full run (`PublishingFasterThanTheSource...`, `CanEncodeWithReversibleEncoding...`) each passed in isolation and were caused by concurrent local load.

The E2E tests need the deployed Azure environment, so what they assert about 3.0 telemetry is what the next E2E run reports.
