### PR TITLE
Size the E2E hang window to the work the job was given

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -234,22 +234,34 @@ jobs:
           set -euo pipefail
           mkdir -p e2e-tests/results
           #
-          # No --blame-hang-timeout here. The blame detector measures the time
-          # between test completions, and a single telemetry quality soak
-          # legitimately observes the stream for soak_minutes (30 by default)
-          # before it finishes, while an A&E test waits for events from the
-          # deployed module. A fixed short inactivity window therefore kills
-          # healthy runs, and it kills them in the worst possible way: the run
-          # is reported as "Test host process crashed" with the results file
-          # listing only the tests that had already passed, so the failure
-          # names no test and carries no assertion. Every E2E test bounds
-          # itself with its own cancellation token (SoakTestBase uses
-          # Duration + 45 minutes) and the job timeout is the outer backstop,
-          # so a genuine hang is still caught -- and caught with a diagnostic.
+          # The blame detector measures the time between test completions, so
+          # the window has to clear the longest legitimate one. A telemetry
+          # quality soak observes the stream for soak_minutes before its single
+          # test finishes; a fixed ten minute window killed every soak job on
+          # preview and reported it as "Test host process crashed" with no
+          # failing test, because the results file holds only the tests that
+          # had already passed.
           #
+          # It is still worth having. Removing it entirely let a stuck A&E test
+          # occupy the shared IoT Edge gateway for the full ninety minute job
+          # timeout, which starves the soak jobs deployed alongside it -- the
+          # suite's own MaxTestTimeoutMilliseconds token did not stop it.
+          #
+          # So: derive the window from the work the job was asked to do. Soak
+          # jobs get their observation window plus headroom for deployment,
+          # warm up and teardown; everything else gets twenty minutes, which is
+          # twice the suite's own per-class budget.
+          #
+          if [ -n "${IIOT_E2E_SOAK_MINUTES:-}" ]; then
+            hang_minutes=$(( IIOT_E2E_SOAK_MINUTES + 45 ))
+          else
+            hang_minutes=20
+          fi
+          echo "Blame hang window: ${hang_minutes}m"
           dotnet test e2e-tests/IIoTPlatform-E2E-Tests.slnx \
             --configuration Release --no-build \
             --filter "${{ inputs.filter_name }}=${{ inputs.filter_value }}" \
+            --blame-hang-timeout "${hang_minutes}m" --blame-hang-dump-type none \
             --logger "trx;LogFileName=${{ inputs.result_label }}.trx" \
             --logger "console;verbosity=detailed" \
             --results-directory e2e-tests/results


### PR DESCRIPTION
Correction to #2530, which removed `--blame-hang-timeout` outright.

That fixed the soaks — a fixed ten-minute window cannot contain a thirty-minute observation, and it was killing every soak job while reporting a crashed host with no failing test. But removing it entirely went too far, and [the next run](https://github.com/Azure/Industrial-IoT/actions/runs/33657983746) showed why.

### What removing it exposed

The A&E job ran to its **ninety-minute job timeout** and was cancelled, stuck in `TestVerifyIntegerNamespaceExpectSimpleEventsInHub` waiting for events — exactly where it was stuck before. It held the shared IoT Edge gateway for that whole time, and the soak jobs deployed alongside it then failed with:

```
DeviceNotFoundException 404103: the requested device isn't online
```

So removing the detector converted a ten-minute kill into ninety minutes of starvation for every job sharing the device.

My justification in #2530 was that every E2E test bounds itself with its own cancellation token. The token exists — `MaxTestTimeoutMilliseconds`, ten minutes per class — but that A&E path plainly does not observe it, or the job would have failed at ten minutes rather than run to ninety. **That reasoning was incomplete.**

### The fix

Size the window to the work the job was given, rather than picking one number for every job:

| Job | Window | Rationale |
|---|---|---|
| Soak | `soak_minutes + 45` (75m default) | Clears the observation window plus deploy/warm-up/teardown; still inside the 90m job timeout |
| Everything else | 20m | Twice the suite's own per-class budget, so a stuck test fails in 20 minutes rather than 90 |

Verified the arithmetic for `soak_minutes` of 30 and 60 and for the unset case.

This does not fix the stuck A&E test or the underlying `DeviceNotFoundException` — those are tracked separately. It stops one stuck test from taking the other jobs down with it.
