### PR TITLE
Let the E2E tests report why they failed

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -233,10 +233,23 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p e2e-tests/results
+          #
+          # No --blame-hang-timeout here. The blame detector measures the time
+          # between test completions, and a single telemetry quality soak
+          # legitimately observes the stream for soak_minutes (30 by default)
+          # before it finishes, while an A&E test waits for events from the
+          # deployed module. A fixed short inactivity window therefore kills
+          # healthy runs, and it kills them in the worst possible way: the run
+          # is reported as "Test host process crashed" with the results file
+          # listing only the tests that had already passed, so the failure
+          # names no test and carries no assertion. Every E2E test bounds
+          # itself with its own cancellation token (SoakTestBase uses
+          # Duration + 45 minutes) and the job timeout is the outer backstop,
+          # so a genuine hang is still caught -- and caught with a diagnostic.
+          #
           dotnet test e2e-tests/IIoTPlatform-E2E-Tests.slnx \
             --configuration Release --no-build \
             --filter "${{ inputs.filter_name }}=${{ inputs.filter_value }}" \
-            --blame-hang-timeout 10m --blame-hang-dump-type none \
             --logger "trx;LogFileName=${{ inputs.result_label }}.trx" \
             --logger "console;verbosity=detailed" \
             --results-directory e2e-tests/results


### PR DESCRIPTION
The E2E run on `preview` failed in **all four** jobs with:

```
The active test run was aborted. Reason: Test host process crashed
Data collector 'Blame' message: The specified inactivity time of 10 minutes has elapsed.
```

**No test failed.** The results files record only the tests that had already passed — A&E 2 of 2, heartbeat 1 of 1, counters none at all — and the run names no assertion, because nothing asserted anything. The jobs were killed while waiting.

### Why it could never work

The blame detector measures time **between test completions**. A telemetry quality soak observes the stream for `soak_minutes` (30 by default) before its single test finishes; an A&E test waits on events from the deployed module. Neither can complete inside a ten-minute inactivity window, so the detector was guaranteed to fire on a healthy run.

Evidence it is a 3.0-line regression: `main` has no `--blame-hang-timeout` on this step, and its soak jobs run **36–38 minutes** to a green result ([run 31594684590](https://github.com/Azure/Industrial-IoT/actions/runs/31594684590)). `git log -G` shows the flag arrived with the 3.0 squash.

It is also redundant. Every E2E test bounds itself with its own cancellation token — `SoakTestBase` allows `Duration + 45 minutes` — which surfaces a real hang as an ordinary test failure with its diagnostics intact, and the job timeout sits outside that as the backstop.

### Scope

This fixes no E2E test. It stops the harness from destroying the evidence, so the next run reports what 3.0 actually does with the deployed module. Any genuine 3.0 behavioural difference will then show up as a named test with an assertion, which is what the follow-up needs.
