### PR TITLE
Stop the E2E exception reporter from replacing the exception

### DIFF
--- a/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
+++ b/e2e-tests/OpcPublisher-E2E-Tests/TestHelper.cs
@@ -1300,8 +1300,18 @@ namespace OpcPublisherAEE2ETests
             var exception = e;
             while (exception != null)
             {
-                outputHelper.WriteLine(exception.Message);
-                outputHelper.WriteLine(exception.StackTrace);
+                //
+                // Exception.StackTrace is null for an exception that was
+                // constructed but never thrown, which happens routinely for
+                // the inner exceptions of an aggregate produced by a cancelled
+                // HTTP call. ITestOutputHelper.WriteLine rejects null, so
+                // passing it straight through replaces the exception being
+                // reported with an ArgumentNullException raised inside the
+                // reporter - the failure then names this method instead of the
+                // direct method call that actually failed.
+                //
+                outputHelper.WriteLine(exception.Message ?? "(no message)");
+                outputHelper.WriteLine(exception.StackTrace ?? "(no stack trace)");
                 outputHelper.WriteLine("");
                 exception = exception.InnerException;
             }


### PR DESCRIPTION
The counters soak in [run 33657983746](https://github.com/Azure/Industrial-IoT/actions/runs/33657983746) failed with:

```
System.ArgumentNullException : Value cannot be null. (Parameter 'message')
  at Guard.ArgumentNotNull
  at TestHelper.PrettyPrintException
  at TestHelper.CallMethodAsync
```

That names neither the direct method that failed nor why. The real failure is in the test's captured output: the `PublishNodes` call was **cancelled**, and under it a socket abort.

`PrettyPrintException` walks the inner exception chain and passes each `StackTrace` to `ITestOutputHelper.WriteLine`. `Exception.StackTrace` is **null** for an exception that was constructed and never thrown — routine for the inner exceptions of a cancelled HTTP call — and xUnit's `WriteLine` rejects null. So the reporter threw while reporting, and the exception that reached the test result was its own.

Both members are now coalesced.

This changes no test behaviour. It stops a failure from being relabelled as a defect in the reporting helper — the same way the ten-minute blame timeout (#2530) and the in-process `ExitProcess` call (#2528) were each hiding the failure they were meant to describe.

The underlying cancellation is a separate matter and needs the next E2E run to characterise, which this makes possible.
