### PR TITLE
Let the soak test fail before the detector does

### DIFF
--- a/.github/workflows/e2e-run-tests.yml
+++ b/.github/workflows/e2e-run-tests.yml
@@ -242,18 +242,26 @@ jobs:
           # failing test, because the results file holds only the tests that
           # had already passed.
           #
-          # It is still worth having. Removing it entirely let a stuck A&E test
-          # occupy the shared IoT Edge gateway for the full ninety minute job
-          # timeout, which starves the soak jobs deployed alongside it -- the
-          # suite's own MaxTestTimeoutMilliseconds token did not stop it.
+          # It is still worth having. Without it a stuck A&E test occupied the
+          # shared IoT Edge gateway for the full job timeout and starved the
+          # soak jobs deployed alongside it.
           #
-          # So: derive the window from the work the job was asked to do. Soak
-          # jobs get their observation window plus headroom for deployment,
-          # warm up and teardown; everything else gets twenty minutes, which is
-          # twice the suite's own per-class budget.
+          # For a soak the window is anchored just under the job timeout rather
+          # than derived from soak_minutes directly. SoakTestBase bounds itself
+          # with Duration + 45 minutes, which at the default is the same 75
+          # minutes an earlier soak_minutes + 45 window produced: the two fired
+          # together and the detector won, so the test never got to report its
+          # own cancellation and the results file came back empty. Sitting five
+          # minutes under the job timeout keeps the detector strictly the last
+          # resort, after the test's own token has had its chance to fail with
+          # a diagnostic.
+          #
+          # Everything else gets twenty minutes, twice the suite's own
+          # per-class budget, so a stuck test there fails quickly instead of
+          # holding the gateway.
           #
           if [ -n "${IIOT_E2E_SOAK_MINUTES:-}" ]; then
-            hang_minutes=$(( IIOT_E2E_SOAK_MINUTES + 45 ))
+            hang_minutes=$(( ${{ inputs.timeout_minutes }} - 5 ))
           else
             hang_minutes=20
           fi


### PR DESCRIPTION
The heartbeat soak in [run 33691039131](https://github.com/Azure/Industrial-IoT/actions/runs/33691039131) ran **77m40s** and was killed by the blame detector with an **empty results file** — no test, no assertion, nothing to read.

### My own arithmetic reintroduced the bug

#2532 set the soak window to `soak_minutes + 45`. `SoakTestBase` bounds itself with `Duration + kOverhead`, and `kOverhead` is 45 minutes. At the default those are **the same 75 minutes** — so the detector and the test's own cancellation came due together, and the detector won.

That is exactly the outcome #2530 and #2532 were both trying to prevent, reintroduced by arithmetic rather than by a fixed number.

### The fix

Anchor the soak window under the **job timeout** instead of deriving it from `soak_minutes`, making the ordering explicit:

| | Value (defaults) |
|---|---|
| Test's own bound (`Duration + kOverhead`) | 75m — reports its own cancellation |
| Blame window (`timeout_minutes - 5`) | 85m — last resort |
| Job timeout | 90m — backstop |

Non-soak jobs keep the 20-minute window, still twice their per-class budget.

### Scope

This does **not** fix the heartbeat soak. That test genuinely does not complete — the counters soak **passed** in the same run with the same observation window, so it is specific to the heartbeat scenario rather than to the soak configuration. Whatever it waits for can now surface as a test failure with a diagnostic instead of an empty file.
