### PR TITLE
Accept the JSON form of a non finite float

### DIFF
--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Extensions/JsonNodeValueExtensions.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Extensions/JsonNodeValueExtensions.cs
@@ -130,8 +130,31 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing
         /// <summary>
         /// Whether the node is a floating point number.
         /// </summary>
+        /// <remarks>
+        /// JSON has no literal for the non finite values, so OPC UA Part 6
+        /// encodes them as the strings "NaN", "Infinity" and "-Infinity". A
+        /// Double or Float field therefore arrives as a number or as one of
+        /// those three strings, and both are the value being asked about. The
+        /// static test arrays are randomly generated and do contain non finite
+        /// values -- the write tests set them deliberately -- so treating only
+        /// a JSON number as a float made the array read assertions fail
+        /// whenever a non finite value happened to land first.
+        /// </remarks>
         public static bool IsDouble(this JsonNode? node)
-            => node?.GetValueKind() == JsonValueKind.Number;
+            => node?.GetValueKind() == JsonValueKind.Number || node.IsNonFiniteNumber();
+
+        /// <summary>
+        /// Whether the node carries one of the three JSON string forms OPC UA
+        /// Part 6 uses for the non finite floating point values.
+        /// </summary>
+        public static bool IsNonFiniteNumber(this JsonNode? node)
+        {
+            if (node?.GetValueKind() != JsonValueKind.String)
+            {
+                return false;
+            }
+            return node.GetValue<string>() is "NaN" or "Infinity" or "-Infinity";
+        }
 
         /// <summary>
         /// Whether the node is a floating point number.

--- a/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Tests/TestData/ReadArrayValueTests.cs
+++ b/src/Azure.IIoT.OpcUa.Publisher.Testing/tests/Tests/TestData/ReadArrayValueTests.cs
@@ -487,7 +487,7 @@ namespace Azure.IIoT.OpcUa.Publisher.Testing.Tests
                 return;
             }
 
-            Assert.True(result.Value[0].IsDouble());
+            Assert.True(result.Value[0].IsDouble(), $"First is {result.Value}");
             Assert.Equal("Double", result.DataType);
         }
 


### PR DESCRIPTION
`ValueReadArrayTests.NodeReadStaticArrayFloatValueVariableTestAsync` fails intermittently on CI:

```
First is [ "NaN", -2.9687988E-18, ...
```

**It is not a race.** JSON has no literal for the non-finite values, so OPC UA Part 6 encodes them as the strings `"NaN"`, `"Infinity"` and `"-Infinity"`. `IsDouble` accepted only `JsonValueKind.Number`, so the assertion that the first array element is a float failed whenever the randomly generated static array happened to *start* with one — which is exactly why it looked flaky rather than broken. The write tests set `float.NaN` and both infinities deliberately, so these values are expected to be in the data.

Seen twice in this session, on separate runs. It matters beyond its own job: `images_build` needs the whole 14-job matrix, so one failure here skips images, package push **and E2E** for that commit.

### Why the extension rather than the call site

The same latent failure sits in the double array test and in both scalar read tests. All four ask whether a value is floating point, and all four should answer yes for a value the encoder was *required* to write as a string. All four call sites are positive assertions, so widening the predicate cannot make an existing assertion wrong.

The double array assertion also gains the diagnostic message its float sibling already had — without it the failure printed nothing about the offending value.

210 read value tests pass locally.
